### PR TITLE
feat: move ukb_ppp_eur datasource ingestion to orchestration

### DIFF
--- a/src/ot_orchestration/dags/config/ukb_ppp_eur_harmonisation.yaml
+++ b/src/ot_orchestration/dags/config/ukb_ppp_eur_harmonisation.yaml
@@ -1,4 +1,4 @@
-cluster_name: otg-ukb-ppp-eur"
+cluster_name: otg-ukb-ppp-eur
 steps:
   - id: ukb_ppp_eur_sumstat_preprocess
     params:

--- a/src/ot_orchestration/dags/config/ukb_ppp_eur_harmonisation.yaml
+++ b/src/ot_orchestration/dags/config/ukb_ppp_eur_harmonisation.yaml
@@ -1,0 +1,12 @@
+cluster_name: otg-ukb-ppp-eur"
+steps:
+  - id: ukb_ppp_eur_sumstat_preprocess
+    params:
+      raw_study_index_path: gs://gentropy-tmp/batch/output/ukb_ppp_eur/study_index.tsv
+      raw_summary_stats_path: gs://gentropy-tmp/batch/output/ukb_ppp_eur/summary_stats.parquet
+      variant_annotation_path: gs://genetics_etl_python_playground/output/python_etl/parquet/XX.XX/variant_annotation
+      tmp_variant_annotation_path: gs://gentropy-tmp/variant_annotation
+      study_index_output_path: gs://ukb_ppp_eur_data/study_index
+      summary_stats_output_path: gs://ukb_ppp_eur_data/summary_stats
+      # session parameters
+      session.extended_stark_conf.spark.sql.shuffle.partitions: "3200"

--- a/src/ot_orchestration/dags/ukb_ppp_eur_harmonisation.py
+++ b/src/ot_orchestration/dags/ukb_ppp_eur_harmonisation.py
@@ -1,0 +1,36 @@
+"""Airflow DAG to ingest and harmonise UKB PPP (EUR) data."""
+
+from pathlib import Path
+
+from airflow.models.dag import DAG
+
+from ot_orchestration.utils import read_yaml_config
+from ot_orchestration.utils.common import (
+    convert_params_to_hydra_positional_arg,
+    shared_dag_args,
+    shared_dag_kwargs,
+)
+from ot_orchestration.utils.dataproc import generate_dag, submit_step
+
+config = read_yaml_config(
+    Path(__file__).parent / "config" / "ukb_ppp_eur_harmonisation.yaml"
+)
+
+with DAG(
+    dag_id=Path(__file__).stem,
+    description="Open Targets Genetics — Ingest UKB PPP (EUR)",
+    default_args=shared_dag_args,
+    **shared_dag_kwargs,
+):
+    tasks = []
+    for step in config["steps"]:
+        step_id = step["id"]
+        step_params = convert_params_to_hydra_positional_arg(step)
+        task = submit_step(
+            cluster_name=config["cluster_name"],
+            step_id=step_id,
+            task_id=step_id,
+            other_args=step_params,
+        )
+        tasks.append(task)
+    dag = generate_dag(cluster_name=config["cluster_name"], tasks=tasks)

--- a/src/ot_orchestration/utils/common.py
+++ b/src/ot_orchestration/utils/common.py
@@ -85,3 +85,27 @@ def prepare_labels(
     labels.update(custom_labels)
 
     return {k: clean_label(v) for k, v in labels.items()}
+
+
+def convert_params_to_hydra_positional_arg(
+    step: dict[str, dict[str, Any]],
+) -> list[str] | None:
+    """Convert configuration parameters to form that can be passed to hydra step positional arguments.
+
+    In case the step does not have a "params" key, there are no parameters to convert.
+
+    Args:
+        step (dict[str, dict[str, Any]]): Config parameters for the step to convert.
+
+    Returns:
+        list[str] | None: List of strings that represents the positional arguments for hydra gentropy step.
+
+    Example:
+        >>> convert_params_to_hydra_positional_arg({"params": {"sig": 1, "pval": 0.05}})
+        ["step.sig=1", "step.pval=0.05"]
+        >>> convert_params_to_hydra_positional_arg({"id": "step1"})
+        None
+    """
+    if "params" not in step.keys() or not step["params"]:
+        return None
+    return [f"step.{k}={v}" for k, v in step["params"].items()]

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -1,0 +1,39 @@
+"""Test common functions."""
+
+import pytest
+from ot_orchestration.utils.common import convert_params_to_hydra_positional_arg
+
+
+@pytest.mark.parametrize(
+    [
+        "step_config",
+        "output",
+    ],
+    [
+        pytest.param(
+            {"id": "step1", "params": {"param1": "value1"}},
+            ["step.param1=value1"],
+            id="Step with one parameter.",
+        ),
+        pytest.param(
+            {"id": "step1"},
+            None,
+            id="Step without parameters.",
+        ),
+        pytest.param(
+            {"id": "step1", "params": {}},
+            None,
+            id="Step with zero parameters.",
+        ),
+        pytest.param(
+            {"id": "step1", "params": {"param1": "value1", "params2": "value2"}},
+            ["step.param1=value1", "step.params2=value2"],
+            id="Step with multiple parameters.",
+        ),
+    ],
+)
+def test_convert_params_to_hydra_positional_arg(
+    step_config: dict, output: list[str] | None
+) -> None:
+    """Test conversion between step configuration and hydra positional arguments."""
+    assert convert_params_to_hydra_positional_arg(step_config) == output


### PR DESCRIPTION
## Context

We want to move all dags from `gentropy` to the `orchestration` repositoy.

## Implementations

This PR:
- [x] moves the dag to ingest and harmonize the `UKB PPP EUR` dataset. 
- [x] Creates dag config and extracts all configuration parameters to it
- [x] Adds a function to convert parameters from dag config to gentropy step parameters (handled by hydra).
- [x] Refactors dag to allow for addition of finemapping step. 