### PR TITLE
feat: freeze 6 improvements

### DIFF
--- a/src/ot_orchestration/dags/config/genetics_etl.yaml
+++ b/src/ot_orchestration/dags/config/genetics_etl.yaml
@@ -208,7 +208,7 @@ nodes:
       step.feature_matrix_path: gs://ot_orchestration/releases/24.10_freeze6/locus_to_gene_feature_matrix
       step.credible_set_path: gs://ot_orchestration/releases/24.10_freeze6/credible_set
       step.download_from_hub: true
-      step.hf_hub_repo_id: opentargets/locus_to_gene
+      step.hf_hub_repo_id: opentargets/locus_to_gene_egl
       step.session.write_mode: overwrite
 
   - id: l2g_evidence

--- a/src/ot_orchestration/dags/config/genetics_etl.yaml
+++ b/src/ot_orchestration/dags/config/genetics_etl.yaml
@@ -163,40 +163,40 @@ nodes:
   #     step.colocalisation_method: Coloc
   #     +step.colocalisation_method_params: "{priorc1: 1e-4, priorc2: 1e-4, priorc12: 1e-5}"
 
-  - id: l2g_feature_matrix
-    prerequisites:
-      - colocalisation_coloc
-      - colocalisation_ecaviar
-      - variant_index
-    params:
-      step: locus_to_gene_feature_matrix
-      step.credible_set_path: gs://ot_orchestration/releases/24.10_freeze6/credible_set
-      step.variant_index_path: gs://ot_orchestration/releases/24.10_freeze6/variant_index
-      step.colocalisation_path: gs://ot_orchestration/releases/24.10_freeze6/colocalisation
-      step.study_index_path: gs://ot_orchestration/releases/24.10_freeze6/study_index
-      step.gene_index_path: gs://ot_orchestration/releases/24.10_freeze6/gene_index
-      step.feature_matrix_path: gs://ot_orchestration/releases/24.10_freeze6/locus_to_gene_feature_matrix
-      +step.session.extended_spark_conf: "{spark.sql.autoBroadcastJoinThreshold:'-1'}"
-      step.session.write_mode: overwrite
-
-  # - id: l2g_train
+  # - id: l2g_feature_matrix
   #   prerequisites:
-  #     - l2g_feature_matrix
+  #     - colocalisation_coloc
+  #     - colocalisation_ecaviar
+  #     - variant_index
   #   params:
-  #     step: locus_to_gene
-  #     step.run_mode: train
-  #     step.wandb_run_name: 24.10_freeze6
-  #     step.hf_hub_repo_id: opentargets/locus_to_gene
-  #     step.model_path: gs://ot_orchestration/releases/24.10_freeze6/locus_to_gene_model/classifier.skops
+  #     step: locus_to_gene_feature_matrix
   #     step.credible_set_path: gs://ot_orchestration/releases/24.10_freeze6/credible_set
   #     step.variant_index_path: gs://ot_orchestration/releases/24.10_freeze6/variant_index
+  #     step.colocalisation_path: gs://ot_orchestration/releases/24.10_freeze6/colocalisation
+  #     step.study_index_path: gs://ot_orchestration/releases/24.10_freeze6/study_index
+  #     step.gene_index_path: gs://ot_orchestration/releases/24.10_freeze6/gene_index
   #     step.feature_matrix_path: gs://ot_orchestration/releases/24.10_freeze6/locus_to_gene_feature_matrix
-  #     step.gold_standard_curation_path: gs://genetics_etl_python_playground/input/l2g/gold_standard/curation.json
-  #     step.gene_interactions_path: gs://genetics_etl_python_playground/static_assets/interaction # OTP 23.12 data
-  #     step.hyperparameters.n_estimators: 100
-  #     step.hyperparameters.max_depth: 5
-  #     step.hyperparameters.loss: log_loss
-  #     +step.session.extended_spark_conf: "{spark.kryoserializer.buffer.max:500m, spark.sql.autoBroadcastJoinThreshold:'-1'}"
+  #     +step.session.extended_spark_conf: "{spark.sql.autoBroadcastJoinThreshold:'-1'}"
+  #     step.session.write_mode: overwrite
+
+  - id: l2g_train
+    prerequisites:
+      - l2g_feature_matrix
+    params:
+      step: locus_to_gene
+      step.run_mode: train
+      step.wandb_run_name: 24.10_freeze6
+      step.hf_hub_repo_id: opentargets/locus_to_gene
+      step.model_path: gs://ot_orchestration/releases/24.10_freeze6/locus_to_gene_model/classifier.skops
+      step.credible_set_path: gs://ot_orchestration/releases/24.10_freeze6/credible_set
+      step.variant_index_path: gs://ot_orchestration/releases/24.10_freeze6/variant_index
+      step.feature_matrix_path: gs://ot_orchestration/releases/24.10_freeze6/locus_to_gene_feature_matrix
+      step.gold_standard_curation_path: gs://genetics_etl_python_playground/input/l2g/gold_standard/curation.json
+      step.gene_interactions_path: gs://genetics_etl_python_playground/static_assets/interaction # OTP 23.12 data
+      step.hyperparameters.n_estimators: 100
+      step.hyperparameters.max_depth: 5
+      step.hyperparameters.loss: log_loss
+      +step.session.extended_spark_conf: "{spark.kryoserializer.buffer.max:500m, spark.sql.autoBroadcastJoinThreshold:'-1'}"
 
   - id: l2g_predict
     prerequisites:
@@ -208,7 +208,7 @@ nodes:
       step.feature_matrix_path: gs://ot_orchestration/releases/24.10_freeze6/locus_to_gene_feature_matrix
       step.credible_set_path: gs://ot_orchestration/releases/24.10_freeze6/credible_set
       step.download_from_hub: true
-      step.hf_hub_repo_id: opentargets/locus_to_gene_egl
+      step.hf_hub_repo_id: opentargets/locus_to_gene
       step.session.write_mode: overwrite
 
   - id: l2g_evidence
@@ -229,6 +229,42 @@ nodes:
       step.disease_index_path: gs://open-targets-pre-data-releases/24.06/output/etl/parquet/diseases
       step.direct_associations_output_path: gs://ot_orchestration/releases/24.10_freeze6/locus_to_gene_associations/direct_associations
       step.indirect_associations_output_path: gs://ot_orchestration/releases/24.10_freeze6/locus_to_gene_associations/indirect_associations
