### PR TITLE
fix: adding NOT_QUALIFYING_LD_BLOCK to exclusion

### DIFF
--- a/src/ot_orchestration/dags/config/genetics_etl_platform.yaml
+++ b/src/ot_orchestration/dags/config/genetics_etl_platform.yaml
@@ -142,6 +142,7 @@ nodes:
         - INVALID_VARIANT_IDENTIFIER
         - INVALID_CHROMOSOME
         - TOP_HIT_AND_SUMMARY_STATS
+        - NOT_QUALIFYING_LD_BLOCK
 
   - id: genetics_variant_conversion
     kind: Task


### PR DESCRIPTION
Related to bug when credible set size is zero for 10445 CSs.
The problem is that r2 for the lead variant is 0 for 100% cases.
There are two possible fixes:

1. Ensure that r2 for lead is always 1 in the ld annotation step.
2. Add the flag "[LD block contains no variants at the required R^2 threshold]" as an exclusion criterion.

This PR fixes 2).