### PR TITLE
feat: Allow gcs paths without prefix

### DIFF
--- a/src/ot_orchestration/utils/__init__.py
+++ b/src/ot_orchestration/utils/__init__.py
@@ -3,7 +3,7 @@
 from ot_orchestration.utils.batch import create_batch_job, create_task_spec
 from ot_orchestration.utils.manifest import extract_study_id_from_path
 from ot_orchestration.utils.path import (
-    POSIX_PATH_PATTERN,
+    URI_PATTERN,
     GCSPath,
     IOManager,
     NativePath,
@@ -28,5 +28,5 @@ __all__ = [
     "create_task_spec",
     "create_batch_job",
     "extract_study_id_from_path",
-    "POSIX_PATH_PATTERN",
+    "URI_PATTERN",
 ]

--- a/src/ot_orchestration/utils/path.py
+++ b/src/ot_orchestration/utils/path.py
@@ -1,7 +1,5 @@
 """Module for Google Cloud Path naive parsers."""
 
-from __future__ import annotations
-
 import concurrent.futures
 import json
 import logging
@@ -18,7 +16,7 @@ from requests.adapters import HTTPAdapter
 
 CHUNK_SIZE = 1024 * 256
 MAX_N_THREADS = 32
-POSIX_PATH_PATTERN = r"^^((?P<protocol>.*)://)?(?P<root>[(\w)-]+)/(?P<path>([(\w)-/])+)"
+URI_PATTERN = r"^^((?P<protocol>.*)://)?(?P<root>[(\w)-]+)/(?P<path>([(\w)-/])+)"
 
 
 class PathSegments(TypedDict):
@@ -161,7 +159,7 @@ class GCSPath(ProtoPath):
     ):
         self._client = client
         self.gcs_path = gcs_path
-        self.path_pattern = re.compile(POSIX_PATH_PATTERN)
+        self.path_pattern = re.compile(URI_PATTERN)
         self.chunk_size = chunk_size
 
     @cached_property
@@ -303,7 +301,7 @@ class IOManager:
         - https:// (currently not implemented)
         - ftp:// (currently not implemented)
 
-        Based on registred protocols, the path is resolved to the appropriate Path object.
+        Based on registered protocols, the path is resolved to the appropriate Path object.
         Works only with POSIX path objects.
 
         Args:
@@ -345,7 +343,7 @@ class IOManager:
         """Load many objects by concurrent operations. Thread safe.
 
         By default this method spawns 32 or num of cpus treads depending on which number is
-        closer to the oveall concurrent process count.
+        closer to the overall concurrent process count.
 
         Args:
             paths (list[str]): Paths to read from.
@@ -387,7 +385,7 @@ class IOManager:
         When dumping many objects make sure, you are not writing to the same object multiple times.
 
         By default this method spawns 32 or num of cpus treads depending on which number is
-        closer to the oveall concurrent process count.
+        closer to the overall concurrent process count.
 
         Args:
             objects (list[Any]): Objects to write.

--- a/tests/test_io_manager.py
+++ b/tests/test_io_manager.py
@@ -7,7 +7,7 @@ from typing import Any
 import pytest
 from ot_orchestration.utils import GCSPath, IOManager
 from ot_orchestration.utils.path import (
-    POSIX_PATH_PATTERN,
+    URI_PATTERN,
     GCSPath,
     IOManager,
     NativePath,
@@ -76,15 +76,15 @@ def test_native_path(tmp_path: Path, suffix: str, obj: Any) -> None:
         ),
     ],
 )
-def test_posix_path_regex(
+def test_uri_pattern_regex(
     input_path: str,
     _match: bool,
     protocol: str | None,
     root: str | None,
     path: str | None,
 ) -> None:
-    """Test POSIX path regex."""
-    pattern = re.compile(POSIX_PATH_PATTERN)
+    """Test URI regex pattern."""
+    pattern = re.compile(URI_PATTERN)
     pattern_match = pattern.search(input_path)
 
     if not _match:

--- a/tests/test_io_manager.py
+++ b/tests/test_io_manager.py
@@ -133,8 +133,8 @@ class TestGCSPath:
             ),
         ],
     )
-    def test_segments(self, gcs_path: str, filename: str, prefix: str) -> None:
-        """Test GCSPath object segments return correct values."""
+    def test_segments_property(self, gcs_path: str, filename: str, prefix: str) -> None:
+        """Test GCSPath object segments property return correct values."""
         gcs_path_obj = GCSPath(gcs_path)
         assert isinstance(gcs_path_obj.segments, dict)
         assert set(gcs_path_obj.segments.keys()) == {
@@ -169,7 +169,7 @@ class TestGCSPath:
             ),
         ],
     )
-    def test_path(self, gcs_path: str, path: str) -> None:
+    def test_path_property(self, gcs_path: str, path: str) -> None:
         """Test GCSPath object path property."""
         gcs_path_obj = GCSPath(gcs_path)
         assert gcs_path_obj.path == path
@@ -184,7 +184,7 @@ class TestGCSPath:
             ),
         ],
     )
-    def test_bucket(self, gcs_path: str, bucket: str) -> None:
-        """Test GCSPath object path property."""
+    def test_bucket_property(self, gcs_path: str, bucket: str) -> None:
+        """Test GCSPath object bucket property."""
         gcs_path_obj = GCSPath(gcs_path)
         assert gcs_path_obj.bucket == bucket


### PR DESCRIPTION
## Context

I want to use google cloud storage paths that do not have prefix like `gs://gwas_catalog_data/manifests/` with the `GCSPath` object.  This will be required for data relocation within the `genetics_etl` dag.

Currently `GCSPath` object regex requires path to have `prefix` and `filename` groups which prevents us from using paths without the prefix, or paths that point directly to the directories within this class.

## Implementation

This PR tries to solve it by changing the regex pattern to catch `path` instead of `filename and prefix` and extract the logic behind path`filename` and `prefix` parsing to the `GCSPath.segments` method.

- [x] Refactored `POSIX_PATH_PATTERN` to capture `path` instead of `prefix` and `filename`.
- [x] Refactored `GCSPath.segments` and `GCSPath.path` methods to preserve backwards compatibility.
- [x] Added tests for `GCSPath` object. 