+      step.session.spark_uri: yarn
+    prerequisites:
+      - l2g_evidence
+
+# TO DROP
+  - id: l2g_predict_egl
+    prerequisites:
+      - l2g_train
+    params:
+      step: locus_to_gene
+      step.run_mode: predict
+      step.predictions_path: gs://ot_orchestration/model_benchmarks/releases/24.10_freeze6/locus_to_gene_predictions_egl
+      step.feature_matrix_path: gs://ot_orchestration/releases/24.10_freeze6/locus_to_gene_feature_matrix
+      step.credible_set_path: gs://ot_orchestration/releases/24.10_freeze6/credible_set
+      step.download_from_hub: true
+      step.hf_hub_repo_id: opentargets/locus_to_gene_egl
+      step.session.write_mode: overwrite
+
+  - id: l2g_evidence_egl
+    prerequisites:
+      - l2g_predict
+    params:
+      step: locus_to_gene_evidence
+      step.evidence_output_path: gs://ot_orchestration/model_benchmarks/releases/24.10_freeze6/locus_to_gene_evidence_egl
+      step.locus_to_gene_predictions_path: gs://ot_orchestration/model_benchmarks/releases/24.10_freeze6/locus_to_gene_predictions_egl
+      step.credible_set_path: gs://ot_orchestration/releases/24.10_freeze6/credible_set
+      step.study_index_path: gs://ot_orchestration/releases/24.10_freeze6/study_index
+      step.locus_to_gene_threshold: 0.05
+
+  - id: l2g_associations_egl
+    params:
+      step: locus_to_gene_associations
+      step.evidence_input_path: gs://ot_orchestration/model_benchmarks/releases/24.10_freeze6/locus_to_gene_evidence_egl
+      step.disease_index_path: gs://open-targets-pre-data-releases/24.06/output/etl/parquet/diseases
+      step.direct_associations_output_path: gs://ot_orchestration/model_benchmarks/releases/24.10_freeze6/locus_to_gene_associations_egl/direct_associations
+      step.indirect_associations_output_path: gs://ot_orchestration/model_benchmarks/releases/24.10_freeze6/locus_to_gene_associations_egl/indirect_associations
       step.session.spark_uri: yarn
     prerequisites:
       - l2g_evidence

--- a/src/ot_orchestration/dags/config/genetics_etl.yaml
+++ b/src/ot_orchestration/dags/config/genetics_etl.yaml
@@ -12,156 +12,156 @@ dataproc:
 
 nodes:
 
-  - id: gene_index
-    kind: Task
-    prerequisites: []
-    params:
-      step: gene_index
-      step.target_path: gs://genetics_etl_python_playground/static_assets/targets # OTP 23.12 data
-      step.gene_index_path: gs://ot_orchestration/releases/24.10_freeze6/gene_index
+  # - id: gene_index
+  #   kind: Task
+  #   prerequisites: []
+  #   params:
+  #     step: gene_index
+  #     step.target_path: gs://genetics_etl_python_playground/static_assets/targets # OTP 23.12 data
+  #     step.gene_index_path: gs://ot_orchestration/releases/24.10_freeze6/gene_index
 
-  - id: biosample_index
-    kind: Task
-    prerequisites: []
-    params:
-      step: biosample_index
-      step.cell_ontology_input_path: gs://open-targets-pre-data-releases/24.06dev-test/input/biosamples/cl.json
-      step.uberon_input_path: gs://open-targets-pre-data-releases/24.06dev-test/input/biosamples/uberon.json
-      step.efo_input_path: gs://open-targets-pre-data-releases/24.06dev-test/input/biosamples/efo.json
-      step.biosample_index_path: gs://ot_orchestration/releases/24.10_freeze6/biosample_index
+  # - id: biosample_index
+  #   kind: Task
+  #   prerequisites: []
+  #   params:
+  #     step: biosample_index
+  #     step.cell_ontology_input_path: gs://open-targets-pre-data-releases/24.06dev-test/input/biosamples/cl.json
+  #     step.uberon_input_path: gs://open-targets-pre-data-releases/24.06dev-test/input/biosamples/uberon.json
+  #     step.efo_input_path: gs://open-targets-pre-data-releases/24.06dev-test/input/biosamples/efo.json
+  #     step.biosample_index_path: gs://ot_orchestration/releases/24.10_freeze6/biosample_index
 
-  - id: study_validation
-    kind: Task
-    prerequisites:
-      - biosample_index
-      - gene_index
-    params:
-      step: study_validation
-      step.study_index_path:
-        - gs://gwas_catalog_top_hits/study_index
-        - gs://gwas_catalog_sumstats_susie/study_index
-        - gs://gwas_catalog_sumstats_pics/study_index
-        - gs://eqtl_catalogue_data/study_index
-        - gs://ukb_ppp_eur_data/study_index
-        - gs://finngen_data/r11/study_index
-      step.target_index_path: gs://ot_orchestration/releases/24.10_freeze6/gene_index
-      step.disease_index_path: gs://open-targets-pre-data-releases/24.06/output/etl/parquet/diseases
-      step.valid_study_index_path: gs://ot_orchestration/releases/24.10_freeze6/study_index
-      step.invalid_study_index_path: gs://ot_orchestration/releases/24.10_freeze6/invalid_study_index
-      step.biosample_index_path: gs://ot_orchestration/releases/24.10_freeze6/biosample_index
-      step.invalid_qc_reasons:
-        - UNRESOLVED_TARGET
-        - UNRESOLVED_DISEASE
-        - UNKNOWN_STUDY_TYPE
-        - DUPLICATED_STUDY
-        - UNKNOWN_BIOSAMPLE
-        - FAILED_MEAN_BETA_CHECK
-        - FAILED_PZ_CHECK
-        - FAILED_GC_LAMBDA_CHECK
-        - NO_OT_CURATION
+  # - id: study_validation
+  #   kind: Task
+  #   prerequisites:
+  #     - biosample_index
+  #     - gene_index
+  #   params:
+  #     step: study_validation
+  #     step.study_index_path:
+  #       - gs://gwas_catalog_top_hits/study_index
+  #       - gs://gwas_catalog_sumstats_susie/study_index
+  #       - gs://gwas_catalog_sumstats_pics/study_index
+  #       - gs://eqtl_catalogue_data/study_index
+  #       - gs://ukb_ppp_eur_data/study_index
+  #       - gs://finngen_data/r11/study_index
+  #     step.target_index_path: gs://ot_orchestration/releases/24.10_freeze6/gene_index
+  #     step.disease_index_path: gs://open-targets-pre-data-releases/24.06/output/etl/parquet/diseases
+  #     step.valid_study_index_path: gs://ot_orchestration/releases/24.10_freeze6/study_index
+  #     step.invalid_study_index_path: gs://ot_orchestration/releases/24.10_freeze6/invalid_study_index
+  #     step.biosample_index_path: gs://ot_orchestration/releases/24.10_freeze6/biosample_index
+  #     step.invalid_qc_reasons:
+  #       - UNRESOLVED_TARGET
+  #       - UNRESOLVED_DISEASE
+  #       - UNKNOWN_STUDY_TYPE
+  #       - DUPLICATED_STUDY
+  #       - UNKNOWN_BIOSAMPLE
+  #       - FAILED_MEAN_BETA_CHECK
+  #       - FAILED_PZ_CHECK
+  #       - FAILED_GC_LAMBDA_CHECK
+  #       - NO_OT_CURATION
 
