### PR TITLE
feat: gwas_catalog_sumstats_pics DAG and harmonised paths

### DIFF
--- a/src/ot_orchestration/dags/config/gwas_catalog_sumstats_pics.yaml
+++ b/src/ot_orchestration/dags/config/gwas_catalog_sumstats_pics.yaml
@@ -1,41 +1,48 @@
 dataproc:
-  cluster_name: otg-tophit-gwascatalog
-  autoscaling_policy: otg-gwascatalog-tophit
+  cluster_name: otg-gwascatalog-sumstats-pics
+  autoscaling_policy: otg-preprocess-gwascatalog
   python_main_module: gs://genetics_etl_python_playground/initialisation/gentropy/dev/cli.py
   cluster_metadata:
     PACKAGE: gs://genetics_etl_python_playground/initialisation/gentropy/dev/gentropy-0.0.0-py3-none-any.whl
   cluster_init_script: gs://genetics_etl_python_playground/initialisation/gentropy/dev/install_dependencies_on_cluster.sh
-  num_workers: 2
+  num_workers: 5
 
 nodes:
-  - id: top_hits_processing
+  - id: summary_statistics_processing
     kind: TaskGroup
     prerequisites: []
     nodes:
-      - id: gwas_catalog_top_hit_ingestion
+      - id: gwas_catalog_study_index
         kind: Task
+        prerequisites: []
         params:
-          step: gwas_catalog_top_hit_ingestion
+          step: gwas_catalog_study_index
           step.catalog_study_files:
             - gs://gwas_catalog_inputs/gwas_catalog_download_studies.tsv
           step.catalog_ancestry_files:
             - gs://gwas_catalog_inputs/gwas_catalog_download_ancestries.tsv
-          step.catalog_associations_file: gs://gwas_catalog_inputs/gwas_catalog_associations_ontology_annotated.tsv
-          step.variant_annotation_path: gs://genetics_etl_python_playground/static_assets/gnomad_variants
-          step.catalog_studies_out: gs://gwas_catalog_top_hits/study_index
-          step.catalog_associations_out: gs://gwas_catalog_top_hits/study_locus
+          step.study_index_path: gs://gwas_catalog_sumstats_pics/study_index
+          step.session.write_mode: overwrite
+          step.session.spark_uri: yarn
+      - id: window_based_clumping
+        kind: Task
+        prerequisites: []
+        params:
+          step: window_based_clumping
+          step.summary_statistics_input_path: gs://gwas_catalog_inputs/harmonised_summary_statistics
+          step.study_locus_output_path: gs://gwas_catalog_sumstats_pics/study_locus
           step.session.write_mode: overwrite
           step.session.spark_uri: yarn
       - id: ld_based_clumping
         kind: Task
         prerequisites:
-          - gwas_catalog_top_hit_ingestion
+          - window_based_clumping
         params:
           step: ld_based_clumping
           step.ld_index_path: gs://genetics_etl_python_playground/static_assets/ld_index
-          step.study_locus_input_path: gs://gwas_catalog_top_hits/study_locus
-          step.clumped_study_locus_output_path: gs://gwas_catalog_top_hits/study_locus_ld_clumped
-          step.study_index_path: gs://gwas_catalog_top_hits/study_index
+          step.study_locus_input_path: gs://gwas_catalog_sumstats_pics/study_locus
+          step.clumped_study_locus_output_path: gs://gwas_catalog_sumstats_pics/study_locus_ld_clumped
+          step.study_index_path: gs://gwas_catalog_sumstats_pics/study_index
           step.session.write_mode: overwrite
           step.session.spark_uri: yarn
       - id: pics
@@ -44,7 +51,7 @@ nodes:
           - ld_based_clumping
         params:
           step: pics
-          step.study_locus_ld_annotated_in: gs://gwas_catalog_top_hits/study_locus_ld_clumped
-          step.picsed_study_locus_out: gs://gwas_catalog_top_hits/credible_sets
+          step.study_locus_ld_annotated_in: gs://gwas_catalog_sumstats_pics/study_locus_ld_clumped
+          step.picsed_study_locus_out: gs://gwas_catalog_sumstats_pics/credible_sets
           step.session.write_mode: overwrite
           step.session.spark_uri: yarn

--- a/src/ot_orchestration/dags/config/gwas_catalog_top_hits.yaml
+++ b/src/ot_orchestration/dags/config/gwas_catalog_top_hits.yaml
@@ -1,10 +1,10 @@
 dataproc:
   cluster_name: otg-tophit-gwascatalog
   autoscaling_policy: otg-gwascatalog-tophit
-  python_main_module: gs://genetics_etl_python_playground/initialisation/gentropy/dev/cli.py
+  python_main_module: gs://genetics_etl_python_playground/initialisation/gentropy/dsdo_top_hits_step/cli.py
   cluster_metadata:
-    PACKAGE: gs://genetics_etl_python_playground/initialisation/gentropy/dev/gentropy-0.0.0-py3-none-any.whl
-  cluster_init_script: gs://genetics_etl_python_playground/initialisation/gentropy/dev/install_dependencies_on_cluster.sh
+    PACKAGE: gs://genetics_etl_python_playground/initialisation/gentropy/dsdo_top_hits_step/gentropy-0.0.0-py3-none-any.whl
+  cluster_init_script: gs://genetics_etl_python_playground/initialisation/gentropy/dsdo_top_hits_step/install_dependencies_on_cluster.sh
   num_workers: 2
 
 nodes:
