### PR TITLE
feat(curation update): genetics curation update 24.11.20

### DIFF
--- a/src/ot_orchestration/dags/config/gwas_catalog_sumstats_susie_clumping.yaml
+++ b/src/ot_orchestration/dags/config/gwas_catalog_sumstats_susie_clumping.yaml
@@ -17,7 +17,7 @@ nodes:
       step.catalog_ancestry_files:
         - gs://gwas_catalog_inputs/gwas_catalog_download_ancestries.tsv
       step.study_index_path: gs://gwas_catalog_sumstats_susie/study_index
-      step.gwas_catalog_study_curation_file: gs://genetics-portal-dev-analysis/yt4/gwas_catalog_curation/20241004_output_curation.tsv
+      step.gwas_catalog_study_curation_file: gs://genetics-portal-dev-analysis/yt4/gwas_catalog_curation/20241120_output_curation.tsv
       step.sumstats_qc_path: gs://gwas_catalog_inputs/summary_statistics_qc
       step.session.write_mode: overwrite
   - id: locus_breaker_clumping

--- a/src/ot_orchestration/dags/gwas_catalog_sumstats_susie_clumping.py
+++ b/src/ot_orchestration/dags/gwas_catalog_sumstats_susie_clumping.py
@@ -34,8 +34,6 @@ with DAG(
     chain_dependencies(nodes=config["nodes"], tasks_or_task_groups=tasks)
 
     dag = generate_dataproc_task_chain(
-        cluster_name=config["dataproc"]["cluster_name"],
-        cluster_init_script=config["dataproc"]["cluster_init_script"],
-        cluster_metadata=config["dataproc"]["cluster_metadata"],
         tasks=[t for t in tasks.values()],
+        **config["dataproc"],
     )


### PR DESCRIPTION
# Context

This PR attempts to replace the current gwas catalog study curation file with the new one from `gs://genetics-portal-dev-analysis/yt4/gwas_catalog_curation/20241120_output_curation.tsv` that has the studies dropped  due to publication  licensing issues

## Things implemented:

* GWAS Catalog curation list update.
* Pass all dataproc parameters from config