-  - id: credible_set_validation
-    kind: Task
-    prerequisites:
-      - study_validation
-    params:
-      step: credible_set_validation
-      step.study_index_path: gs://ot_orchestration/releases/24.10_freeze6/study_index
-      step.study_locus_path:
-        - gs://gwas_catalog_top_hits/credible_sets/
-        - gs://gwas_catalog_sumstats_pics/credible_sets/
-        - gs://gwas_catalog_sumstats_susie/credible_set_clean/
-        - gs://eqtl_catalogue_data/credible_set_datasets/eqtl_catalogue_susie/
-        - gs://ukb_ppp_eur_data/credible_set_clean/
-        - gs://finngen_data/r11/credible_set_datasets/susie/
-      step.valid_study_locus_path: gs://ot_orchestration/releases/24.10_freeze6/credible_set
-      step.invalid_study_locus_path: gs://ot_orchestration/releases/24.10_freeze6/invalid_credible_set
-      step.invalid_qc_reasons:
-        - DUPLICATED_STUDYLOCUS_ID
-        - AMBIGUOUS_STUDY
-        - MISSING_STUDY
-        - NO_GENOMIC_LOCATION_FLAG
-        - COMPOSITE_FLAG
-        - INCONSISTENCY_FLAG
-        - PALINDROMIC_ALLELE_FLAG
-        - SUBSIGNIFICANT_FLAG
-        - LD_CLUMPED
-        - IN_MHC
-        - REDUNDANT_PICS_TOP_HIT
-        - EXPLAINED_BY_SUSIE
-        - WINDOW_CLUMPED
-        - NON_MAPPED_VARIANT_FLAG
-        - INVALID_VARIANT_IDENTIFIER
-        - INVALID_CHROMOSOME
-        - TOP_HIT_AND_SUMMARY_STATS
+  # - id: credible_set_validation
+  #   kind: Task
+  #   prerequisites:
+  #     - study_validation
+  #   params:
+  #     step: credible_set_validation
+  #     step.study_index_path: gs://ot_orchestration/releases/24.10_freeze6/study_index
+  #     step.study_locus_path:
+  #       - gs://gwas_catalog_top_hits/credible_sets/
+  #       - gs://gwas_catalog_sumstats_pics/credible_sets/
+  #       - gs://gwas_catalog_sumstats_susie/credible_set_clean/
+  #       - gs://eqtl_catalogue_data/credible_set_datasets/eqtl_catalogue_susie/
+  #       - gs://ukb_ppp_eur_data/credible_set_clean/
+  #       - gs://finngen_data/r11/credible_set_datasets/susie/
+  #     step.valid_study_locus_path: gs://ot_orchestration/releases/24.10_freeze6/credible_set
+  #     step.invalid_study_locus_path: gs://ot_orchestration/releases/24.10_freeze6/invalid_credible_set
+  #     step.invalid_qc_reasons:
+  #       - DUPLICATED_STUDYLOCUS_ID
+  #       - AMBIGUOUS_STUDY
+  #       - MISSING_STUDY
+  #       - NO_GENOMIC_LOCATION_FLAG
+  #       - COMPOSITE_FLAG
+  #       - INCONSISTENCY_FLAG
+  #       - PALINDROMIC_ALLELE_FLAG
+  #       - SUBSIGNIFICANT_FLAG
+  #       - LD_CLUMPED
+  #       - IN_MHC
+  #       - REDUNDANT_PICS_TOP_HIT
+  #       - EXPLAINED_BY_SUSIE
+  #       - WINDOW_CLUMPED
+  #       - NON_MAPPED_VARIANT_FLAG
+  #       - INVALID_VARIANT_IDENTIFIER
+  #       - INVALID_CHROMOSOME
+  #       - TOP_HIT_AND_SUMMARY_STATS
 
-  - id: convert_variants_to_vcf
-    kind: Task
-    prerequisites:
-      - credible_set_validation
-    params:
-      step: variant_to_vcf
-      step.source_paths:
-        - gs://open-targets-pre-data-releases/24.09/input/evidence-files/uniprot.json.gz
-        - gs://open-targets-pre-data-releases/24.09/input/evidence-files/eva.json.gz
-        - gs://open-targets-pre-data-releases/24.09/input/pharmacogenomics-inputs/pharmacogenomics.json.gz
-        - gs://ot_orchestration/releases/24.10_freeze6/credible_set
-      step.source_formats:
-        - json
-        - json
-        - json
-        - parquet
-      step.output_path: gs://ot_orchestration/releases/24.10_freeze6/variants/partitioned_variants
-      step.partition_size: 2_000 # approximate num of variants per partition!
+  # - id: convert_variants_to_vcf
+  #   kind: Task
+  #   prerequisites:
+  #     - credible_set_validation
+  #   params:
+  #     step: variant_to_vcf
+  #     step.source_paths:
+  #       - gs://open-targets-pre-data-releases/24.09/input/evidence-files/uniprot.json.gz
+  #       - gs://open-targets-pre-data-releases/24.09/input/evidence-files/eva.json.gz
+  #       - gs://open-targets-pre-data-releases/24.09/input/pharmacogenomics-inputs/pharmacogenomics.json.gz
+  #       - gs://ot_orchestration/releases/24.10_freeze6/credible_set
+  #     step.source_formats:
+  #       - json
+  #       - json
+  #       - json
+  #       - parquet
+  #     step.output_path: gs://ot_orchestration/releases/24.10_freeze6/variants/partitioned_variants
+  #     step.partition_size: 2_000 # approximate num of variants per partition!
 
