### PR TITLE
chore: configure hf repo in l2g predicting step

### DIFF
--- a/src/ot_orchestration/dags/config/genetics_etl.yaml
+++ b/src/ot_orchestration/dags/config/genetics_etl.yaml
@@ -207,6 +207,7 @@ nodes:
       step.feature_matrix_path: gs://ot_orchestration/releases/24.10_freeze6/locus_to_gene_feature_matrix
       step.credible_set_path: gs://ot_orchestration/releases/24.10_freeze6/credible_set
       step.download_from_hub: true
+      step.hf_hub_repo_id: opentargets/locus_to_gene
 
   - id: l2g_evidence
     prerequisites:


### PR DESCRIPTION
The default behaviour is to pull the data from `open_targets/locus_to_gene`. 
We want to add the parameter to the dag so that we test other experimental models.

After a discussion with @addramir, we want to load in the Back end the predictions based on [this experimental model ](https://github.com/opentargets/issues/issues/3526#issuecomment-2457463182) that is hosted in a diff repo `opentargets/locus_to_gene_egl`