### PR TITLE
chore(eqtl_catalogue): configure step to run on cluster mode

### DIFF
--- a/src/ot_orchestration/dags/config/eqtl_catalogue_ingestion.yaml
+++ b/src/ot_orchestration/dags/config/eqtl_catalogue_ingestion.yaml
@@ -24,4 +24,5 @@ nodes:
       step.mqtl_quantification_methods_blacklist: []
       step.eqtl_lead_pvalue_threshold: 1.0e-3
       step.session.write_mode: overwrite
+      step.session.spark_uri: yarn
       +step.session.extended_spark_conf: "{spark.sql.shuffle.partitions: '3200'}"


### PR DESCRIPTION
We have new eQTL Catalogue data after applying these fixes https://github.com/opentargets/gentropy/pull/849 that remove the duplication on the locus. Job took 30min. A 33% increase compared to last time.
New credible sets:
`gs://eqtl_catalogue_data/credible_set_datasets/eqtl_catalogue_susie`

The only thing I had to change in the config was to tell Spark to use yarn. Other than that, generating the data was one click on Airflow.