-  - id: variant_annotation
-    kind: Task
-    prerequisites:
-      - convert_variants_to_vcf
-    google_batch:
-      entrypoint: /bin/sh
-      image: europe-west1-docker.pkg.dev/open-targets-genetics-dev/gentropy-app/custom_ensembl_vep:dev
-      resource_specs:
-        cpu_milli: 2000
-        memory_mib: 2000
-        boot_disk_mib: 10000
-      task_specs:
-        max_retry_count: 1
-        max_run_duration: "2h"
-      policy_specs:
-        machine_type: n1-standard-4
-    params:
-      vep_cache_path: gs://genetics_etl_python_playground/vep/cache
-      vcf_input_path: gs://ot_orchestration/releases/24.10_freeze6/variants/partitioned_variants
-      vep_output_path: gs://ot_orchestration/releases/24.10_freeze6/variants/annotated_variants
+  # - id: variant_annotation
+  #   kind: Task
+  #   prerequisites:
+  #     - convert_variants_to_vcf
+  #   google_batch:
+  #     entrypoint: /bin/sh
+  #     image: europe-west1-docker.pkg.dev/open-targets-genetics-dev/gentropy-app/custom_ensembl_vep:dev
+  #     resource_specs:
+  #       cpu_milli: 2000
+  #       memory_mib: 2000
+  #       boot_disk_mib: 10000
+  #     task_specs:
+  #       max_retry_count: 1
+  #       max_run_duration: "2h"
+  #     policy_specs:
+  #       machine_type: n1-standard-4
+  #   params:
+  #     vep_cache_path: gs://genetics_etl_python_playground/vep/cache
+  #     vcf_input_path: gs://ot_orchestration/releases/24.10_freeze6/variants/partitioned_variants
+  #     vep_output_path: gs://ot_orchestration/releases/24.10_freeze6/variants/annotated_variants
 
-  - id: variant_index
-    prerequisites:
-      - variant_annotation
-    params:
-      step: variant_index
-      step.vep_output_json_path: gs://ot_orchestration/releases/24.10_freeze6/variants/annotated_variants
-      step.gnomad_variant_annotations_path: gs://genetics_etl_python_playground/static_assets/gnomad_variants
-      step.variant_index_path: gs://ot_orchestration/releases/24.10_freeze6/variant_index
+  # - id: variant_index
+  #   prerequisites:
+  #     - variant_annotation
+  #   params:
+  #     step: variant_index
+  #     step.vep_output_json_path: gs://ot_orchestration/releases/24.10_freeze6/variants/annotated_variants
+  #     step.gnomad_variant_annotations_path: gs://genetics_etl_python_playground/static_assets/gnomad_variants
+  #     step.variant_index_path: gs://ot_orchestration/releases/24.10_freeze6/variant_index
 
-  - id: colocalisation_ecaviar
-    prerequisites:
-      - credible_set_validation
-    params:
-      step: colocalisation
-      step.credible_set_path: gs://ot_orchestration/releases/24.10_freeze6/credible_set
-      step.coloc_path: gs://ot_orchestration/releases/24.10_freeze6/colocalisation
-      step.colocalisation_method: ECaviar
+  # - id: colocalisation_ecaviar
+  #   prerequisites:
+  #     - credible_set_validation
+  #   params:
+  #     step: colocalisation
+  #     step.credible_set_path: gs://ot_orchestration/releases/24.10_freeze6/credible_set
+  #     step.coloc_path: gs://ot_orchestration/releases/24.10_freeze6/colocalisation
+  #     step.colocalisation_method: ECaviar
 
-  - id: colocalisation_coloc
-    prerequisites:
-      - colocalisation_ecaviar
-    params:
-      step: colocalisation
-      step.credible_set_path: gs://ot_orchestration/releases/24.10_freeze6/credible_set
-      step.coloc_path: gs://ot_orchestration/releases/24.10_freeze6/colocalisation/
-      step.colocalisation_method: Coloc
-      +step.colocalisation_method_params: "{priorc1: 1e-4, priorc2: 1e-4, priorc12: 1e-5}"
+  # - id: colocalisation_coloc
+  #   prerequisites:
+  #     - colocalisation_ecaviar
+  #   params:
+  #     step: colocalisation
+  #     step.credible_set_path: gs://ot_orchestration/releases/24.10_freeze6/credible_set
+  #     step.coloc_path: gs://ot_orchestration/releases/24.10_freeze6/colocalisation/
+  #     step.colocalisation_method: Coloc
+  #     +step.colocalisation_method_params: "{priorc1: 1e-4, priorc2: 1e-4, priorc12: 1e-5}"
 
   - id: l2g_feature_matrix
     prerequisites:
@@ -177,25 +177,26 @@ nodes:
       step.gene_index_path: gs://ot_orchestration/releases/24.10_freeze6/gene_index
       step.feature_matrix_path: gs://ot_orchestration/releases/24.10_freeze6/locus_to_gene_feature_matrix
       +step.session.extended_spark_conf: "{spark.sql.autoBroadcastJoinThreshold:'-1'}"
+      step.session.write_mode: overwrite
 
-  - id: l2g_train
-    prerequisites:
-      - l2g_feature_matrix
-    params:
-      step: locus_to_gene
-      step.run_mode: train
-      step.wandb_run_name: 24.10_freeze6
-      step.hf_hub_repo_id: opentargets/locus_to_gene
-      step.model_path: gs://ot_orchestration/releases/24.10_freeze6/locus_to_gene_model/classifier.skops
-      step.credible_set_path: gs://ot_orchestration/releases/24.10_freeze6/credible_set
-      step.variant_index_path: gs://ot_orchestration/releases/24.10_freeze6/variant_index
-      step.feature_matrix_path: gs://ot_orchestration/releases/24.10_freeze6/locus_to_gene_feature_matrix
-      step.gold_standard_curation_path: gs://genetics_etl_python_playground/input/l2g/gold_standard/curation.json
-      step.gene_interactions_path: gs://genetics_etl_python_playground/static_assets/interaction # OTP 23.12 data
-      step.hyperparameters.n_estimators: 100
-      step.hyperparameters.max_depth: 5
-      step.hyperparameters.loss: log_loss
-      +step.session.extended_spark_conf: "{spark.kryoserializer.buffer.max:500m, spark.sql.autoBroadcastJoinThreshold:'-1'}"
+  # - id: l2g_train
+  #   prerequisites:
+  #     - l2g_feature_matrix
+  #   params:
+  #     step: locus_to_gene
+  #     step.run_mode: train
+  #     step.wandb_run_name: 24.10_freeze6
+  #     step.hf_hub_repo_id: opentargets/locus_to_gene
+  #     step.model_path: gs://ot_orchestration/releases/24.10_freeze6/locus_to_gene_model/classifier.skops
+  #     step.credible_set_path: gs://ot_orchestration/releases/24.10_freeze6/credible_set
+  #     step.variant_index_path: gs://ot_orchestration/releases/24.10_freeze6/variant_index
+  #     step.feature_matrix_path: gs://ot_orchestration/releases/24.10_freeze6/locus_to_gene_feature_matrix
+  #     step.gold_standard_curation_path: gs://genetics_etl_python_playground/input/l2g/gold_standard/curation.json
+  #     step.gene_interactions_path: gs://genetics_etl_python_playground/static_assets/interaction # OTP 23.12 data
+  #     step.hyperparameters.n_estimators: 100
+  #     step.hyperparameters.max_depth: 5
+  #     step.hyperparameters.loss: log_loss
+  #     +step.session.extended_spark_conf: "{spark.kryoserializer.buffer.max:500m, spark.sql.autoBroadcastJoinThreshold:'-1'}"
 
   - id: l2g_predict
     prerequisites:
