### PR TITLE
feat: refactoring vep annotation step

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -7784,4 +7784,4 @@ cffi = ["cffi (>=1.11)"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10, <3.11"
-content-hash = "870b50a07e5f4ef2e53c5e4e214308ff23994054dabb586a6d375df59e94c831"
+content-hash = "b2e6201a741bd241b308f0adaa82e81d39ef092706a13712e9ec192131cdf516"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,6 @@ pendulum = "^3.0.0"
 apache-airflow-providers-apache-beam = "^5.7.1"
 requests = "^2.32.3"
 pyhocon = "^0.3.61"
-pandas = ">=2.1.2,<2.2"
 
 [tool.poetry.group.dev.dependencies]
 ruff = "^0.4.9"

--- a/src/ot_orchestration/dags/config/genetics_etl.yaml
+++ b/src/ot_orchestration/dags/config/genetics_etl.yaml
@@ -54,6 +54,10 @@ nodes:
         - UNKNOWN_STUDY_TYPE
         - DUPLICATED_STUDY
         - UNKNOWN_BIOSAMPLE
+        - FAILED_MEAN_BETA_CHECK
+        - FAILED_PZ_CHECK
+        - FAILED_GC_LAMBDA_CHECK
+        - NO_OT_CURATION
 
   - id: credible_set_validation
     kind: Task
@@ -86,6 +90,9 @@ nodes:
         - EXPLAINED_BY_SUSIE
         - WINDOW_CLUMPED
         - NON_MAPPED_VARIANT_FLAG
+        - INVALID_VARIANT_IDENTIFIER
+        - INVALID_CHROMOSOME
+        - TOP_HIT_AND_SUMMARY_STATS
 
   - id: convert_variants_to_vcf
     kind: Task

--- a/src/ot_orchestration/dags/config/genetics_etl.yaml
+++ b/src/ot_orchestration/dags/config/genetics_etl.yaml
@@ -1,10 +1,10 @@
 l2g_gold_standard_path: gs://genetics_etl_python_playground/input/l2g/gold_standard/curation.json
 release_dir: gs://ot_orchestration/releases/24.10_freeze6
 dataproc:
-  python_main_module: gs://genetics_etl_python_playground/initialisation/gentropy/chr-quotes/cli.py
+  python_main_module: gs://genetics_etl_python_playground/initialisation/gentropy/dev/cli.py
   cluster_metadata:
-    PACKAGE: gs://genetics_etl_python_playground/initialisation/gentropy/chr-quotes/gentropy-0.0.0-py3-none-any.whl
-  cluster_init_script: gs://genetics_etl_python_playground/initialisation/gentropy/chr-quotes/install_dependencies_on_cluster.sh
+    PACKAGE: gs://genetics_etl_python_playground/initialisation/gentropy/dev/gentropy-0.0.0-py3-none-any.whl
+  cluster_init_script: gs://genetics_etl_python_playground/initialisation/gentropy/dev/install_dependencies_on_cluster.sh
   cluster_name: otg-etl
   autoscaling_policy: otg-efm
   allow_efm: true
@@ -142,7 +142,7 @@ nodes:
       step: variant_index
       step.vep_output_json_path: gs://ot_orchestration/releases/24.10_freeze6/variants/annotated_variants
       step.gnomad_variant_annotations_path: gs://genetics_etl_python_playground/static_assets/gnomad_variants
-      step.variant_index_path: gs://ot_orchestration/test/releases/24.10_freeze6/variant_index
+      step.variant_index_path: gs://ot_orchestration/releases/24.10_freeze6/variant_index
 
   - id: colocalisation_ecaviar
     prerequisites:
@@ -184,7 +184,7 @@ nodes:
     params:
       step: locus_to_gene
       step.run_mode: train
-      step.wandb_run_name: 24.10_freeze5
+      step.wandb_run_name: 24.10_freeze6
       step.hf_hub_repo_id: opentargets/locus_to_gene
       step.model_path: gs://ot_orchestration/releases/24.10_freeze6/locus_to_gene_model/classifier.skops
       step.credible_set_path: gs://ot_orchestration/releases/24.10_freeze6/credible_set
@@ -222,10 +222,10 @@ nodes:
   - id: l2g_associations
     params:
       step: locus_to_gene_associations
-      step.evidence_input_path: gs://ot_orchestration/releases/24.10_freeze5/locus_to_gene_evidence
+      step.evidence_input_path: gs://ot_orchestration/releases/24.10_freeze6/locus_to_gene_evidence
       step.disease_index_path: gs://open-targets-pre-data-releases/24.06/output/etl/parquet/diseases
-      step.direct_associations_output_path: gs://ot_orchestration/releases/24.10_freeze5/locus_to_gene_associations/direct_associations
-      step.indirect_associations_output_path: gs://ot_orchestration/releases/24.10_freeze5/locus_to_gene_associations/indirect_associations
+      step.direct_associations_output_path: gs://ot_orchestration/releases/24.10_freeze6/locus_to_gene_associations/direct_associations
+      step.indirect_associations_output_path: gs://ot_orchestration/releases/24.10_freeze6/locus_to_gene_associations/indirect_associations
       step.session.spark_uri: yarn
     prerequisites:
       - l2g_evidence

--- a/src/ot_orchestration/dags/config/genetics_etl.yaml
+++ b/src/ot_orchestration/dags/config/genetics_etl.yaml
@@ -1,10 +1,10 @@
 l2g_gold_standard_path: gs://genetics_etl_python_playground/input/l2g/gold_standard/curation.json
 release_dir: gs://ot_orchestration/releases/24.10_freeze5
 dataproc:
-  python_main_module: gs://genetics_etl_python_playground/initialisation/gentropy/dev/cli.py
+  python_main_module: gs://genetics_etl_python_playground/initialisation/gentropy/chr-quotes/cli.py
   cluster_metadata:
-    PACKAGE: gs://genetics_etl_python_playground/initialisation/gentropy/dev/gentropy-0.0.0-py3-none-any.whl
-  cluster_init_script: gs://genetics_etl_python_playground/initialisation/gentropy/dev/install_dependencies_on_cluster.sh
+    PACKAGE: gs://genetics_etl_python_playground/initialisation/gentropy/chr-quotes/gentropy-0.0.0-py3-none-any.whl
+  cluster_init_script: gs://genetics_etl_python_playground/initialisation/gentropy/chr-quotes/install_dependencies_on_cluster.sh
   cluster_name: otg-etl
   autoscaling_policy: otg-efm
   allow_efm: true
@@ -87,97 +87,67 @@ nodes:
         - INVALID_CHROMOSOME
         - TOP_HIT_AND_SUMMARY_STATS
       step.session.spark_uri: yarn
-  - id: variant_annotation
-    kind: TaskGroup
-    nodes:
-      - id: variant_to_vcf
-        kind: Task
-        google_batch:
-          entrypoint: /bin/sh
-          commands:
-            - -c
-            - poetry
-            - run
-            - gentropy
-          image: europe-west1-docker.pkg.dev/open-targets-genetics-dev/gentropy-app/gentropy:dev
-          environment:
-            - SOURCE_NAME: uniprot
-              SOURCE_PATH: gs://open-targets-pre-data-releases/24.09/input/evidence-files/uniprot.json.gz
-              SOURCE_FORMAT: json
-            - SOURCE_NAME: clinvar
-              SOURCE_PATH: gs://open-targets-pre-data-releases/24.09/input/evidence-files/eva.json.gz
-              SOURCE_FORMAT: json
-            - SOURCE_NAME: pharmgkb
-              SOURCE_PATH: gs://open-targets-pre-data-releases/24.09/input/pharmacogenomics-inputs/pharmacogenomics.json.gz
-              SOURCE_FORMAT: json
-            - SOURCE_NAME: gentropy_credible_sets
-              SOURCE_PATH: gs://ot_orchestration/releases/24.10_freeze5/credible_set
-              SOURCE_FORMAT: parquet
-          resource_specs:
-            cpu_milli: 2000
-            memory_mib: 26_000
-            boot_disk_mib: 25000
-          task_specs:
-            max_retry_count: 4
-            max_run_duration: "2h"
-          policy_specs:
-            machine_type: n1-highmem-4
-        params:
-          step: variant_to_vcf
-          step.source_path: $SOURCE_PATH
-          step.source_format: $SOURCE_FORMAT
-          step.vcf_path: gs://ot_orchestration/releases/24.10_freeze5/variants/raw_variants/$SOURCE_NAME
-          +step.session.extended_spark_conf: "{spark.jars:https://storage.googleapis.com/hadoop-lib/gcs/gcs-connector-hadoop3-latest.jar,spark.driver.memory:26g}"
-      - id: list_nonannotated_vcfs
-        kind: Task
-        params:
-          # the extension after saving from pyspark csv is going to be the .csv
-          input_vcf_glob: gs://ot_orchestration/releases/24.10_freeze5/variants/raw_variants/**.csv
-          output_path: gs://ot_orchestration/releases/24.10_freeze5/variants/merged_variants
-          chunk_size: 2000
-        prerequisites:
-          - variant_to_vcf
-      - id: vep_annotation
-        kind: Task
-        google_batch:
-          entrypoint: /bin/sh
-          image: europe-west1-docker.pkg.dev/open-targets-genetics-dev/gentropy-app/custom_ensembl_vep:dev
-          resource_specs:
-            cpu_milli: 2000
-            memory_mib: 2000
-            boot_disk_mib: 10000
-          task_specs:
-            max_retry_count: 4
-            max_run_duration: "2h"
-          policy_specs:
-            machine_type: n1-standard-4
-        params:
-          vep_cache_path: gs://genetics_etl_python_playground/vep/cache
-          vcf_input_path: gs://ot_orchestration/releases/24.10_freeze5/variants/merged_variants
-          vep_output_path: gs://ot_orchestration/releases/24.10_freeze5/variants/annotated_variants
-        prerequisites:
-          - list_nonannotated_vcfs
+
+  - id: convert_variants_to_vcf
+    kind: Task
+    params:
+      step: variant_to_vcf
+      step.source_paths:
+        - gs://open-targets-pre-data-releases/24.09/input/evidence-files/uniprot.json.gz
+        - gs://open-targets-pre-data-releases/24.09/input/evidence-files/eva.json.gz
+        - gs://open-targets-pre-data-releases/24.09/input/pharmacogenomics-inputs/pharmacogenomics.json.gz
+        - gs://ot_orchestration/releases/24.10_freeze5/credible_set
+      step.source_formats:
+        - json
+        - json
+        - json
+        - parquet
+      step.output_path: gs://ot_orchestration/releases/24.10_freeze5/variants/partitioned_variants
+      step.partition_size: 2_000 # approximate num of variants per partition!
     prerequisites:
       - credible_set_validation
+
+  - id: variant_annotation
+    kind: Task
+    google_batch:
+      entrypoint: /bin/sh
+      image: europe-west1-docker.pkg.dev/open-targets-genetics-dev/gentropy-app/custom_ensembl_vep:dev
+      resource_specs:
+        cpu_milli: 2000
+        memory_mib: 2000
+        boot_disk_mib: 10000
+      task_specs:
+        max_retry_count: 1
+        max_run_duration: "2h"
+      policy_specs:
+        machine_type: n1-standard-4
+    params:
+      vep_cache_path: gs://genetics_etl_python_playground/vep/cache
+      vcf_input_path: gs://ot_orchestration/releases/24.10_freeze5/variants/partitioned_variants
+      vep_output_path: gs://ot_orchestration/releases/24.10_freeze5/variants/annotated_variants
+    prerequisites:
+      - convert_variants_to_vcf
+
   - id: variant_index
-    command: gs://genetics_etl_python_playground/initialisation/0.0.0/cli.py
     params:
       step: variant_index
       step.vep_output_json_path: gs://ot_orchestration/releases/24.10_freeze5/variants/annotated_variants
       step.gnomad_variant_annotations_path: gs://genetics_etl_python_playground/static_assets/gnomad_variants
-      step.variant_index_path: gs://ot_orchestration/releases/24.10_freeze5/variant_index
+      step.variant_index_path: gs://ot_orchestration/test/releases/24.10_freeze5/variant_index
       step.session.spark_uri: yarn
+      step.session.write_mode: overwrite
     prerequisites:
       - variant_annotation
+
   - id: gene_index
-    command: gs://genetics_etl_python_playground/initialisation/0.0.0/cli.py
     params:
       step: gene_index
       step.target_path: gs://genetics_etl_python_playground/static_assets/targets # OTP 23.12 data
       step.gene_index_path: gs://ot_orchestration/releases/24.10_freeze5/gene_index
       step.session.spark_uri: yarn
+    prerequisites: []
+
   - id: colocalisation_ecaviar
-    command: gs://genetics_etl_python_playground/initialisation/0.0.0/cli.py
     params:
       step: colocalisation
       step.credible_set_path: gs://ot_orchestration/releases/24.10_freeze5/credible_set
@@ -186,8 +156,8 @@ nodes:
       step.session.spark_uri: yarn
     prerequisites:
       - credible_set_validation
+
   - id: colocalisation_coloc
-    command: gs://genetics_etl_python_playground/initialisation/0.0.0/cli.py
     params:
       step: colocalisation
       step.credible_set_path: gs://ot_orchestration/releases/24.10_freeze5/credible_set
@@ -197,8 +167,8 @@ nodes:
       +step.colocalisation_method_params: "{priorc1: 1e-4, priorc2: 1e-4, priorc12: 1e-5}"
     prerequisites:
       - credible_set_validation
+
   - id: l2g_feature_matrix
-    command: gs://genetics_etl_python_playground/initialisation/0.0.0/cli.py
     params:
       step: locus_to_gene_feature_matrix
       step.credible_set_path: gs://ot_orchestration/releases/24.10_freeze5/credible_set
@@ -214,8 +184,8 @@ nodes:
       - colocalisation_ecaviar
       - variant_index
       - gene_index
+
   - id: l2g_train
-    command: gs://genetics_etl_python_playground/initialisation/0.0.0/cli.py
     params:
       step: locus_to_gene
       step.run_mode: train
@@ -225,7 +195,7 @@ nodes:
       step.credible_set_path: gs://ot_orchestration/releases/24.10_freeze5/credible_set
       step.variant_index_path: gs://ot_orchestration/releases/24.10_freeze5/variant_index
       step.feature_matrix_path: gs://ot_orchestration/releases/24.10_freeze5/locus_to_gene_feature_matrix
-      step.gold_standard_curation_path: gs://ot_orchestration/releases/24.10_freeze5/locus_to_gene_gold_standard.json
+      step.gold_standard_curation_path: gs://genetics_etl_python_playground/input/l2g/gold_standard/curation.json
       step.gene_interactions_path: gs://genetics_etl_python_playground/static_assets/interaction # OTP 23.12 data
       step.hyperparameters.n_estimators: 100
       step.hyperparameters.max_depth: 5
@@ -234,8 +204,8 @@ nodes:
       +step.session.extended_spark_conf: "{spark.kryoserializer.buffer.max:500m, spark.sql.autoBroadcastJoinThreshold:'-1'}"
     prerequisites:
       - l2g_feature_matrix
+
   - id: l2g_predict
-    command: gs://genetics_etl_python_playground/initialisation/0.0.0/cli.py
     params:
       step: locus_to_gene
       step.run_mode: predict
@@ -246,8 +216,8 @@ nodes:
       step.session.spark_uri: yarn
     prerequisites:
       - l2g_train
+
   - id: l2g_evidence
-    command: gs://genetics_etl_python_playground/initialisation/0.0.0/cli.py
     params:
       step: locus_to_gene_evidence
       step.evidence_output_path: gs://ot_orchestration/releases/24.10_freeze5/locus_to_gene_evidence

--- a/src/ot_orchestration/dags/config/genetics_etl.yaml
+++ b/src/ot_orchestration/dags/config/genetics_etl.yaml
@@ -1,5 +1,5 @@
 l2g_gold_standard_path: gs://genetics_etl_python_playground/input/l2g/gold_standard/curation.json
-release_dir: gs://ot_orchestration/releases/24.10_freeze5
+release_dir: gs://ot_orchestration/releases/24.10_freeze6
 dataproc:
   python_main_module: gs://genetics_etl_python_playground/initialisation/gentropy/chr-quotes/cli.py
   cluster_metadata:
@@ -11,6 +11,14 @@ dataproc:
   num_workers: 10
 
 nodes:
+
+  - id: gene_index
+    prerequisites: []
+    params:
+      step: gene_index
+      step.target_path: gs://genetics_etl_python_playground/static_assets/targets # OTP 23.12 data
+      step.gene_index_path: gs://ot_orchestration/releases/24.10_freeze6/gene_index
+
   - id: biosample_index
     kind: Task
     prerequisites: []
@@ -19,8 +27,8 @@ nodes:
       step.cell_ontology_input_path: gs://open-targets-pre-data-releases/24.06dev-test/input/biosamples/cl.json
       step.uberon_input_path: gs://open-targets-pre-data-releases/24.06dev-test/input/biosamples/uberon.json
       step.efo_input_path: gs://open-targets-pre-data-releases/24.06dev-test/input/biosamples/efo.json
-      step.biosample_index_path: gs://ot_orchestration/releases/24.10_freeze5/biosample_index
-      step.session.spark_uri: yarn
+      step.biosample_index_path: gs://ot_orchestration/releases/24.10_freeze6/biosample_index
+
   - id: study_validation
     kind: Task
     prerequisites:
@@ -35,22 +43,17 @@ nodes:
         - gs://eqtl_catalogue_data/study_index
         - gs://ukb_ppp_eur_data/study_index
         - gs://finngen_data/r11/study_index
-      step.target_index_path: gs://ot_orchestration/releases/24.10_freeze5/gene_index
+      step.target_index_path: gs://ot_orchestration/releases/24.10_freeze6/gene_index
       step.disease_index_path: gs://open-targets-pre-data-releases/24.06/output/etl/parquet/diseases
-      step.valid_study_index_path: gs://ot_orchestration/releases/24.10_freeze5/study_index
-      step.invalid_study_index_path: gs://ot_orchestration/releases/24.10_freeze5/invalid_study_index
-      step.biosample_index_path: gs://ot_orchestration/releases/24.10_freeze5/biosample_index
+      step.valid_study_index_path: gs://ot_orchestration/releases/24.10_freeze6/study_index
+      step.invalid_study_index_path: gs://ot_orchestration/releases/24.10_freeze6/invalid_study_index
+      step.biosample_index_path: gs://ot_orchestration/releases/24.10_freeze6/biosample_index
       step.invalid_qc_reasons:
         - UNRESOLVED_TARGET
         - UNRESOLVED_DISEASE
         - UNKNOWN_STUDY_TYPE
         - DUPLICATED_STUDY
         - UNKNOWN_BIOSAMPLE
-        - FAILED_MEAN_BETA_CHECK
-        - FAILED_PZ_CHECK
-        - FAILED_GC_LAMBDA_CHECK
-        - NO_OT_CURATION
-      step.session.spark_uri: yarn
 
   - id: credible_set_validation
     kind: Task
@@ -58,7 +61,7 @@ nodes:
       - study_validation
     params:
       step: credible_set_validation
-      step.study_index_path: gs://ot_orchestration/releases/24.10_freeze5/study_index
+      step.study_index_path: gs://ot_orchestration/releases/24.10_freeze6/study_index
       step.study_locus_path:
         - gs://gwas_catalog_top_hits/credible_sets/
         - gs://gwas_catalog_sumstats_pics/credible_sets/
@@ -66,8 +69,8 @@ nodes:
         - gs://eqtl_catalogue_data/credible_set_datasets/eqtl_catalogue_susie/
         - gs://ukb_ppp_eur_data/credible_set_clean/
         - gs://finngen_data/r11/credible_set_datasets/susie/
-      step.valid_study_locus_path: gs://ot_orchestration/releases/24.10_freeze5/credible_set
-      step.invalid_study_locus_path: gs://ot_orchestration/releases/24.10_freeze5/invalid_credible_set
+      step.valid_study_locus_path: gs://ot_orchestration/releases/24.10_freeze6/credible_set
+      step.invalid_study_locus_path: gs://ot_orchestration/releases/24.10_freeze6/invalid_credible_set
       step.invalid_qc_reasons:
         - DUPLICATED_STUDYLOCUS_ID
         - AMBIGUOUS_STUDY
@@ -83,32 +86,30 @@ nodes:
         - EXPLAINED_BY_SUSIE
         - WINDOW_CLUMPED
         - NON_MAPPED_VARIANT_FLAG
-        - INVALID_VARIANT_IDENTIFIER
-        - INVALID_CHROMOSOME
-        - TOP_HIT_AND_SUMMARY_STATS
-      step.session.spark_uri: yarn
 
   - id: convert_variants_to_vcf
     kind: Task
+    prerequisites:
+      - credible_set_validation
     params:
       step: variant_to_vcf
       step.source_paths:
         - gs://open-targets-pre-data-releases/24.09/input/evidence-files/uniprot.json.gz
         - gs://open-targets-pre-data-releases/24.09/input/evidence-files/eva.json.gz
         - gs://open-targets-pre-data-releases/24.09/input/pharmacogenomics-inputs/pharmacogenomics.json.gz
-        - gs://ot_orchestration/releases/24.10_freeze5/credible_set
+        - gs://ot_orchestration/releases/24.10_freeze6/credible_set
       step.source_formats:
         - json
         - json
         - json
         - parquet
-      step.output_path: gs://ot_orchestration/releases/24.10_freeze5/variants/partitioned_variants
+      step.output_path: gs://ot_orchestration/releases/24.10_freeze6/variants/partitioned_variants
       step.partition_size: 2_000 # approximate num of variants per partition!
-    prerequisites:
-      - credible_set_validation
 
   - id: variant_annotation
     kind: Task
+    prerequisites:
+      - convert_variants_to_vcf
     google_batch:
       entrypoint: /bin/sh
       image: europe-west1-docker.pkg.dev/open-targets-genetics-dev/gentropy-app/custom_ensembl_vep:dev
@@ -123,119 +124,89 @@ nodes:
         machine_type: n1-standard-4
     params:
       vep_cache_path: gs://genetics_etl_python_playground/vep/cache
-      vcf_input_path: gs://ot_orchestration/releases/24.10_freeze5/variants/partitioned_variants
-      vep_output_path: gs://ot_orchestration/releases/24.10_freeze5/variants/annotated_variants
-    prerequisites:
-      - convert_variants_to_vcf
+      vcf_input_path: gs://ot_orchestration/releases/24.10_freeze6/variants/partitioned_variants
+      vep_output_path: gs://ot_orchestration/releases/24.10_freeze6/variants/annotated_variants
 
   - id: variant_index
-    params:
-      step: variant_index
-      step.vep_output_json_path: gs://ot_orchestration/releases/24.10_freeze5/variants/annotated_variants
-      step.gnomad_variant_annotations_path: gs://genetics_etl_python_playground/static_assets/gnomad_variants
-      step.variant_index_path: gs://ot_orchestration/test/releases/24.10_freeze5/variant_index
-      step.session.spark_uri: yarn
-      step.session.write_mode: overwrite
     prerequisites:
       - variant_annotation
-
-  - id: gene_index
     params:
-      step: gene_index
-      step.target_path: gs://genetics_etl_python_playground/static_assets/targets # OTP 23.12 data
-      step.gene_index_path: gs://ot_orchestration/releases/24.10_freeze5/gene_index
-      step.session.spark_uri: yarn
-    prerequisites: []
+      step: variant_index
+      step.vep_output_json_path: gs://ot_orchestration/releases/24.10_freeze6/variants/annotated_variants
+      step.gnomad_variant_annotations_path: gs://genetics_etl_python_playground/static_assets/gnomad_variants
+      step.variant_index_path: gs://ot_orchestration/test/releases/24.10_freeze6/variant_index
 
   - id: colocalisation_ecaviar
-    params:
-      step: colocalisation
-      step.credible_set_path: gs://ot_orchestration/releases/24.10_freeze5/credible_set
-      step.coloc_path: gs://ot_orchestration/releases/24.10_freeze5/colocalisation
-      step.colocalisation_method: ECaviar
-      step.session.spark_uri: yarn
     prerequisites:
       - credible_set_validation
+    params:
+      step: colocalisation
+      step.credible_set_path: gs://ot_orchestration/releases/24.10_freeze6/credible_set
+      step.coloc_path: gs://ot_orchestration/releases/24.10_freeze6/colocalisation
+      step.colocalisation_method: ECaviar
 
   - id: colocalisation_coloc
-    params:
-      step: colocalisation
-      step.credible_set_path: gs://ot_orchestration/releases/24.10_freeze5/credible_set
-      step.coloc_path: gs://ot_orchestration/releases/24.10_freeze5/colocalisation/
-      step.colocalisation_method: Coloc
-      step.session.spark_uri: yarn
-      +step.colocalisation_method_params: "{priorc1: 1e-4, priorc2: 1e-4, priorc12: 1e-5}"
     prerequisites:
       - credible_set_validation
+    params:
+      step: colocalisation
+      step.credible_set_path: gs://ot_orchestration/releases/24.10_freeze6/credible_set
+      step.coloc_path: gs://ot_orchestration/releases/24.10_freeze6/colocalisation/
+      step.colocalisation_method: Coloc
+      +step.colocalisation_method_params: "{priorc1: 1e-4, priorc2: 1e-4, priorc12: 1e-5}"
 
   - id: l2g_feature_matrix
-    params:
-      step: locus_to_gene_feature_matrix
-      step.credible_set_path: gs://ot_orchestration/releases/24.10_freeze5/credible_set
-      step.variant_index_path: gs://ot_orchestration/releases/24.10_freeze5/variant_index
-      step.colocalisation_path: gs://ot_orchestration/releases/24.10_freeze5/colocalisation
-      step.study_index_path: gs://ot_orchestration/releases/24.10_freeze5/study_index
-      step.gene_index_path: gs://ot_orchestration/releases/24.10_freeze5/gene_index
-      step.feature_matrix_path: gs://ot_orchestration/releases/24.10_freeze5/locus_to_gene_feature_matrix
-      +step.session.extended_spark_conf: "{spark.sql.autoBroadcastJoinThreshold:'-1'}"
-      step.session.spark_uri: yarn
     prerequisites:
       - colocalisation_coloc
       - colocalisation_ecaviar
       - variant_index
-      - gene_index
+    params:
+      step: locus_to_gene_feature_matrix
+      step.credible_set_path: gs://ot_orchestration/releases/24.10_freeze6/credible_set
+      step.variant_index_path: gs://ot_orchestration/releases/24.10_freeze6/variant_index
+      step.colocalisation_path: gs://ot_orchestration/releases/24.10_freeze6/colocalisation
+      step.study_index_path: gs://ot_orchestration/releases/24.10_freeze6/study_index
+      step.gene_index_path: gs://ot_orchestration/releases/24.10_freeze6/gene_index
+      step.feature_matrix_path: gs://ot_orchestration/releases/24.10_freeze6/locus_to_gene_feature_matrix
+      +step.session.extended_spark_conf: "{spark.sql.autoBroadcastJoinThreshold:'-1'}"
 
   - id: l2g_train
+    prerequisites:
+      - l2g_feature_matrix
     params:
       step: locus_to_gene
       step.run_mode: train
       step.wandb_run_name: 24.10_freeze5
       step.hf_hub_repo_id: opentargets/locus_to_gene
-      step.model_path: gs://ot_orchestration/releases/24.10_freeze5/locus_to_gene_model/classifier.skops
-      step.credible_set_path: gs://ot_orchestration/releases/24.10_freeze5/credible_set
-      step.variant_index_path: gs://ot_orchestration/releases/24.10_freeze5/variant_index
-      step.feature_matrix_path: gs://ot_orchestration/releases/24.10_freeze5/locus_to_gene_feature_matrix
+      step.model_path: gs://ot_orchestration/releases/24.10_freeze6/locus_to_gene_model/classifier.skops
+      step.credible_set_path: gs://ot_orchestration/releases/24.10_freeze6/credible_set
+      step.variant_index_path: gs://ot_orchestration/releases/24.10_freeze6/variant_index
+      step.feature_matrix_path: gs://ot_orchestration/releases/24.10_freeze6/locus_to_gene_feature_matrix
       step.gold_standard_curation_path: gs://genetics_etl_python_playground/input/l2g/gold_standard/curation.json
       step.gene_interactions_path: gs://genetics_etl_python_playground/static_assets/interaction # OTP 23.12 data
       step.hyperparameters.n_estimators: 100
       step.hyperparameters.max_depth: 5
       step.hyperparameters.loss: log_loss
-      step.session.spark_uri: yarn
+      step.download_from_hub: true
       +step.session.extended_spark_conf: "{spark.kryoserializer.buffer.max:500m, spark.sql.autoBroadcastJoinThreshold:'-1'}"
-    prerequisites:
-      - l2g_feature_matrix
 
   - id: l2g_predict
+    prerequisites:
+      - l2g_train
     params:
       step: locus_to_gene
       step.run_mode: predict
-      step.predictions_path: gs://ot_orchestration/releases/24.10_freeze5/locus_to_gene_predictions
-      step.feature_matrix_path: gs://ot_orchestration/releases/24.10_freeze5/locus_to_gene_feature_matrix
-      step.credible_set_path: gs://ot_orchestration/releases/24.10_freeze5/credible_set
-      step.download_from_hub: true
-      step.session.spark_uri: yarn
-    prerequisites:
-      - l2g_train
+      step.predictions_path: gs://ot_orchestration/releases/24.10_freeze6/locus_to_gene_predictions
+      step.feature_matrix_path: gs://ot_orchestration/releases/24.10_freeze6/locus_to_gene_feature_matrix
+      step.credible_set_path: gs://ot_orchestration/releases/24.10_freeze6/credible_set
 
   - id: l2g_evidence
-    params:
-      step: locus_to_gene_evidence
-      step.evidence_output_path: gs://ot_orchestration/releases/24.10_freeze5/locus_to_gene_evidence
-      step.locus_to_gene_predictions_path: gs://ot_orchestration/releases/24.10_freeze5/locus_to_gene_predictions
-      step.credible_set_path: gs://ot_orchestration/releases/24.10_freeze5/credible_set
-      step.study_index_path: gs://ot_orchestration/releases/24.10_freeze5/study_index
-      step.locus_to_gene_threshold: 0.05
-      step.session.spark_uri: yarn
     prerequisites:
       - l2g_predict
-  - id: l2g_associations
-    command: gs://genetics_etl_python_playground/initialisation/0.0.0/cli.py
     params:
-      step: locus_to_gene_associations
-      step.evidence_input_path: gs://ot_orchestration/releases/24.10_freeze5/locus_to_gene_evidence
-      step.disease_index_path: gs://open-targets-pre-data-releases/24.06/output/etl/parquet/diseases
-      step.direct_associations_output_path: gs://ot_orchestration/releases/24.10_freeze5/locus_to_gene_associations/direct_associations
-      step.indirect_associations_output_path: gs://ot_orchestration/releases/24.10_freeze5/locus_to_gene_associations/indirect_associations
-      step.session.spark_uri: yarn
-    prerequisites:
-      - l2g_evidence
+      step: locus_to_gene_evidence
+      step.evidence_output_path: gs://ot_orchestration/releases/24.10_freeze6/locus_to_gene_evidence
+      step.locus_to_gene_predictions_path: gs://ot_orchestration/releases/24.10_freeze6/locus_to_gene_predictions
+      step.credible_set_path: gs://ot_orchestration/releases/24.10_freeze6/credible_set
+      step.study_index_path: gs://ot_orchestration/releases/24.10_freeze6/study_index
+      step.locus_to_gene_threshold: 0.05

--- a/src/ot_orchestration/dags/config/genetics_etl.yaml
+++ b/src/ot_orchestration/dags/config/genetics_etl.yaml
@@ -13,6 +13,7 @@ dataproc:
 nodes:
 
   - id: gene_index
+    kind: Task
     prerequisites: []
     params:
       step: gene_index
@@ -154,7 +155,7 @@ nodes:
 
   - id: colocalisation_coloc
     prerequisites:
-      - credible_set_validation
+      - colocalisation_ecaviar
     params:
       step: colocalisation
       step.credible_set_path: gs://ot_orchestration/releases/24.10_freeze6/credible_set

--- a/src/ot_orchestration/dags/config/genetics_etl.yaml
+++ b/src/ot_orchestration/dags/config/genetics_etl.yaml
@@ -217,3 +217,14 @@ nodes:
       step.credible_set_path: gs://ot_orchestration/releases/24.10_freeze6/credible_set
       step.study_index_path: gs://ot_orchestration/releases/24.10_freeze6/study_index
       step.locus_to_gene_threshold: 0.05
+
+  - id: l2g_associations
+    params:
+      step: locus_to_gene_associations
+      step.evidence_input_path: gs://ot_orchestration/releases/24.10_freeze5/locus_to_gene_evidence
+      step.disease_index_path: gs://open-targets-pre-data-releases/24.06/output/etl/parquet/diseases
+      step.direct_associations_output_path: gs://ot_orchestration/releases/24.10_freeze5/locus_to_gene_associations/direct_associations
+      step.indirect_associations_output_path: gs://ot_orchestration/releases/24.10_freeze5/locus_to_gene_associations/indirect_associations
+      step.session.spark_uri: yarn
+    prerequisites:
+      - l2g_evidence

--- a/src/ot_orchestration/dags/config/genetics_etl.yaml
+++ b/src/ot_orchestration/dags/config/genetics_etl.yaml
@@ -194,7 +194,6 @@ nodes:
       step.hyperparameters.n_estimators: 100
       step.hyperparameters.max_depth: 5
       step.hyperparameters.loss: log_loss
-      step.download_from_hub: true
       +step.session.extended_spark_conf: "{spark.kryoserializer.buffer.max:500m, spark.sql.autoBroadcastJoinThreshold:'-1'}"
 
   - id: l2g_predict
@@ -206,6 +205,7 @@ nodes:
       step.predictions_path: gs://ot_orchestration/releases/24.10_freeze6/locus_to_gene_predictions
       step.feature_matrix_path: gs://ot_orchestration/releases/24.10_freeze6/locus_to_gene_feature_matrix
       step.credible_set_path: gs://ot_orchestration/releases/24.10_freeze6/credible_set
+      step.download_from_hub: true
 
   - id: l2g_evidence
     prerequisites:

--- a/src/ot_orchestration/dags/genetics_etl.py
+++ b/src/ot_orchestration/dags/genetics_etl.py
@@ -2,37 +2,19 @@
 
 from __future__ import annotations
 
-import time
 from pathlib import Path
 
 from airflow.decorators import task
-from airflow.models.baseoperator import chain
 from airflow.models.dag import DAG
-from airflow.providers.google.cloud.operators.cloud_batch import (
-    CloudBatchSubmitJobOperator,
-)
-from airflow.providers.google.cloud.transfers.gcs_to_gcs import GCSToGCSOperator
 from airflow.utils.task_group import TaskGroup
 
-from ot_orchestration.operators.batch.vep import (
-    ConvertVariantsToVcfOperator,
-    VepAnnotateOperator,
-)
+from ot_orchestration.operators.batch.vep import VepAnnotateOperator
 from ot_orchestration.utils import (
-    GCSPath,
     chain_dependencies,
     find_node_in_config,
     read_yaml_config,
 )
-from ot_orchestration.utils.batch import (
-    create_batch_job,
-    create_task_commands,
-    create_task_env,
-    create_task_spec,
-)
 from ot_orchestration.utils.common import (
-    GCP_PROJECT_GENETICS,
-    GCP_REGION,
     shared_dag_args,
     shared_dag_kwargs,
 )
@@ -47,12 +29,6 @@ nodes = config["nodes"]
 node_map = {}
 
 
-# FIXME: eventually this task group should have 2 steps only
-# - 1. transform variant sources to vcf files, collect and partition them by chunk size - should be done by a single gentropy step rather then
-# multiple tasks in the DAG (pending)
-# - 2. list new chunk vcf files and annotate them - batch job
-
-
 # This operator meant to fail the DAG if the release folder exists:
 with DAG(
     dag_id=Path(__file__).stem,
@@ -60,108 +36,20 @@ with DAG(
     default_args=shared_dag_args,
     **shared_dag_kwargs,
 ):
-    # Compiling tasks for moving data to the right place:
-    with TaskGroup(group_id="data_transfer") as data_transfer:
-        # Defining the tasks to execute in the task group:
-        l2g_gold_standard_path = GCSPath(config["l2g_gold_standard_path"])
-        release_dir = GCSPath(config["release_dir"])
-        # Files to move:
-        DATA_TO_MOVE = {
-            # L2G gold standard:
-            "l2g_gold_standard": {
-                "source_bucket": l2g_gold_standard_path.bucket,
-                "source_object": l2g_gold_standard_path.path,
-                "destination_bucket": release_dir.bucket,
-                "destination_object": f"{release_dir.path}/locus_to_gene_gold_standard.json",
-            },
-        }
-        [
-            GCSToGCSOperator(
-                task_id=f"move_{data_name}",
-                source_bucket=data["source_bucket"],
-                source_object=data["source_object"],
-                destination_bucket=data["destination_bucket"],
-                destination_object=data["destination_object"],
-            )
-            for data_name, data in DATA_TO_MOVE.items()
-        ]
-
     with TaskGroup(group_id="genetics_etl") as genetics_etl:
-        # ===== Variant annotation task group ======
-        with TaskGroup(group_id="variant_annotation") as variant_annotation:
-            variant_annotation_task_group_config = find_node_in_config(
-                nodes, "variant_annotation"
-            )
+        task_config = find_node_in_config(nodes, "variant_annotation")
+        task_config_params = task_config["params"]
+        variant_annotation = VepAnnotateOperator(
+            task_id=task_config["id"],
+            vcf_input_path=task_config_params["vcf_input_path"],
+            vep_output_path=task_config_params["vep_output_path"],
+            vep_cache_path=task_config_params["vep_cache_path"],
+            google_batch=task_config["google_batch"],
+        )
 
-            # ===== Convert variant datasource to vcf file step ======
-            task_config = find_node_in_config(
-                variant_annotation_task_group_config["nodes"],
-                node_id="variant_to_vcf",
-            )
-            google_batch_config = task_config["google_batch"]
-            commands = create_task_commands(
-                commands=google_batch_config["commands"],
-                params=task_config["params"],
-            )
-            task = create_task_spec(
-                image=google_batch_config["image"],
-                commands=commands,
-                resource_specs=google_batch_config["resource_specs"],
-                task_specs=google_batch_config["task_specs"],
-                entrypoint=google_batch_config["entrypoint"],
-            )
-            environment = google_batch_config["environment"]
-            batch_job = create_batch_job(
-                task=task,
-                task_env=create_task_env(environment),
-                policy_specs=google_batch_config["policy_specs"],
-            )
-            variant_to_vcf = CloudBatchSubmitJobOperator(
-                task_id="variant_to_vcf",
-                project_id=GCP_PROJECT_GENETICS,
-                region=GCP_REGION,
-                job_name=f"variant-to-vcf-job-{time.strftime('%Y%m%d-%H%M%S')}",
-                job=batch_job,
-                deferrable=False,
-            )
+        node_map["variant_annotation"] = variant_annotation
 
-            # ===== Partition vcf files into chunks step ======
-            task_config = find_node_in_config(
-                config=variant_annotation_task_group_config["nodes"],
-                node_id="list_nonannotated_vcfs",
-            )
-            merged_vcfs = ConvertVariantsToVcfOperator(
-                task_id="list_nonannotated_vcfs",
-                tsv_files_glob=task_config["params"]["input_vcf_glob"],
-                output_path=task_config["params"]["output_path"],
-                chunk_size=task_config["params"]["chunk_size"],
-            )
-            # ===== Perform VEP annotations on chunks step =====
-            task_config = find_node_in_config(
-                variant_annotation_task_group_config["nodes"],
-                node_id="vep_annotation",
-            )
-            task_config_params = task_config["params"]
-            vep_annotation = VepAnnotateOperator(
-                task_id=task_config["id"],
-                vcf_input_path=task_config_params["vcf_input_path"],
-                vep_output_path=task_config_params["vep_output_path"],
-                vep_cache_path=task_config_params["vep_cache_path"],
-                google_batch=task_config["google_batch"],
-            )
-
-            chain_dependencies(
-                nodes=variant_annotation_task_group_config["nodes"],
-                tasks_or_task_groups={
-                    "variant_to_vcf": variant_to_vcf,
-                    "list_nonannotated_vcfs": merged_vcfs,
-                    "vep_annotation": vep_annotation,
-                },
-            )
-            node_map["variant_annotation"] = variant_annotation
-        # ===== END Variant annotation task group ======
-
-        tasks = [node for node in nodes if node.get("kind", "Task") == "Task"]
+        tasks = [node for node in nodes if "google_batch" not in node]
         # Build individual tasks and register them as nodes.
         for task in tasks:
             dataproc_specs = config["dataproc"]
@@ -179,11 +67,3 @@ with DAG(
             tasks=list(node_map.values()),  # type: ignore
             **config["dataproc"],
         )
-
-    # DAG description:
-    chain(
-        # Run data transfer:
-        data_transfer,
-        # Once datasets are transferred, run the rest of the steps:
-        genetics_etl,
-    )

--- a/src/ot_orchestration/dags/genetics_etl.py
+++ b/src/ot_orchestration/dags/genetics_etl.py
@@ -1,10 +1,11 @@
-"""Test DAG to prototype data transfer."""
+"""Genetics ETL dag."""
 
 from __future__ import annotations
 
 from pathlib import Path
 
 from airflow.decorators import task
+from airflow.models.baseoperator import BaseOperator
 from airflow.models.dag import DAG
 from airflow.utils.task_group import TaskGroup
 
@@ -26,7 +27,7 @@ from ot_orchestration.utils.dataproc import (
 SOURCE_CONFIG_FILE_PATH = Path(__file__).parent / "config" / "genetics_etl.yaml"
 config = read_yaml_config(SOURCE_CONFIG_FILE_PATH)
 nodes = config["nodes"]
-node_map = {}
+node_map: dict[str, BaseOperator] = {}
 
 
 # This operator meant to fail the DAG if the release folder exists:
@@ -59,11 +60,11 @@ with DAG(
                 python_main_module=dataproc_specs["python_main_module"],
                 params=task["params"],
             )
-            node_map[task["id"]] = this_task  # type: ignore
+            node_map[task["id"]] = this_task
 
         # chain prerequisites
         chain_dependencies(nodes=config["nodes"], tasks_or_task_groups=node_map)
         generate_dataproc_task_chain(
-            tasks=list(node_map.values()),  # type: ignore
+            tasks=list(node_map.values()),
             **config["dataproc"],
         )

--- a/src/ot_orchestration/operators/batch/vep.py
+++ b/src/ot_orchestration/operators/batch/vep.py
@@ -7,8 +7,10 @@ from functools import cached_property
 from pathlib import Path
 from typing import Sequence, Set
 
+from airflow.exceptions import AirflowException
 from airflow.providers.google.cloud.hooks.cloud_batch import CloudBatchHook
 from airflow.providers.google.cloud.operators.cloud_base import GoogleCloudBaseOperator
+from google.cloud.batch import JobStatus
 from google.cloud.batch_v1 import Job
 from google.cloud.storage import Client
 
@@ -92,6 +94,10 @@ class VepAnnotateOperator(GoogleCloudBaseOperator):
     This operator performs the VEP annotation of vcf files provided in the `vcf_input_path`.
     The annotation command is custom to OTG needs. The number of batch tasks is inferred by listing the number of
     vcf files introduced in the `vcf_input_path`. Each input file will result in a single vep task.
+
+    The operator tries to list the tasks after they are completed, in case of any failures in the task, the
+    operator throws AirflowException and stops the execution of the DAG. The defails of the failed job can be
+    retrieved from the logs.
     """
 
     def __init__(
@@ -123,23 +129,23 @@ class VepAnnotateOperator(GoogleCloudBaseOperator):
         self.impersonation_chain = impersonation_chain
         self.polling_period_seconds = polling_period_seconds
         self.timeout_seconds = timeout_seconds
-
-    def execute(self, context) -> dict:
-        """Execute the operator."""
         self.pm = VepAnnotationPathManager(
             vcf_input_path=self.vcf_input_path,
             vep_output_path=self.vep_output_path,
             vep_cache_path=self.vep_cache_path,
             mount_dir_root=self.mount_dir_root,
         )
-        hook: CloudBatchHook = CloudBatchHook(
-            self.gcp_conn_id, self.impersonation_chain
-        )
 
-        vcf_files = self._get_vcf_partition_basenames()
+    @cached_property
+    def hook(self) -> CloudBatchHook:
+        """Get the cloud batch hook."""
+        return CloudBatchHook(self.gcp_conn_id, self.impersonation_chain)
 
+    def execute(self, context) -> dict:
+        """Execute the operator."""
+        vcf_files = self._get_vcf_partition_basenames(self.pm.paths["input"])
         environments = [
-            {"INPUT_FILE": file, "OUTPUT_FILE": file.replace(".vcf", ".json")}
+            {"INPUT_FILE": file, "OUTPUT_FILE": file.replace(".csv", ".json")}
             for file in vcf_files
         ]
 
@@ -155,27 +161,40 @@ class VepAnnotateOperator(GoogleCloudBaseOperator):
             policy_specs=self.google_batch["policy_specs"],
             mounting_points=self.pm.mount_config,
         )
-        self.log.info(job_def)
-
-        job = hook.submit_batch_job(
+        self.log.debug(job_def)
+        job = self.hook.submit_batch_job(
             job_name=self.job_name,
             job=job_def,
             region=self.region,
             project_id=self.project_id,
         )
-        completed_job = hook.wait_for_job(
+        completed_job = self.hook.wait_for_job(
             job_name=job.name,
             polling_period_seconds=self.polling_period_seconds,
             timeout=self.timeout_seconds,
         )
-        print(
-            hook.list_tasks(
-                region=self.region, job_name=job.name, project_id=self.project_id
+        self.log.debug(completed_job)
+
+        # Retrieve the job status
+        _filter = f"name:projects/{self.project_id}/locations/{self.region}/jobs/{self.job_name}*"
+        jobs = list(
+            self.hook.list_jobs(
+                region=self.region, project_id=self.project_id, filter=_filter
             )
         )
-        return Job.to_dict(completed_job)  # type: ignore
+        if len(jobs) != 1:
+            raise AirflowException(f"Found more then one job for id {self.job_name}")
 
-    def _get_vcf_partition_basenames(self) -> Set[str]:
+        job_status = jobs[0].status
+        job_state = job_status.state
+
+        if job_state != JobStatus.State.SUCCEEDED:
+            self.log.error(job_status)
+            raise AirflowException(f"Job {self.job_name} failed.")
+
+        return Job.to_dict(jobs[0])  # type: ignore
+
+    def _get_vcf_partition_basenames(self, input_path: GCSPath) -> Set[str]:
         """Based on listed vcf file partition extract their basenames.
 
         NOTE: Do not reconstruct full path to the mount, as it will
@@ -186,16 +205,10 @@ class VepAnnotateOperator(GoogleCloudBaseOperator):
         Returns:
             Set[str]: set of basenames to pass to the task environments.
         """
-        input_path = self.pm.paths["input"]
         c = Client(project=self.project_id)
         b = c.bucket(bucket_name=input_path.bucket)
         blobs = b.list_blobs(prefix=input_path.path, match_glob="**.csv")
-        _blobs = []
-        i = 0
-        while i < 1:
-            i += 1
-            _blobs.append(next(blobs))
-        vcf_paths = {Path(blob.name).name for blob in _blobs}
+        vcf_paths = {Path(blob.name).name for blob in blobs}
         # FIXME: Apparently this operator logs are not appearing in the airflow UI.
         self.log.info("Found %s vcf files", len(vcf_paths))
         return vcf_paths
@@ -204,11 +217,18 @@ class VepAnnotateOperator(GoogleCloudBaseOperator):
     def _vep_command(self) -> list[str]:
         return [
             "-c",
-            rf"vep --cache --offline --format vcf --force_overwrite \
+            # NOTE: Ensure the CHROM column is replaced with #CHROM
+            rf"sed -i '0,/CHROM/s/CHROM/#CHROM/' {self.pm.input_dir}/$INPUT_FILE && \
+                 vep \
+                --cache \
+                --offline \
+                --format vcf \
+                --force_overwrite \
                 --no_stats \
                 --dir_cache {self.pm.cache_dir} \
                 --input_file {self.pm.input_dir}/$INPUT_FILE \
-                --output_file {self.pm.output_dir}/$OUTPUT_FILE --json \
+                --output_file {self.pm.output_dir}/$OUTPUT_FILE \
+                --json \
                 --dir_plugins {self.pm.cache_dir}/VEP_plugins \
                 --sift b \
                 --polyphen b \

--- a/src/ot_orchestration/operators/batch/vep.py
+++ b/src/ot_orchestration/operators/batch/vep.py
@@ -3,17 +3,14 @@
 from __future__ import annotations
 
 import time
-from collections import OrderedDict
 from functools import cached_property
 from pathlib import Path
-from typing import Sequence, Set, Type
+from typing import Sequence, Set
 
-import pandas as pd
-from airflow.models import BaseOperator
 from airflow.providers.google.cloud.hooks.cloud_batch import CloudBatchHook
 from airflow.providers.google.cloud.operators.cloud_base import GoogleCloudBaseOperator
 from google.cloud.batch_v1 import Job
-from google.cloud.storage import Blob, Client
+from google.cloud.storage import Client
 
 from ot_orchestration.types import GCSMountObject, GoogleBatchSpecs
 from ot_orchestration.utils.batch import (
@@ -26,7 +23,7 @@ from ot_orchestration.utils.path import GCSPath
 
 
 class VepAnnotationPathManager:
-    """It is quite complicated to keep track of all the input/output buckets, the corresponding mounting points prefixes etc..."""
+    """Manager class for setting correct mounting points for VEP google batch tasks."""
 
     def __init__(
         self,
@@ -35,29 +32,28 @@ class VepAnnotationPathManager:
         vep_cache_path: str,
         mount_dir_root: str,
     ):
+        self._mount_dir_root = mount_dir_root
         self.paths = {
             "input": GCSPath(vcf_input_path),
             "output": GCSPath(vep_output_path),
             "cache": GCSPath(vep_cache_path),
         }
-        self.mount_dir_root = mount_dir_root
 
-        self._validate_mount_dir()
-        self.path_registry = self._prepare_path_registry()
-        # explicitly set the properties
-        self.cache_dir = self.path_registry["cache"]["mount_point"]
-        self.input_dir = self.path_registry["input"]["mount_point"]
-        self.output_dir = self.path_registry["output"]["mount_point"]
-
-    def _validate_mount_dir(self) -> VepAnnotationPathManager:
-        if not self.mount_dir_root.startswith("/"):
+    @cached_property
+    def mount_dir_root(self) -> str:
+        """Get the mount directory root."""
+        if not self._mount_dir_root.startswith("/"):
             raise ValueError("Mount dir has to be an absolute path.")
-        return self
+        if self._mount_dir_root.endswith("/"):
+            return str(Path(self._mount_dir_root))
+        return self._mount_dir_root
 
-    def _prepare_path_registry(self) -> dict[str, GCSMountObject]:
+    @cached_property
+    def path_registry(self) -> dict[str, GCSMountObject]:
+        """Get the path registry."""
         return {
             key: {
-                # NOTE: remote_path has to start from the bucket_name
+                # NOTE: remote_path has to start from the bucket_name but without the gs://
                 # see https://cloud.google.com/batch/docs/create-run-job-storage#gcloud_2:~:text=BUCKET_PATH%3A%20the%20path,the%20subdirectory%20subdirectory.
                 "remote_path": f"{value.bucket}/{value.path}",
                 "mount_point": f"{self.mount_dir_root}/{key}",
@@ -65,7 +61,23 @@ class VepAnnotationPathManager:
             for key, value in self.paths.items()
         }
 
-    def get_mount_config(self) -> list[GCSMountObject]:
+    @cached_property
+    def cache_dir(self) -> str:
+        """Get cache dir."""
+        return self.path_registry["cache"]["mount_point"]
+
+    @cached_property
+    def input_dir(self) -> str:
+        """Get input dir."""
+        return self.path_registry["input"]["mount_point"]
+
+    @cached_property
+    def output_dir(self) -> str:
+        """Get output dir."""
+        return self.path_registry["output"]["mount_point"]
+
+    @cached_property
+    def mount_config(self) -> list[GCSMountObject]:
         """Return the mount configuration.
 
         Returns:
@@ -80,7 +92,6 @@ class VepAnnotateOperator(GoogleCloudBaseOperator):
     This operator performs the VEP annotation of vcf files provided in the `vcf_input_path`.
     The annotation command is custom to OTG needs. The number of batch tasks is inferred by listing the number of
     vcf files introduced in the `vcf_input_path`. Each input file will result in a single vep task.
-
     """
 
     def __init__(
@@ -115,13 +126,18 @@ class VepAnnotateOperator(GoogleCloudBaseOperator):
 
     def execute(self, context) -> dict:
         """Execute the operator."""
-        vcf_files = self._get_vcf_partition_basenames()
         self.pm = VepAnnotationPathManager(
             vcf_input_path=self.vcf_input_path,
             vep_output_path=self.vep_output_path,
             vep_cache_path=self.vep_cache_path,
             mount_dir_root=self.mount_dir_root,
         )
+        hook: CloudBatchHook = CloudBatchHook(
+            self.gcp_conn_id, self.impersonation_chain
+        )
+
+        vcf_files = self._get_vcf_partition_basenames()
+
         environments = [
             {"INPUT_FILE": file, "OUTPUT_FILE": file.replace(".vcf", ".json")}
             for file in vcf_files
@@ -137,12 +153,10 @@ class VepAnnotateOperator(GoogleCloudBaseOperator):
             ),
             task_env=create_task_env(environments),
             policy_specs=self.google_batch["policy_specs"],
-            mounting_points=self.pm.get_mount_config(),
+            mounting_points=self.pm.mount_config,
         )
         self.log.info(job_def)
-        hook: CloudBatchHook = CloudBatchHook(
-            self.gcp_conn_id, self.impersonation_chain
-        )
+
         job = hook.submit_batch_job(
             job_name=self.job_name,
             job=job_def,
@@ -154,16 +168,20 @@ class VepAnnotateOperator(GoogleCloudBaseOperator):
             polling_period_seconds=self.polling_period_seconds,
             timeout=self.timeout_seconds,
         )
-
+        print(
+            hook.list_tasks(
+                region=self.region, job_name=job.name, project_id=self.project_id
+            )
+        )
         return Job.to_dict(completed_job)  # type: ignore
 
     def _get_vcf_partition_basenames(self) -> Set[str]:
         """Based on listed vcf file partition extract their basenames.
 
-        # NOTE: Do not reconstruct full path to the mount, as it will
-        # reduce the payload send to the google batch job. The mount
-        # name is the same at every task command, the basename is
-        # different.
+        NOTE: Do not reconstruct full path to the mount, as it will
+        reduce the payload send to the google batch job. The mount
+        name is the same at every task command, the basename is
+        different.
 
         Returns:
             Set[str]: set of basenames to pass to the task environments.
@@ -171,8 +189,13 @@ class VepAnnotateOperator(GoogleCloudBaseOperator):
         input_path = self.pm.paths["input"]
         c = Client(project=self.project_id)
         b = c.bucket(bucket_name=input_path.bucket)
-        blobs = b.list_blobs(prefix=input_path.path, match_glob="**.vcf")
-        vcf_paths = {Path(blob.name).name for blob in blobs}
+        blobs = b.list_blobs(prefix=input_path.path, match_glob="**.csv")
+        _blobs = []
+        i = 0
+        while i < 1:
+            i += 1
+            _blobs.append(next(blobs))
+        vcf_paths = {Path(blob.name).name for blob in _blobs}
         # FIXME: Apparently this operator logs are not appearing in the airflow UI.
         self.log.info("Found %s vcf files", len(vcf_paths))
         return vcf_paths
@@ -205,134 +228,3 @@ class VepAnnotateOperator(GoogleCloudBaseOperator):
                 --plugin AlphaMissense,file={self.pm.cache_dir}/AlphaMissense_hg38.tsv.gz,transcript_match=1 \
                 --plugin CADD,snv={self.pm.cache_dir}/CADD_GRCh38_whole_genome_SNVs.tsv.gz",
         ]
-
-
-class ConvertVariantsToVcfOperator(BaseOperator):
-    def __init__(
-        self,
-        tsv_files_glob: str,
-        output_path: str,
-        *args,
-        chunk_size: int = 2000,
-        project_id: str = GCP_PROJECT_GENETICS,
-        **kwargs,
-    ) -> None:
-        """Custom operator to merge vcf header based tab separated files found under given pattern.
-
-        This operator merges vcf files by:
-        - "#CHROM": str, '#' as a first column row name after header
-        - "POS": int,
-        - "ID": str,
-        - "REF": str,
-        - "ALT": str,
-        - "QUAL": str,
-        - "FILTER": str,
-        - "INFO": str,
-        header fields, performs deduplication and sorting if requested and
-        partitions the output file by the partitions with `chunk_size` number
-        of variants in each.
-
-        """
-        super().__init__(*args, **kwargs)
-        self.project_id = project_id
-        self.tsv_files_glob = tsv_files_glob
-        self.output_path = output_path
-        self.chunk_size = chunk_size
-        self.sep = "\t"
-        self.output_files: list[str] = []
-
-    def _list_input_files(self) -> Set[str]:
-        gcs_path = GCSPath(self.tsv_files_glob)
-        c = Client(project=self.project_id)
-        b = c.bucket(bucket_name=gcs_path.bucket)
-        blobs = b.list_blobs(
-            prefix=gcs_path.segments["prefix"],
-            match_glob=gcs_path.segments["filename"],
-        )
-        files = {f"gs://{gcs_path.bucket}/{blob.name}" for blob in blobs}
-        self.log.info("Found %s files", files)
-        return files
-
-    def _cleanup_output_dir(self):
-        gcs_path = GCSPath(self.output_path)
-        client_object = Client(project=self.project_id)
-        bucket_object = client_object.bucket(bucket_name=gcs_path.bucket)
-        output_path_blob = Blob(name=gcs_path.path, bucket=bucket_object)
-        if output_path_blob.exists(client=client_object):
-            self.log.warning("Output path %s exists, will attempt to drop it", gcs_path)
-            blobs_to_delete = list(
-                bucket_object.list_blobs(prefix=gcs_path.segments["prefix"])
-            )
-            bucket_object.delete_blobs(blobs=blobs_to_delete)
-        return self
-
-    @property
-    def _vcf_columns(self) -> OrderedDict[str, Type]:
-        return OrderedDict(
-            {
-                "#CHROM": str,
-                "POS": int,
-                "ID": str,
-                "REF": str,
-                "ALT": str,
-                "QUAL": str,
-                "FILTER": str,
-                "INFO": str,
-            }
-        )
-
-    @property
-    def _sort_columns(self) -> list[str]:
-        return ["#CHROM", "POS"]
-
-    @property
-    def _deduplicate_columns(self) -> list[str]:
-        return ["#CHROM", "POS", "REF", "ALT"]
-
-    def _read_input_files(self) -> ConvertVariantsToVcfOperator:
-        raw_dfs = [
-            pd.read_csv(file, sep=self.sep, dtype=self._vcf_columns)
-            for file in self._list_input_files()
-        ]
-        for raw_df in raw_dfs:
-            self.log.info("Size of variants df from source: %s", raw_df.shape[0])
-
-        self.df = (
-            pd.concat(raw_dfs)
-            .drop_duplicates(subset=self._deduplicate_columns)
-            .sort_values(by=self._sort_columns)
-            .reset_index(drop=True)
-        )
-        self.log.info("Size of variants df after merge: %s", self.df.shape[0])
-        return self
-
-    def _write_output_files(self) -> ConvertVariantsToVcfOperator:
-        chunks = 0
-        self.output_files = []
-        self.log.info("")
-        for i in range(0, self.df.shape[0], self.chunk_size):
-            partial_df = self.df[i : i + self.chunk_size]
-            filename = f"{self.output_path}/chunk_{i + 1}-{i + self.chunk_size}.vcf"
-            self.log.info(
-                "Outputting chunk %s with variant range %s-%s to %s",
-                chunks,
-                i,
-                i + self.chunk_size - 1,  # last element is not contained in the list
-                filename,
-            )
-            partial_df.to_csv(filename, index=False, header=True, sep=self.sep)
-            chunks += 1
-            self.output_files.append(filename)
-        expected_chunk_count = len(self.df) // self.chunk_size + 1
-        if not (chunks == expected_chunk_count):
-            raise ValueError("Expected %s, got %s chunks", expected_chunk_count, chunks)
-        return self
-
-    def execute(self, **_) -> list[str]:
-        """Execute the operator."""
-        return (
-            self._cleanup_output_dir()
-            ._read_input_files()
-            ._write_output_files()
-            .output_files
-        )

--- a/src/ot_orchestration/utils/common.py
+++ b/src/ot_orchestration/utils/common.py
@@ -2,9 +2,14 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import pendulum
 
 from ot_orchestration.utils import strhash
+
+if TYPE_CHECKING:
+    from typing import Any, Callable
 
 GENTROPY_VERSION = "0.0.0"
 
@@ -41,19 +46,19 @@ CONFIG_NAME = "ot_config"
 PYTHON_CLI = "cli.py"
 
 # Shared DAG construction parameters.
-shared_dag_args = {
+shared_dag_args: dict[str, Any] = {
     "owner": "Open Targets Data Team",
     "retries": 0,
 }
 
-shared_dag_kwargs = {
+shared_dag_kwargs: dict[str, Any] = {
     "tags": ["genetics_etl", "experimental"],
     "start_date": pendulum.now(tz="Europe/London").subtract(days=1),
     "schedule": "@once",
     "catchup": False,
 }
 
-unified_pipeline_dag_kwargs = {
+unified_pipeline_dag_kwargs: dict[str, Any] = {
     "dag_id": "unified_pipeline",
     "description": "Open Targets unified data generation pipeline",
     "catchup": False,
@@ -63,7 +68,7 @@ unified_pipeline_dag_kwargs = {
     "user_defined_filters": {"strhash": strhash},
 }
 
-shared_labels = lambda project: {
+shared_labels: Callable[[str], dict[str, str]] = lambda project: {
     "team": "open-targets",
     "subteam": "backend",
     "environment": "development" if "dev" in project else "production",

--- a/src/ot_orchestration/utils/dataproc.py
+++ b/src/ot_orchestration/utils/dataproc.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from typing import Any
 
+from airflow.models.baseoperator import BaseOperator
 from airflow.providers.google.cloud.operators.dataproc import (
     ClusterGenerator,
     DataprocCreateClusterOperator,
@@ -38,7 +39,7 @@ def create_cluster(
     cluster_init_script: str | None = None,
     cluster_metadata: dict[str, str] | None = None,
     allow_efm: bool = False,
-    **kwargs,
+    **kwargs: Any,
 ) -> DataprocCreateClusterOperator:
     """Generate an Airflow task to create a Dataproc cluster. Common parameters are reused, and varying parameters can be specified as needed.
 
@@ -262,49 +263,36 @@ def delete_cluster(cluster_name: str) -> DataprocDeleteClusterOperator:
 
 
 def generate_dataproc_task_chain(
-    tasks: list[DataprocSubmitJobOperator],
-    **kwargs,
-) -> Any:
+    tasks: list[BaseOperator],
+    *,
+    create: bool = True,
+    delete: bool = True,
+    **kwargs: Any,
+) -> list[BaseOperator]:
     """For a list of Dataproc tasks, generate a complete chain of tasks.
 
     This function adds create_cluster, install_dependencies to the task that does not have any upstream tasks (first one in the DAG)
     and adds delete_cluster tasks to the task that does not have any downstream tasks (last one in the DAG)
 
     Args:
-        tasks (list[DataprocSubmitJobOperator]): List of tasks to execute.
-        **kwargs (Any): keyword arguments passed to the `create_cluster`.
+        tasks (list[BaseOperator]): List of tasks to execute.
+        create (bool): Indicate if the cluster should be created prior the first dataproc task. Defaults to True.
+        delete (bool): Indicate if the cluster should be deleted after the last dataproc task. Defaults to True.
+        **kwargs (Any): keyword arguments passed to the `create_cluster`. Should always contain the cluster_name.
 
     Returns:
-        list[DataprocSubmitJobOperator]: list of input tasks with muted chain.
+        list[BaseOperator]: list of input tasks with muted chain.
     """
-    create_cluster_task = create_cluster(**kwargs)
-    delete_cluster_task = delete_cluster(kwargs["cluster_name"])
-    for task in tasks:
-        if not task.get_direct_relatives(upstream=True):
-            task.set_upstream(create_cluster_task)
-        if not task.get_direct_relatives(upstream=False):
-            task.set_downstream(delete_cluster_task)
-
-    return tasks
-
-
-def generate_dag(cluster_name: str, tasks: list[DataprocSubmitJobOperator]) -> Any:
-    """For a list of tasks, generate a complete DAG.
-
-    Args:
-        cluster_name (str): Name of the cluster.
-        tasks (list[DataprocSubmitJobOperator]): List of tasks to execute.
-
-    Returns:
-        Any: Airflow DAG.
-    """
-    create_cluster_task = create_cluster(cluster_name)
-    delete_cluster_task = delete_cluster(cluster_name)
-    for task in tasks:
-        if not task.get_direct_relatives(upstream=True):
-            task.set_upstream(create_cluster_task)
-        if not task.get_direct_relatives(upstream=False):
-            task.set_downstream(delete_cluster_task)
+    if create:
+        create_cluster_task = create_cluster(**kwargs)
+        for task in tasks:
+            if not task.get_direct_relatives(upstream=True):
+                task.set_upstream(create_cluster_task)
+    if delete:
+        delete_cluster_task = delete_cluster(kwargs["cluster_name"])
+        for task in tasks:
+            if not task.get_direct_relatives(upstream=False):
+                task.set_downstream(delete_cluster_task)
 
     return tasks
 

--- a/tests/test_vep_path_manager.py
+++ b/tests/test_vep_path_manager.py
@@ -1,0 +1,107 @@
+"""Test vep manager."""
+
+from __future__ import annotations
+
+import pytest
+from ot_orchestration.operators.batch.vep import VepAnnotationPathManager
+
+
+class TestVepAnnotationPathManger:
+    @pytest.fixture(autouse=True)
+    def _setup(self) -> TestVepAnnotationPathManger:
+        """Setup vep annotation paths."""
+        vep_cache_path = "gs://bucket/cache"
+        mount_dir_root = "/root"
+        vcf_input_path = "gs://bucket/vcf"
+        vep_output_path = "gs://bucket/output"
+
+        self.vp = VepAnnotationPathManager(
+            vcf_input_path=vcf_input_path,
+            vep_output_path=vep_output_path,
+            vep_cache_path=vep_cache_path,
+            mount_dir_root=mount_dir_root,
+        )
+        return self
+
+    def test_invalid_mount_dir(self) -> None:
+        """Mount dir must be an absolute path."""
+        vp = VepAnnotationPathManager(
+            "vcf_input_path",
+            "vep_output_path",
+            "vep_cache_path",
+            "root",
+        )
+        with pytest.raises(ValueError) as e:
+            vp.mount_dir_root
+            assert e.value.args[0] == "Mount dir has to be an absolute path."
+
+    def test_mount_dir_ends_with_slash(self) -> None:
+        """Assert that mount dir trailing slash will be dropped."""
+        vp = VepAnnotationPathManager(
+            "vcf_input_path",
+            "vep_output_path",
+            "vep_cache_path",
+            "/root//",
+        )
+
+        assert vp.mount_dir_root == "/root"
+
+    def test_not_gcs_paths(self) -> None:
+        """Mount dir must be an absolute path."""
+        vp = VepAnnotationPathManager(
+            "vcf_input_path",
+            "vep_output_path",
+            "vep_cache_path",
+            "/root",
+        )
+        with pytest.raises(ValueError) as e:
+            vp.path_registry
+            assert "Invalid GCS path" in e.value.args[0]
+
+    def test_mount_dir_property(self) -> None:
+        """Test correct paths provided."""
+        assert self.vp.mount_dir_root == "/root"
+
+    def test_cache_dir_property(self) -> None:
+        """Test if the `cache_dir property exists and returns correct value."""
+        assert self.vp.cache_dir == "/root/cache"
+
+    def test_output_dir_property(self) -> None:
+        """Test if the `output_dir` property exists and returns correct value."""
+        assert self.vp.output_dir == "/root/output"
+
+    def test_input_dir_property(self) -> None:
+        """Test if the `input_dir` property exists and returns correct value."""
+        assert self.vp.input_dir == "/root/input"
+
+    def test_path_registry_property(self) -> None:
+        """Test if the `path_registry` property returns correct value."""
+        assert self.vp.path_registry["input"] == {
+            "remote_path": "bucket/vcf",
+            "mount_point": "/root/input",
+        }
+        assert self.vp.path_registry["output"] == {
+            "remote_path": "bucket/output",
+            "mount_point": "/root/output",
+        }
+        assert self.vp.path_registry["cache"] == {
+            "remote_path": "bucket/cache",
+            "mount_point": "/root/cache",
+        }
+
+    def test_mount_config(self) -> None:
+        """Test if the `mount_config` property returns correct value."""
+        assert self.vp.mount_config == [
+            {
+                "remote_path": "bucket/vcf",
+                "mount_point": "/root/input",
+            },
+            {
+                "remote_path": "bucket/output",
+                "mount_point": "/root/output",
+            },
+            {
+                "remote_path": "bucket/cache",
+                "mount_point": "/root/cache",
+            },
+        ]


### PR DESCRIPTION
# Context

This PR is a part of effort to reduce the complexity of genetics_etl dag. Due to the fact that we want to submerge the genetics_etl to the platform etl dag, we need to simplify the VariantAnnotation task group.

## Implementations

This PR changes the logic of `variant_annotation` node in the genetics etl dag.

- [x] Change the  `variant_to_vcf` dag node implementation:
  Node was previously running as a google batch job with  4  `variant_to_vcf` gentropy steps (one per each datasource
      * uniprot
      * eva
      * credible sets
      * pharmgkb)  
   that was followed by `local` (run with python operator - `ConvertVariantsToVcfOperator`) partitioning of the vcf based data sources.
   With refactoring of `variant_to_vcf` step implemented in  https://github.com/opentargets/gentropy/pull/891 the step can now take **n datasources** that are running in sequence and produce a single partitioned dataset. This allows for the:
* removal of google batch task for variant to vcf convertion
* removal of the local partitioning of vcf data sources
* drop pandas as dependency (no longer needed, as `ConvertVariantsToVcfOperator` is no longer there
* removal of the entire TaskGroup and adding a single dataproc node for variant annotation instead
- [x] Refactoring of the VepPathManager and addition of the tests
- [x] Preparation for freeze_6
- [x] Handling issue with spark not able to write csv with `#` in the column name without quoting the column name - issue comes when ` variant_to_vcf` wants to save the `#CHROM` column as `"#CHROM"` creating the following issue in VEP:
```bash
WARNING: line 1 skipped ("#CHROM" POS ID REF ALT QUAL FILTER INFO): Invalid start 'POS' or end '2' coordinate
```



> [!NOTE]
> This PR requires the https://github.com/opentargets/gentropy/pull/896 to be merged, as the `#CHROM` issue was resolved by dynamically change the `CHROM` to `#CHROM`, so the `variant_to_vcf` step should drop the hash.


 