### PR TITLE
chore(finngen_ingestion): update configuration

### DIFF
--- a/docs/datasources/finngen_data/README.md
+++ b/docs/datasources/finngen_data/README.md
@@ -20,7 +20,7 @@ Raw data is fetched by the gentropy steps directly from the data source. No prep
 The fetching paths are:
 
 - snp files from `gs://finngen-public-data-r11/finemap/full/susie/*.snp.bgz`
-- credible_set files from `gs://finngen-public-data-r11/finemap/summary/*_99.cred.summary.tsv`
+- credible_set files from `gs://finngen-public-data-r11/finemap/summary/*SUSIE.cred.summary.tsv`
 
 ## Processing description
 

--- a/src/ot_orchestration/dags/config/finngen_ingestion.yaml
+++ b/src/ot_orchestration/dags/config/finngen_ingestion.yaml
@@ -16,7 +16,7 @@ nodes:
       step: finngen_studies
       step.finngen_study_index_out: gs://finngen_data/r11/study_index
       step.finngen_phenotype_table_url: https://r11.finngen.fi/api/phenos
-      step.finngen_release_prefix: FINNGEN_R11_
+      step.finngen_release_prefix: FINNGEN_R11
       step.finngen_summary_stats_url_prefix: gs://finngen-public-data-r11/summary_stats/finngen_R11_
       step.sample_size: 453733
       step.finngen_summary_stats_url_suffix: ".gz"
@@ -30,8 +30,9 @@ nodes:
       step: finngen_finemapping_ingestion
       step.finngen_finemapping_out: gs://finngen_data/r11/credible_set_datasets/susie
       step.finngen_susie_finemapping_snp_files: gs://finngen-public-data-r11/finemap/full/susie/*.snp.bgz
-      # As directory contains also *.cred.summary.tsv, *_99.cred.summary.tsv enure only 99 credible sets are ingested,
-      step.finngen_susie_finemapping_cs_summary_files: gs://finngen-public-data-r11/finemap/summary/*_99.cred.summary.tsv
+      # As directory contains SUSIE.cred.summary.tsv, SUSIE_99.cred.summary.tsv enure only non 99 credible sets are ingested,
+      step.finngen_susie_finemapping_cs_summary_files: gs://finngen-public-data-r11/finemap/summary/*SUSIE.cred.summary.tsv
       step.finngen_finemapping_lead_pvalue_threshold: 1e-5
+      step.finngen_release_prefix: FINNGEN_R11
       step.session.start_hail: true
       step.session.write_mode: overwrite


### PR DESCRIPTION
# Context

We want to bring back the `FINNGEN_R11_` prefix to the `studyId` fields and remove duplicates from the credible sets that were read by providing too wide pattern (capturing credible sets and 99 credible sets)