@@ -208,6 +209,7 @@ nodes:
       step.credible_set_path: gs://ot_orchestration/releases/24.10_freeze6/credible_set
       step.download_from_hub: true
       step.hf_hub_repo_id: opentargets/locus_to_gene
+      step.session.write_mode: overwrite
 
   - id: l2g_evidence
     prerequisites:

--- a/src/ot_orchestration/dags/config/genetics_etl.yaml
+++ b/src/ot_orchestration/dags/config/genetics_etl.yaml
@@ -12,172 +12,172 @@ dataproc:
 
 nodes:
 
-  # - id: gene_index
-  #   kind: Task
-  #   prerequisites: []
-  #   params:
-  #     step: gene_index
-  #     step.target_path: gs://genetics_etl_python_playground/static_assets/targets # OTP 23.12 data
-  #     step.gene_index_path: gs://ot_orchestration/releases/24.10_freeze6/gene_index
+  - id: gene_index
+    kind: Task
+    prerequisites: []
+    params:
+      step: gene_index
+      step.target_path: gs://genetics_etl_python_playground/static_assets/targets # OTP 23.12 data
+      step.gene_index_path: gs://ot_orchestration/releases/24.10_freeze6/gene_index
 
-  # - id: biosample_index
-  #   kind: Task
-  #   prerequisites: []
-  #   params:
-  #     step: biosample_index
-  #     step.cell_ontology_input_path: gs://open-targets-pre-data-releases/24.06dev-test/input/biosamples/cl.json
-  #     step.uberon_input_path: gs://open-targets-pre-data-releases/24.06dev-test/input/biosamples/uberon.json
-  #     step.efo_input_path: gs://open-targets-pre-data-releases/24.06dev-test/input/biosamples/efo.json
-  #     step.biosample_index_path: gs://ot_orchestration/releases/24.10_freeze6/biosample_index
+  - id: biosample_index
+    kind: Task
+    prerequisites: []
+    params:
+      step: biosample_index
+      step.cell_ontology_input_path: gs://open-targets-pre-data-releases/24.06dev-test/input/biosamples/cl.json
+      step.uberon_input_path: gs://open-targets-pre-data-releases/24.06dev-test/input/biosamples/uberon.json
+      step.efo_input_path: gs://open-targets-pre-data-releases/24.06dev-test/input/biosamples/efo.json
+      step.biosample_index_path: gs://ot_orchestration/releases/24.10_freeze6/biosample_index
 
-  # - id: study_validation
-  #   kind: Task
-  #   prerequisites:
-  #     - biosample_index
-  #     - gene_index
-  #   params:
-  #     step: study_validation
-  #     step.study_index_path:
-  #       - gs://gwas_catalog_top_hits/study_index
-  #       - gs://gwas_catalog_sumstats_susie/study_index
-  #       - gs://gwas_catalog_sumstats_pics/study_index
-  #       - gs://eqtl_catalogue_data/study_index
-  #       - gs://ukb_ppp_eur_data/study_index
-  #       - gs://finngen_data/r11/study_index
-  #     step.target_index_path: gs://ot_orchestration/releases/24.10_freeze6/gene_index
-  #     step.disease_index_path: gs://open-targets-pre-data-releases/24.06/output/etl/parquet/diseases
-  #     step.valid_study_index_path: gs://ot_orchestration/releases/24.10_freeze6/study_index
-  #     step.invalid_study_index_path: gs://ot_orchestration/releases/24.10_freeze6/invalid_study_index
-  #     step.biosample_index_path: gs://ot_orchestration/releases/24.10_freeze6/biosample_index
-  #     step.invalid_qc_reasons:
-  #       - UNRESOLVED_TARGET
-  #       - UNRESOLVED_DISEASE
-  #       - UNKNOWN_STUDY_TYPE
-  #       - DUPLICATED_STUDY
-  #       - UNKNOWN_BIOSAMPLE
-  #       - FAILED_MEAN_BETA_CHECK
-  #       - FAILED_PZ_CHECK
-  #       - FAILED_GC_LAMBDA_CHECK
-  #       - NO_OT_CURATION
+  - id: study_validation
+    kind: Task
+    prerequisites:
+      - biosample_index
+      - gene_index
+    params:
+      step: study_validation
+      step.study_index_path:
+        - gs://gwas_catalog_top_hits/study_index
+        - gs://gwas_catalog_sumstats_susie/study_index
+        - gs://gwas_catalog_sumstats_pics/study_index
+        - gs://eqtl_catalogue_data/study_index
+        - gs://ukb_ppp_eur_data/study_index
+        - gs://finngen_data/r11/study_index
+      step.target_index_path: gs://ot_orchestration/releases/24.10_freeze6/gene_index
+      step.disease_index_path: gs://open-targets-pre-data-releases/24.06/output/etl/parquet/diseases
+      step.valid_study_index_path: gs://ot_orchestration/releases/24.10_freeze6/study_index
+      step.invalid_study_index_path: gs://ot_orchestration/releases/24.10_freeze6/invalid_study_index
+      step.biosample_index_path: gs://ot_orchestration/releases/24.10_freeze6/biosample_index
+      step.invalid_qc_reasons:
+        - UNRESOLVED_TARGET
+        - UNRESOLVED_DISEASE
+        - UNKNOWN_STUDY_TYPE
+        - DUPLICATED_STUDY
+        - UNKNOWN_BIOSAMPLE
+        - FAILED_MEAN_BETA_CHECK
+        - FAILED_PZ_CHECK
+        - FAILED_GC_LAMBDA_CHECK
+        - NO_OT_CURATION
 
