### PR TITLE
feat: additional reasons for invalid studies and credible sets

### DIFF
--- a/src/ot_orchestration/dags/config/genetics_etl.yaml
+++ b/src/ot_orchestration/dags/config/genetics_etl.yaml
@@ -19,8 +19,8 @@ steps:
         - UNRESOLVED_TARGET
         - UNRESOLVED_DISEASE
         - UNKNOWN_STUDY_TYPE
+        - UNKNOWN_BIOSAMPLE
         - DUPLICATED_STUDY
-        - NO_GENE_PROVIDED
       session.write_mode: overwrite
 
   - id: credible_set_validation
@@ -48,6 +48,9 @@ steps:
         - PALINDROMIC_ALLELE_FLAG
         - SUBSIGNIFICANT_FLAG
         - LD_CLUMPED
+        - IN_MHC
+        - REDUNDANT_PICS_TOP_HIT
+        - EXPLAINED_BY_SUSIE
       session.write_mode: overwrite
   - id: "ot_gene_index"
   - id: "ot_variant_index"


### PR DESCRIPTION
This PR only adds additional configuration for the recently added filters during study and credible set validation

Approximate description of the flags. Please look at the original tickets for a more precise description

Study:
- UNKNOWN_BIOSAMPLE - QTL biosample needs to be in the newly created biosample index (step still to be added to orchestration)
- NO_GENE_PROVIDED - Deprecated

Credible set
- IN_MHC - Excluded if credible set is in MHC
- REDUNDANT_PICS_TOP_HIT - when PICS results -> top hit already covered by summary statistics
- EXPLAINED_BY_SUSIE - flags credible sets explained by an overlapping SuSiE region