@@ -25,6 +25,7 @@ nodes:
           step.catalog_studies_out: gs://gwas_catalog_top_hits_data/study_index
           step.catalog_associations_out: gs://gwas_catalog_top_hits_data/study_locus_datasets/gwas_catalog_curated_associations
           step.session.write_mode: overwrite
+          step.session.spark_uri: yarn
       - id: ld_based_clumping
         kind: Task
         prerequisites:
@@ -36,6 +37,7 @@ nodes:
           step.clumped_study_locus_output_path: gs://gwas_catalog_top_hits_data/study_locus_datasets/gwas_catalog_curated_associations_ld_clumped
           step.study_index_path: gs://gwas_catalog_top_hits_data/study_index
           step.session.write_mode: overwrite
+          step.session.spark_uri: yarn
       - id: pics
         kind: Task
         prerequisites:
@@ -45,3 +47,4 @@ nodes:
           step.study_locus_ld_annotated_in: gs://gwas_catalog_top_hits_data/study_locus_datasets/gwas_catalog_curated_associations_ld_clumped
           step.picsed_study_locus_out: gs://gwas_catalog_top_hits_data/credible_set_datasets/gwas_catalog_PICSed_curated_associations
           step.session.write_mode: overwrite
+          step.session.spark_uri: yarn

--- a/src/ot_orchestration/dags/gwas_catalog_sumstats_pics.py
+++ b/src/ot_orchestration/dags/gwas_catalog_sumstats_pics.py
@@ -18,7 +18,6 @@ from ot_orchestration.utils.dataproc import (
     create_cluster,
     delete_cluster,
     submit_gentropy_step,
-    reinstall_dependencies,
 )
 
 CONFIG_PATH = Path(__file__).parent / "config" / "gwas_catalog_sumstats_pics.yaml"
@@ -55,10 +54,6 @@ with DAG(
             autoscaling_policy=config["dataproc"]["autoscaling_policy"],
             num_workers=config["dataproc"]["num_workers"],
             cluster_metadata=config["dataproc"]["cluster_metadata"],
-            cluster_init_script=config["dataproc"]["cluster_init_script"],
-        ),
-        reinstall_dependencies(
-            cluster_name=config["dataproc"]["cluster_name"],
             cluster_init_script=config["dataproc"]["cluster_init_script"],
         ),
         summary_statistics_processing,

--- a/src/ot_orchestration/dags/gwas_catalog_sumstats_pics.py
+++ b/src/ot_orchestration/dags/gwas_catalog_sumstats_pics.py
@@ -1,0 +1,69 @@
+"""Airflow DAG for the preprocessing of GWAS Catalog's harmonised summary statistics and curated associations."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from airflow.models.baseoperator import chain
+from airflow.models.dag import DAG
+from airflow.utils.task_group import TaskGroup
+
+from ot_orchestration.utils import (
+    chain_dependencies,
+    find_node_in_config,
+    read_yaml_config,
+)
+from ot_orchestration.utils.common import shared_dag_args, shared_dag_kwargs
+from ot_orchestration.utils.dataproc import (
+    create_cluster,
+    delete_cluster,
+    submit_gentropy_step,
+    reinstall_dependencies,
+)
+
+CONFIG_PATH = Path(__file__).parent / "config" / "gwas_catalog_sumstats_pics.yaml"
+config = read_yaml_config(CONFIG_PATH)
+sumstat_config = find_node_in_config(config["nodes"], "summary_statistics_processing")
+
+with DAG(
+    dag_id=Path(__file__).stem,
+    description="Open Targets Genetics — GWAS Catalog preprocess",
+    default_args=shared_dag_args,
+    **shared_dag_kwargs,
+) as dag:
+
+    # Processing summary statistics from GWAS Catalog:
+    with TaskGroup(group_id=sumstat_config["id"]) as summary_statistics_processing:
+        tasks = {}
+        if sumstat_config["nodes"]:
+            for step in sumstat_config["nodes"]:
+                task = submit_gentropy_step(
+                    cluster_name=config["dataproc"]["cluster_name"],
+                    step_name=step["id"],
+                    python_main_module=config["dataproc"]["python_main_module"],
+                    params=step["params"],
+                )
+                tasks[step["id"]] = task
+            chain_dependencies(
+                nodes=sumstat_config["nodes"], tasks_or_task_groups=tasks
+            )  # type: ignore
+
+    # DAG description:
+    chain(
+        create_cluster(
+            cluster_name=config["dataproc"]["cluster_name"],
+            autoscaling_policy=config["dataproc"]["autoscaling_policy"],
+            num_workers=config["dataproc"]["num_workers"],
+            cluster_metadata=config["dataproc"]["cluster_metadata"],
+            cluster_init_script=config["dataproc"]["cluster_init_script"],
+        ),
+        reinstall_dependencies(
+            cluster_name=config["dataproc"]["cluster_name"],
+            cluster_init_script=config["dataproc"]["cluster_init_script"],
+        ),
+        summary_statistics_processing,
+        delete_cluster(config["dataproc"]["cluster_name"]),
+    )
+
+if __name__ == "__main__":
+    pass


### PR DESCRIPTION
This PR implements:

- Updates to paths in top_hits DAG
- New gwas_catalog_sumstats_pics DAG

Both DAGs ran to completion using unmerged PR in gentropy https://github.com/opentargets/gentropy/pull/808