-  # - id: credible_set_validation
-  #   kind: Task
-  #   prerequisites:
-  #     - study_validation
-  #   params:
-  #     step: credible_set_validation
-  #     step.study_index_path: gs://ot_orchestration/releases/24.10_freeze6/study_index
-  #     step.study_locus_path:
-  #       - gs://gwas_catalog_top_hits/credible_sets/
-  #       - gs://gwas_catalog_sumstats_pics/credible_sets/
-  #       - gs://gwas_catalog_sumstats_susie/credible_set_clean/
-  #       - gs://eqtl_catalogue_data/credible_set_datasets/eqtl_catalogue_susie/
-  #       - gs://ukb_ppp_eur_data/credible_set_clean/
-  #       - gs://finngen_data/r11/credible_set_datasets/susie/
-  #     step.valid_study_locus_path: gs://ot_orchestration/releases/24.10_freeze6/credible_set
-  #     step.invalid_study_locus_path: gs://ot_orchestration/releases/24.10_freeze6/invalid_credible_set
-  #     step.invalid_qc_reasons:
-  #       - DUPLICATED_STUDYLOCUS_ID
-  #       - AMBIGUOUS_STUDY
-  #       - MISSING_STUDY
-  #       - NO_GENOMIC_LOCATION_FLAG
-  #       - COMPOSITE_FLAG
-  #       - INCONSISTENCY_FLAG
-  #       - PALINDROMIC_ALLELE_FLAG
-  #       - SUBSIGNIFICANT_FLAG
-  #       - LD_CLUMPED
-  #       - IN_MHC
-  #       - REDUNDANT_PICS_TOP_HIT
-  #       - EXPLAINED_BY_SUSIE
-  #       - WINDOW_CLUMPED
-  #       - NON_MAPPED_VARIANT_FLAG
-  #       - INVALID_VARIANT_IDENTIFIER
-  #       - INVALID_CHROMOSOME
-  #       - TOP_HIT_AND_SUMMARY_STATS
+  - id: credible_set_validation
+    kind: Task
+    prerequisites:
+      - study_validation
+    params:
+      step: credible_set_validation
+      step.study_index_path: gs://ot_orchestration/releases/24.10_freeze6/study_index
+      step.study_locus_path:
+        - gs://gwas_catalog_top_hits/credible_sets/
+        - gs://gwas_catalog_sumstats_pics/credible_sets/
+        - gs://gwas_catalog_sumstats_susie/credible_set_clean/
+        - gs://eqtl_catalogue_data/credible_set_datasets/eqtl_catalogue_susie/
+        - gs://ukb_ppp_eur_data/credible_set_clean/
+        - gs://finngen_data/r11/credible_set_datasets/susie/
+      step.valid_study_locus_path: gs://ot_orchestration/releases/24.10_freeze6/credible_set
+      step.invalid_study_locus_path: gs://ot_orchestration/releases/24.10_freeze6/invalid_credible_set
+      step.invalid_qc_reasons:
+        - DUPLICATED_STUDYLOCUS_ID
+        - AMBIGUOUS_STUDY
+        - MISSING_STUDY
+        - NO_GENOMIC_LOCATION_FLAG
+        - COMPOSITE_FLAG
+        - INCONSISTENCY_FLAG
+        - PALINDROMIC_ALLELE_FLAG
+        - SUBSIGNIFICANT_FLAG
+        - LD_CLUMPED
+        - IN_MHC
+        - REDUNDANT_PICS_TOP_HIT
+        - EXPLAINED_BY_SUSIE
+        - WINDOW_CLUMPED
+        - NON_MAPPED_VARIANT_FLAG
+        - INVALID_VARIANT_IDENTIFIER
+        - INVALID_CHROMOSOME
+        - TOP_HIT_AND_SUMMARY_STATS
 
-  # - id: convert_variants_to_vcf
-  #   kind: Task
-  #   prerequisites:
-  #     - credible_set_validation
-  #   params:
-  #     step: variant_to_vcf
-  #     step.source_paths:
-  #       - gs://open-targets-pre-data-releases/24.09/input/evidence-files/uniprot.json.gz
-  #       - gs://open-targets-pre-data-releases/24.09/input/evidence-files/eva.json.gz
-  #       - gs://open-targets-pre-data-releases/24.09/input/pharmacogenomics-inputs/pharmacogenomics.json.gz
-  #       - gs://ot_orchestration/releases/24.10_freeze6/credible_set
-  #     step.source_formats:
-  #       - json
-  #       - json
-  #       - json
-  #       - parquet
-  #     step.output_path: gs://ot_orchestration/releases/24.10_freeze6/variants/partitioned_variants
-  #     step.partition_size: 2_000 # approximate num of variants per partition!
+  - id: convert_variants_to_vcf
+    kind: Task
+    prerequisites:
+      - credible_set_validation
+    params:
+      step: variant_to_vcf
+      step.source_paths:
+        - gs://open-targets-pre-data-releases/24.09/input/evidence-files/uniprot.json.gz
+        - gs://open-targets-pre-data-releases/24.09/input/evidence-files/eva.json.gz
+        - gs://open-targets-pre-data-releases/24.09/input/pharmacogenomics-inputs/pharmacogenomics.json.gz
+        - gs://ot_orchestration/releases/24.10_freeze6/credible_set
+      step.source_formats:
+        - json
+        - json
+        - json
+        - parquet
+      step.output_path: gs://ot_orchestration/releases/24.10_freeze6/variants/partitioned_variants
+      step.partition_size: 2_000 # approximate num of variants per partition!
 
-  # - id: variant_annotation
-  #   kind: Task
-  #   prerequisites:
-  #     - convert_variants_to_vcf
-  #   google_batch:
-  #     entrypoint: /bin/sh
-  #     image: europe-west1-docker.pkg.dev/open-targets-genetics-dev/gentropy-app/custom_ensembl_vep:dev
-  #     resource_specs:
-  #       cpu_milli: 2000
-  #       memory_mib: 2000
-  #       boot_disk_mib: 10000
-  #     task_specs:
-  #       max_retry_count: 1
-  #       max_run_duration: "2h"
-  #     policy_specs:
-  #       machine_type: n1-standard-4
-  #   params:
-  #     vep_cache_path: gs://genetics_etl_python_playground/vep/cache
-  #     vcf_input_path: gs://ot_orchestration/releases/24.10_freeze6/variants/partitioned_variants
-  #     vep_output_path: gs://ot_orchestration/releases/24.10_freeze6/variants/annotated_variants
+  - id: variant_annotation
+    kind: Task
+    prerequisites:
+      - convert_variants_to_vcf
+    google_batch:
+      entrypoint: /bin/sh
+      image: europe-west1-docker.pkg.dev/open-targets-genetics-dev/gentropy-app/custom_ensembl_vep:dev
+      resource_specs:
+        cpu_milli: 2000
+        memory_mib: 2000
+        boot_disk_mib: 10000
+      task_specs:
+        max_retry_count: 1
+        max_run_duration: "2h"
+      policy_specs:
+        machine_type: n1-standard-4
+    params:
+      vep_cache_path: gs://genetics_etl_python_playground/vep/cache
+      vcf_input_path: gs://ot_orchestration/releases/24.10_freeze6/variants/partitioned_variants
+      vep_output_path: gs://ot_orchestration/releases/24.10_freeze6/variants/annotated_variants
 
