### PR TITLE
perf(efm): enhanced flexibility mode in genetics etl cluster

### DIFF
--- a/src/ot_orchestration/dags/config/genetics_etl.yaml
+++ b/src/ot_orchestration/dags/config/genetics_etl.yaml
@@ -6,7 +6,9 @@ dataproc:
     PACKAGE: gs://genetics_etl_python_playground/initialisation/gentropy/dev/gentropy-0.0.0-py3-none-any.whl
   cluster_init_script: gs://genetics_etl_python_playground/initialisation/gentropy/dev/install_dependencies_on_cluster.sh
   cluster_name: otg-etl
-  autoscaling_policy: otg-etl
+  autoscaling_policy: otg-efm
+  allow_efm: true
+  num_workers: 10
 
 nodes:
   - id: biosample_index

--- a/src/ot_orchestration/dags/genetics_etl.py
+++ b/src/ot_orchestration/dags/genetics_etl.py
@@ -176,10 +176,8 @@ with DAG(
         # chain prerequisites
         chain_dependencies(nodes=config["nodes"], tasks_or_task_groups=node_map)
         generate_dataproc_task_chain(
-            cluster_name=dataproc_specs["cluster_name"],
-            cluster_metadata=dataproc_specs["cluster_metadata"],
-            cluster_init_script=dataproc_specs["cluster_init_script"],
             tasks=list(node_map.values()),  # type: ignore
+            **config["dataproc"],
         )
 
     # DAG description:

--- a/src/ot_orchestration/utils/common.py
+++ b/src/ot_orchestration/utils/common.py
@@ -16,6 +16,7 @@ GCP_REGION = "europe-west1"
 GCP_ZONE = "europe-west1-d"
 GCP_DATAPROC_IMAGE = "2.1"
 GCP_AUTOSCALING_POLICY = "otg-etl"
+GCP_EFM_AUTOSCALING_POLICY = "otg-efm"
 
 # Image configuration.
 GENTROPY_DOCKER_IMAGE = (

--- a/src/ot_orchestration/utils/dataproc.py
+++ b/src/ot_orchestration/utils/dataproc.py
@@ -18,6 +18,7 @@ from ot_orchestration.utils import convert_params_to_hydra_positional_arg
 from ot_orchestration.utils.common import (
     GCP_AUTOSCALING_POLICY,
     GCP_DATAPROC_IMAGE,
+    GCP_EFM_AUTOSCALING_POLICY,
     GCP_PROJECT_GENETICS,
     GCP_REGION,
     GCP_ZONE,
@@ -29,13 +30,15 @@ def create_cluster(
     cluster_name: str,
     master_machine_type: str = "n1-highmem-16",
     worker_machine_type: str = "n1-standard-16",
-    num_workers: int = 2,
+    num_workers: int = 1,
     num_preemptible_workers: int = 0,
     num_local_ssds: int = 1,
     autoscaling_policy: str = GCP_AUTOSCALING_POLICY,
     master_disk_size: int = 500,
     cluster_init_script: str | None = None,
     cluster_metadata: dict[str, str] | None = None,
+    allow_efm: bool = False,
+    **kwargs,
 ) -> DataprocCreateClusterOperator:
     """Generate an Airflow task to create a Dataproc cluster. Common parameters are reused, and varying parameters can be specified as needed.
 
@@ -50,18 +53,41 @@ def create_cluster(
         master_disk_size (int): Size of the master node's boot disk in GB. Defaults to 500.
         cluster_init_script (str | None): Cluster initialization scripts.
         cluster_metadata (str | None): Cluster METADATA.
+        allow_efm (bool): Wether to allow for Enhanced Flexibility Mode in spark cluster to store the shuffle partitions in the primary workers only.
+        **kwargs (Any): Other parameters to the ClusterGenerator.
+
+        NOTE: When `allow_efm` is enabled, the autoscaling policy can not use the graceful decommissioning for primary workers!
+        NOTE: When `allow_efm` is enabled, the ratio between primary and secondary workers should not be small (1:10) at least.
+        NOTE: When `allow_efm` is enabled, the size of primary workers disks should be increased and set to use the pd-ssd
+        To see more about EFM see https://cloud.google.com/dataproc/docs/concepts/configuring-clusters/enhanced-flexibility-mode
 
     Returns:
         DataprocCreateClusterOperator: Airflow task to create a Dataproc cluster.
     """
     # Create base cluster configuration.
+    properties = None
+    if allow_efm:
+        properties = {
+            "dataproc:efm.spark.shuffle": "primary-worker",
+            "spark:spark.sql.files.maxPartitionBytes": "1073741824",  # value proposed by the Dataproc documentation. See EFM in docstring.
+            "spark:spark.sql.shuffle.partitions": "100",
+            "yarn:spark.shuffle.io.serverThreads": "50",  # ensure more threads can write default for n-standard-16 is 2 * (16 cores) threads
+            "spark:spark.shuffle.io.numConnectionsPerPeer": "5",
+            "spark:spark.stage.maxConsecutiveAttempts": "10",  # defaults to 4, this is in case the master was lost
+            "spark:spark.task.maxFailures": "10",
+        }
+
     cluster_config = ClusterGenerator(
+        num_masters=3
+        if allow_efm
+        else 1,  # allows to run the dataproc cluster in HA mode.
         project_id=GCP_PROJECT_GENETICS,
         zone=GCP_ZONE,
         master_machine_type=master_machine_type,
         worker_machine_type=worker_machine_type,
+        worker_disk_type="pd-ssd" if allow_efm else "pd-standard",
         master_disk_size=master_disk_size,
-        worker_disk_size=500,
+        worker_disk_size=1024 if allow_efm else 500,
         num_preemptible_workers=num_preemptible_workers,
         num_workers=num_workers,
         image_version=GCP_DATAPROC_IMAGE,
@@ -69,7 +95,9 @@ def create_cluster(
         metadata=cluster_metadata,
         idle_delete_ttl=30 * 60,  # In seconds.
         init_actions_uris=[cluster_init_script] if cluster_init_script else None,
-        autoscaling_policy=f"projects/{GCP_PROJECT_GENETICS}/regions/{GCP_REGION}/autoscalingPolicies/{autoscaling_policy}",
+        autoscaling_policy=get_autoscaling_policy(policy_name=autoscaling_policy),
+        properties=properties,
+        **kwargs,
     ).make()
 
     # If specified, amend the configuration to include local SSDs for worker nodes.
@@ -91,6 +119,19 @@ def create_cluster(
         cluster_name=cluster_name,
         trigger_rule=TriggerRule.ALL_SUCCESS,
     )
+
+
+def get_autoscaling_policy(
+    *,
+    policy_name: str = GCP_AUTOSCALING_POLICY,
+    region: str = GCP_REGION,
+    project: str = GCP_PROJECT_GENETICS,
+    allow_efm: bool = False,
+) -> str:
+    """Get the autoscaling policy full path."""
+    if allow_efm and policy_name == GCP_AUTOSCALING_POLICY:
+        policy_name = GCP_EFM_AUTOSCALING_POLICY
+    return f"projects/{project}/regions/{region}/autoscalingPolicies/{policy_name}"
 
 
 def submit_gentropy_step(
@@ -221,10 +262,8 @@ def delete_cluster(cluster_name: str) -> DataprocDeleteClusterOperator:
 
 
 def generate_dataproc_task_chain(
-    cluster_name: str,
-    cluster_init_script: str,
-    cluster_metadata: dict[str, str],
     tasks: list[DataprocSubmitJobOperator],
+    **kwargs,
 ) -> Any:
     """For a list of Dataproc tasks, generate a complete chain of tasks.
 
@@ -232,20 +271,14 @@ def generate_dataproc_task_chain(
     and adds delete_cluster tasks to the task that does not have any downstream tasks (last one in the DAG)
 
     Args:
-        cluster_name (str): Name of the cluster.
-        cluster_init_script (str): URI to the cluster initialization script.
-        cluster_metadata: (dict[str, str]): METADATA to fill into the cluster during initialization.
         tasks (list[DataprocSubmitJobOperator]): List of tasks to execute.
+        **kwargs (Any): keyword arguments passed to the `create_cluster`.
 
     Returns:
         list[DataprocSubmitJobOperator]: list of input tasks with muted chain.
     """
-    create_cluster_task = create_cluster(
-        cluster_name,
-        cluster_metadata=cluster_metadata,
-        cluster_init_script=cluster_init_script,
-    )
-    delete_cluster_task = delete_cluster(cluster_name)
+    create_cluster_task = create_cluster(**kwargs)
+    delete_cluster_task = delete_cluster(kwargs["cluster_name"])
     for task in tasks:
         if not task.get_direct_relatives(upstream=True):
             task.set_upstream(create_cluster_task)

--- a/src/ot_orchestration/utils/utils.py
+++ b/src/ot_orchestration/utils/utils.py
@@ -134,7 +134,8 @@ def chain_dependencies(nodes: list[ConfigNode], tasks_or_task_groups: dict[str, 
         for label, node in tasks_or_task_groups.items():
             print(node_dependencies)
             for dependency in node_dependencies[label]:
-                node.set_upstream(tasks_or_task_groups[dependency])
+                if dependency in tasks_or_task_groups:
+                    node.set_upstream(tasks_or_task_groups[dependency])
 
 
 def convert_params_to_hydra_positional_arg(


### PR DESCRIPTION
# Context

Introduction of the new SuSiE credible sets from `gwas_catalog` (gs://gwas_catalog_sumstats_susie/credible_set_clean) resulted in `ColocStep` failures. Job performed on `otg-etl` cluster took ~4h and did not finish in that time - see [job](https://console.cloud.google.com/dataproc/jobs/f8b8af30-2022-4b0f-aea1-640301bc59b8/monitoring?region=europe-west1&project=open-targets-genetics-dev).

The most of the error logs trace the fact that he executors got lost during the job execution.
```
java.io.IOException: Connecting to otg-etl-sw-0qf7.europe-west1-d.c.open-targets-genetics-dev.internal/10.132.0.54:41329 failed in the last 4750 ms, fail this connection directly
	at org.apache.spark.network.client.TransportClientFactory.createClient(TransportClientFactory.java:214)
	at org.apache.spark.network.shuffle.ExternalBlockStoreClient.lambda$fetchBlocks$0(ExternalBlockStoreClient.java:132)
	at org.apache.spark.network.shuffle.RetryingBlockTransferor.transferAllOutstanding(RetryingBlockTransferor.java:173)
	at org.apache.spark.network.shuffle.RetryingBlockTransferor.lambda$initiateRetry$0(RetryingBlockTransferor.java:206)
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
```
The `otg-etl` cluster uses the following autoscaling policy

```json
{
  "id": "otg-etl",
  "name": "projects/open-targets-genetics-dev/regions/europe-west1/autoscalingPolicies/otg-etl",
  "basicAlgorithm": {
    "yarnConfig": {
      "scaleUpFactor": 1,
      "scaleDownFactor": 1,
      "gracefulDecommissionTimeout": "10800s"
    },
    "cooldownPeriod": "120s"
  },
  "workerConfig": {
    "minInstances": 2,
    "maxInstances": 2,
    "weight": 1
  },
  "secondaryWorkerConfig": {
    "maxInstances": 100,
    "weight": 1
  }
}
```
Which specifies the ratio of `secondaryWorkers` to `primaryWorkers` to be max `100:2`.

> [!CAUTION]
> In case of the Coloc step, which requires many intensive shuffle operations, if the input dataset increases, the complexity of shuffling will also increase, thus resulting in time increase. This is a potential issue when we store the shuffle partitions on lost exectuors, as described in the [EFM (Enhanced Flexibility Mode) description](https://cloud.google.com/dataproc/docs/concepts/configuring-clusters/enhanced-flexibility-mode). Losing a worker will make the task restart, resulting in run time elongation. 
> 
> Further more this can not be determined in advance due to the nature of preemptible (secondary) workers.

To accomodate for the lost shuffle partitions the EFM mode can be utilized. 

The EFM mode will make the cluster to **save the shuffle partitions only on primary workers**. This will mean that we have to accomodate the disk size of the workers and effectively change the autoscaling policy, as EFM does not support the graceful decomissioning of workers. 



## Changes

The above tweaks were added to the existing dataproc cluster setup to accomodate the shuffling operations in Coloc step:
- [x] Enable the EFM mode with `dataproc:efm.spark.shuffle=primary-workers` property
- [x] Increase the number of primary workers on EFM mode from 2 to 10
- [x] Increase the ssd disk size on primary workers to 1TB when running on EFM mode
- [x] Create new autoscaling policy without graceful decomissioning - [otg-efm](https://console.cloud.google.com/dataproc/autoscalingPolicies/europe-west1/otg-efm?project=open-targets-genetics-dev)
- [x] Allow for more then default concurrent threads to save the shuffle data into the primary workers (default is 16 cores * 2 which was adjusted to 50)
- [x] Allow for more peer connections (from default 1 to 5)
- [x] Tuning of shuffling with 
```
yarn:yarn.resourcemanager.am.max-attempts
mapred:mapreduce.map.maxattempts
mapred:mapreduce.reduce.maxattempts
spark:spark.task.maxFailures
spark:spark.stage.maxConsecutiveAttempts
```
All of above comes from reading the documentation on EFM

- [x] Allow for 3 master nodes to run in parallel to decrese the risk of decomissioning the master node while the job tries to shuffle data to primary workers see [High Availability mode](https://cloud.google.com/dataproc/docs/concepts/configuring-clusters/high-availability)
- [x] Adjustments to the `create_cluster` function to accomodate all parameters from `ClusterGenerator`

Additionally
- [x] Do not fail on parsing the dag topology when prerequisite task is not foud (allows easier config changes) - no need to comment out the `prerequisites` in the node configuration, if the tasks were commented out.

> [!NOTE]
> The Coloc step succeded in 1h 20 min with the EFM mode enabled - see [job](https://console.cloud.google.com/dataproc/jobs/5a00d79c-1aae-4c4d-bd14-2a76dbdb1d70/monitoring?region=europe-west1&project=open-targets-genetics-dev) - we still experienced executor loses
