### PR TITLE
chore: request additional vep fields for variant index

### DIFF
--- a/src/ot_orchestration/operators/batch/vep.py
+++ b/src/ot_orchestration/operators/batch/vep.py
@@ -239,6 +239,8 @@ class VepAnnotateOperator(GoogleCloudBaseOperator):
                 --pick_order  mane_select,canonical \
                 --per_gene \
                 --uniprot \
+                --symbol \
+                --biotype \
                 --check_existing \
                 --exclude_null_alleles \
                 --canonical \


### PR DESCRIPTION
# Content of this PR

To generate variant description for the variant index, we need to bring in gene symbol and biotype for the transcript object. More info under ticket [#3623](https://github.com/opentargets/issues/issues/3623).