-  # - id: variant_index
-  #   prerequisites:
-  #     - variant_annotation
-  #   params:
-  #     step: variant_index
-  #     step.vep_output_json_path: gs://ot_orchestration/releases/24.10_freeze6/variants/annotated_variants
-  #     step.gnomad_variant_annotations_path: gs://genetics_etl_python_playground/static_assets/gnomad_variants
-  #     step.variant_index_path: gs://ot_orchestration/releases/24.10_freeze6/variant_index
+  - id: variant_index
+    prerequisites:
+      - variant_annotation
+    params:
+      step: variant_index
+      step.vep_output_json_path: gs://ot_orchestration/releases/24.10_freeze6/variants/annotated_variants
+      step.gnomad_variant_annotations_path: gs://genetics_etl_python_playground/static_assets/gnomad_variants
+      step.variant_index_path: gs://ot_orchestration/releases/24.10_freeze6/variant_index
 
-  # - id: colocalisation_ecaviar
-  #   prerequisites:
-  #     - credible_set_validation
-  #   params:
-  #     step: colocalisation
-  #     step.credible_set_path: gs://ot_orchestration/releases/24.10_freeze6/credible_set
-  #     step.coloc_path: gs://ot_orchestration/releases/24.10_freeze6/colocalisation
-  #     step.colocalisation_method: ECaviar
+  - id: colocalisation_ecaviar
+    prerequisites:
+      - credible_set_validation
+    params:
+      step: colocalisation
+      step.credible_set_path: gs://ot_orchestration/releases/24.10_freeze6/credible_set
+      step.coloc_path: gs://ot_orchestration/releases/24.10_freeze6/colocalisation
+      step.colocalisation_method: ECaviar
 
-  # - id: colocalisation_coloc
-  #   prerequisites:
-  #     - colocalisation_ecaviar
-  #   params:
-  #     step: colocalisation
-  #     step.credible_set_path: gs://ot_orchestration/releases/24.10_freeze6/credible_set
-  #     step.coloc_path: gs://ot_orchestration/releases/24.10_freeze6/colocalisation/
-  #     step.colocalisation_method: Coloc
-  #     +step.colocalisation_method_params: "{priorc1: 1e-4, priorc2: 1e-4, priorc12: 1e-5}"
+  - id: colocalisation_coloc
+    prerequisites:
+      - colocalisation_ecaviar
+    params:
+      step: colocalisation
+      step.credible_set_path: gs://ot_orchestration/releases/24.10_freeze6/credible_set
+      step.coloc_path: gs://ot_orchestration/releases/24.10_freeze6/colocalisation/
+      step.colocalisation_method: Coloc
+      +step.colocalisation_method_params: "{priorc1: 1e-4, priorc2: 1e-4, priorc12: 1e-5}"
 
-  # - id: l2g_feature_matrix
-  #   prerequisites:
-  #     - colocalisation_coloc
-  #     - colocalisation_ecaviar
-  #     - variant_index
-  #   params:
-  #     step: locus_to_gene_feature_matrix
-  #     step.credible_set_path: gs://ot_orchestration/releases/24.10_freeze6/credible_set
-  #     step.variant_index_path: gs://ot_orchestration/releases/24.10_freeze6/variant_index
-  #     step.colocalisation_path: gs://ot_orchestration/releases/24.10_freeze6/colocalisation
-  #     step.study_index_path: gs://ot_orchestration/releases/24.10_freeze6/study_index
-  #     step.gene_index_path: gs://ot_orchestration/releases/24.10_freeze6/gene_index
-  #     step.feature_matrix_path: gs://ot_orchestration/releases/24.10_freeze6/locus_to_gene_feature_matrix
-  #     +step.session.extended_spark_conf: "{spark.sql.autoBroadcastJoinThreshold:'-1'}"
-  #     step.session.write_mode: overwrite
+  - id: l2g_feature_matrix
+    prerequisites:
+      - colocalisation_coloc
+      - colocalisation_ecaviar
+      - variant_index
+    params:
+      step: locus_to_gene_feature_matrix
+      step.credible_set_path: gs://ot_orchestration/releases/24.10_freeze6/credible_set
+      step.variant_index_path: gs://ot_orchestration/releases/24.10_freeze6/variant_index
+      step.colocalisation_path: gs://ot_orchestration/releases/24.10_freeze6/colocalisation
+      step.study_index_path: gs://ot_orchestration/releases/24.10_freeze6/study_index
+      step.gene_index_path: gs://ot_orchestration/releases/24.10_freeze6/gene_index
+      step.feature_matrix_path: gs://ot_orchestration/releases/24.10_freeze6/locus_to_gene_feature_matrix
+      +step.session.extended_spark_conf: "{spark.sql.autoBroadcastJoinThreshold:'-1'}"
+      step.session.write_mode: overwrite
 
   - id: l2g_train
     prerequisites:
@@ -221,6 +221,7 @@ nodes:
       step.credible_set_path: gs://ot_orchestration/releases/24.10_freeze6/credible_set
       step.study_index_path: gs://ot_orchestration/releases/24.10_freeze6/study_index
       step.locus_to_gene_threshold: 0.05
+      step.session.write_mode: overwrite
 
   - id: l2g_associations
     params:
@@ -230,41 +231,7 @@ nodes:
       step.direct_associations_output_path: gs://ot_orchestration/releases/24.10_freeze6/locus_to_gene_associations/direct_associations
       step.indirect_associations_output_path: gs://ot_orchestration/releases/24.10_freeze6/locus_to_gene_associations/indirect_associations
       step.session.spark_uri: yarn
-    prerequisites:
-      - l2g_evidence
-
-# TO DROP
-  - id: l2g_predict_egl
-    prerequisites:
-      - l2g_train
-    params:
-      step: locus_to_gene
-      step.run_mode: predict
-      step.predictions_path: gs://ot_orchestration/model_benchmarks/releases/24.10_freeze6/locus_to_gene_predictions_egl
-      step.feature_matrix_path: gs://ot_orchestration/releases/24.10_freeze6/locus_to_gene_feature_matrix
-      step.credible_set_path: gs://ot_orchestration/releases/24.10_freeze6/credible_set
-      step.download_from_hub: true
-      step.hf_hub_repo_id: opentargets/locus_to_gene_egl
       step.session.write_mode: overwrite
 
