### PR TITLE
fix(vep_operator): change dtype for pos to int for correct sorting

### DIFF
--- a/src/ot_orchestration/operators/vep.py
+++ b/src/ot_orchestration/operators/vep.py
@@ -235,7 +235,7 @@ class ConvertVariantsToVcfOperator(BaseOperator):
         return OrderedDict(
             {
                 "#CHROM": str,
-                "POS": str,
+                "POS": int,
                 "ID": str,
                 "REF": str,
                 "ALT": str,


### PR DESCRIPTION
# Rationale

This PR fixes isssue issue with vep variant annotation operator spotted on [batch job](https://console.cloud.google.com/batch/jobsDetail/regions/europe-west1/jobs/vep-job-20241010-143828/details?project=open-targets-genetics-dev), that caused the partitionned vcf files were not sorted correctly before annotating them by vep.

See the exact errors of failed jobs in [logs](https://console.cloud.google.com/logs/query;query=logName%3D%22projects%2Fopen-targets-genetics-dev%2Flogs%2Fbatch_task_logs%22%20OR%20%22projects%2Fopen-targets-genetics-dev%2Flogs%2Fbatch_agent_logs%22%20labels.job_uid%3D%22vep-job-20241010-1-4549f95f-1363-4e1e0%22%20timestamp%3E%3D%222024-10-10T13:38:29.707Z%22%20timestamp%3C%3D%222024-10-10T15:49:00.928Z%22%20severity%3E%3DDEFAULT%0Aseverity%3DERROR%0ASEARCH%2528%22Exiting%20the%20program%22%2529;storageScope=project;cursorTimestamp=2024-10-10T14:46:05.154689297Z;startTime=2024-10-11T12:02:30Z;endTime=2024-10-11T12:25:00Z?project=open-targets-genetics-dev)

## Fixes

This PR changes the `POS` field in partitionned vcfs to `int` so the partitionning is done correctly.