-  - id: l2g_evidence_egl
-    prerequisites:
-      - l2g_predict
-    params:
-      step: locus_to_gene_evidence
-      step.evidence_output_path: gs://ot_orchestration/model_benchmarks/releases/24.10_freeze6/locus_to_gene_evidence_egl
-      step.locus_to_gene_predictions_path: gs://ot_orchestration/model_benchmarks/releases/24.10_freeze6/locus_to_gene_predictions_egl
-      step.credible_set_path: gs://ot_orchestration/releases/24.10_freeze6/credible_set
-      step.study_index_path: gs://ot_orchestration/releases/24.10_freeze6/study_index
-      step.locus_to_gene_threshold: 0.05
-
-  - id: l2g_associations_egl
-    params:
-      step: locus_to_gene_associations
-      step.evidence_input_path: gs://ot_orchestration/model_benchmarks/releases/24.10_freeze6/locus_to_gene_evidence_egl
-      step.disease_index_path: gs://open-targets-pre-data-releases/24.06/output/etl/parquet/diseases
-      step.direct_associations_output_path: gs://ot_orchestration/model_benchmarks/releases/24.10_freeze6/locus_to_gene_associations_egl/direct_associations
-      step.indirect_associations_output_path: gs://ot_orchestration/model_benchmarks/releases/24.10_freeze6/locus_to_gene_associations_egl/indirect_associations
-      step.session.spark_uri: yarn
     prerequisites:
       - l2g_evidence

--- a/src/ot_orchestration/dags/genetics_etl.py
+++ b/src/ot_orchestration/dags/genetics_etl.py
@@ -39,16 +39,17 @@ with DAG(
 ):
     with TaskGroup(group_id="genetics_etl") as genetics_etl:
         task_config = find_node_in_config(nodes, "variant_annotation")
-        task_config_params = task_config["params"]
-        variant_annotation = VepAnnotateOperator(
-            task_id=task_config["id"],
-            vcf_input_path=task_config_params["vcf_input_path"],
-            vep_output_path=task_config_params["vep_output_path"],
-            vep_cache_path=task_config_params["vep_cache_path"],
-            google_batch=task_config["google_batch"],
-        )
+        if task_config:
+            task_config_params = task_config["params"]
+            variant_annotation = VepAnnotateOperator(
+                task_id=task_config["id"],
+                vcf_input_path=task_config_params["vcf_input_path"],
+                vep_output_path=task_config_params["vep_output_path"],
+                vep_cache_path=task_config_params["vep_cache_path"],
+                google_batch=task_config["google_batch"],
+            )
 
-        node_map["variant_annotation"] = variant_annotation
+            node_map["variant_annotation"] = variant_annotation
 
         tasks = [node for node in nodes if "google_batch" not in node]
         # Build individual tasks and register them as nodes.

--- a/src/ot_orchestration/utils/utils.py
+++ b/src/ot_orchestration/utils/utils.py
@@ -171,9 +171,9 @@ def convert_params_to_hydra_positional_arg(
     return positional_args
 
 
-def find_node_in_config(config: list[ConfigNode], node_id: str) -> ConfigNode:
+def find_node_in_config(config: list[ConfigNode], node_id: str) -> ConfigNode | None:
     """Find node config list."""
     for node_config in config:
         if node_config["id"] == node_id:
             return node_config
-    raise KeyError(f"Config for {node_id} was not found")
+    return None

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,8 +1,8 @@
 """Tests for package util functions."""
 
 import pytest
+from ot_orchestration.types import ConfigNode
 from ot_orchestration.utils import (
-    chain_dependencies,
     convert_params_to_hydra_positional_arg,
     find_node_in_config,
     time_to_seconds,
@@ -67,48 +67,21 @@ def test_convert_params_to_hydra_positional_arg(
     assert convert_params_to_hydra_positional_arg(input, is_dataproc_job) == output
 
 
-def test_find_node_in_config() -> None:
+@pytest.mark.parametrize(
+    ["node", "result"],
+    [
+        pytest.param(
+            "A", {"id": "A", "kind": "Task", "prerequisites": []}, id="Existing node"
+        ),
+        pytest.param("D", None, id="Non existing node"),
+    ],
+)
+def test_find_node_in_config(node: str, result: ConfigNode | None) -> None:
     """Test finding a node in a configuration."""
-    config = [
+    config_list = [
         {"id": "A", "kind": "Task", "prerequisites": []},
         {"id": "B", "kind": "Task", "prerequisites": ["A"]},
         {"id": "C", "kind": "Task", "prerequisites": ["B"]},
     ]
 
-    assert find_node_in_config(config, "A") == {
-        "id": "A",
-        "kind": "Task",
-        "prerequisites": [],
-    }
-    assert find_node_in_config(config, "B") == {
-        "id": "B",
-        "kind": "Task",
-        "prerequisites": ["A"],
-    }
-    assert find_node_in_config(config, "C") == {
-        "id": "C",
-        "kind": "Task",
-        "prerequisites": ["B"],
-    }
-    with pytest.raises(KeyError):
-        find_node_in_config(config, "D")
-
-
-@pytest.mark.xfail(reason="Need to mock the Task class and set_upstream method.")
-def test_chain_dependencies() -> None:
-    """Test chaining dependencies between tasks."""
-    nodes = [
-        {"id": "A", "kind": "Task", "prerequisites": []},
-        {"id": "B", "kind": "Task", "prerequisites": ["A"]},
-        {"id": "C", "kind": "Task", "prerequisites": ["B"]},
-    ]
-    tasks_or_task_groups = {
-        "A": "Task A",
-        "B": "Task B",
-        "C": "Task C",
-    }
-
-    chain_dependencies(nodes, tasks_or_task_groups)
-    assert tasks_or_task_groups["A"].upstream_task_ids == set()
-    assert tasks_or_task_groups["B"].upstream_task_ids == {"A"}
-    assert tasks_or_task_groups["C"].upstream_task_ids == {"B"}
+    assert find_node_in_config(config_list, node) == result  # type: ignore


### PR DESCRIPTION
# Context:

- [x] genetics etl config changes to accomodate freeze6  rerun for l2g steps
- [x] Improvement over the hadling of variant annotation step in genetics etl

The change to `find_node_in_config` function allows for skipping the step, if config is not present without issueing error when generics ETL dag is parsed, but config does not contain the `VariantAnnotation` node.