### PR TITLE
feat(genetics_etl): data freeze 10

### DIFF
--- a/src/ot_orchestration/dags/config/genetics_etl.yaml
+++ b/src/ot_orchestration/dags/config/genetics_etl.yaml
@@ -6,9 +6,9 @@ dataproc:
     PACKAGE: gs://genetics_etl_python_playground/initialisation/gentropy/dev/gentropy-0.0.0-py3-none-any.whl
   cluster_init_script: gs://genetics_etl_python_playground/initialisation/gentropy/dev/install_dependencies_on_cluster.sh
   cluster_name: otg-etl
-  autoscaling_policy: otg-efm
-  allow_efm: true
-  num_workers: 10
+  autoscaling_policy: otg-etl
+  allow_efm: false
+  num_workers: 2
 
 nodes:
 
@@ -143,26 +143,26 @@ nodes:
       step.gnomad_variant_annotations_path: gs://genetics_etl_python_playground/static_assets/gnomad_variants
       step.variant_index_path: gs://ot_orchestration/releases/24.11_freeze10/variant_index
 
-  - id: colocalisation_ecaviar
-    prerequisites:
-      - credible_set_validation
-    params:
-      step: colocalisation
-      step.credible_set_path: gs://ot_orchestration/releases/24.11_freeze10/credible_set
-      step.coloc_path: gs://ot_orchestration/releases/24.11_freeze10/colocalisation
-      step.colocalisation_method: ECaviar
-      +step.session.extended_spark_conf: "{spark:spark.sql.shuffle.partitions: '4000'}"
-
   - id: colocalisation_coloc
     prerequisites:
-      - colocalisation_ecaviar
+      - variant_index
     params:
       step: colocalisation
       step.credible_set_path: gs://ot_orchestration/releases/24.11_freeze10/credible_set
       step.coloc_path: gs://ot_orchestration/releases/24.11_freeze10/colocalisation/
       step.colocalisation_method: Coloc
       +step.colocalisation_method_params: "{priorc1: 1e-4, priorc2: 1e-4, priorc12: 1e-5}"
-      +step.session.extended_spark_conf: "{spark:spark.sql.shuffle.partitions: '4000'}"
+      +step.session.extended_spark_conf: "{spark.sql.shuffle.partitions: '4000'}"
+
+  - id: colocalisation_ecaviar
+    prerequisites:
+      - colocalisation_coloc
+    params:
+      step: colocalisation
+      step.credible_set_path: gs://ot_orchestration/releases/24.11_freeze10/credible_set
+      step.coloc_path: gs://ot_orchestration/releases/24.11_freeze10/colocalisation
+      step.colocalisation_method: ECaviar
+      +step.session.extended_spark_conf: "{spark.sql.shuffle.partitions: '4000', spark.executor.memory: '8g'}"
 
   - id: l2g_feature_matrix
     prerequisites:
@@ -180,61 +180,61 @@ nodes:
       +step.session.extended_spark_conf: "{spark.sql.autoBroadcastJoinThreshold:'-1'}"
       step.session.write_mode: overwrite
 
-# - id: l2g_train
-#   prerequisites:
-#     - l2g_feature_matrix
-#   params:
-#     step: locus_to_gene
-#     step.run_mode: train
-#     step.wandb_run_name: 24.11_freeze10
-#     step.hf_hub_repo_id: opentargets/locus_to_gene
-#     step.hf_model_commit_message: "chore: update model based on 24.11_freeze10 run"
-#     step.model_path: gs://ot_orchestration/releases/24.11_freeze10/locus_to_gene_model/classifier.skops
-#     step.credible_set_path: gs://ot_orchestration/releases/24.11_freeze10/credible_set
-#     step.variant_index_path: gs://ot_orchestration/releases/24.11_freeze10/variant_index
-#     step.feature_matrix_path: gs://ot_orchestration/releases/24.11_freeze10/locus_to_gene_feature_matrix
-#     step.gold_standard_curation_path: gs://genetics_etl_python_playground/input/l2g/gold_standard/curation.json
-#     step.gene_interactions_path: gs://genetics_etl_python_playground/static_assets/interaction # OTP 23.12 data
-#     step.hyperparameters.n_estimators: 100
-#     step.hyperparameters.max_depth: 5
-#     step.hyperparameters.loss: log_loss
-#     +step.session.extended_spark_conf: "{spark.kryoserializer.buffer.max:500m, spark.sql.autoBroadcastJoinThreshold:'-1'}"
+  - id: l2g_train
+    prerequisites:
+      - l2g_feature_matrix
+    params:
+      step: locus_to_gene
+      step.run_mode: train
+      step.wandb_run_name: 24.11_freeze10
+      step.hf_hub_repo_id: opentargets/locus_to_gene
+      step.hf_model_commit_message: "chore: update model based on 24.11_freeze10 run"
+      step.model_path: gs://ot_orchestration/releases/24.11_freeze10/locus_to_gene_model/classifier.skops
+      step.credible_set_path: gs://ot_orchestration/releases/24.11_freeze10/credible_set
+      step.variant_index_path: gs://ot_orchestration/releases/24.11_freeze10/variant_index
+      step.feature_matrix_path: gs://ot_orchestration/releases/24.11_freeze10/locus_to_gene_feature_matrix
+      step.gold_standard_curation_path: gs://genetics_etl_python_playground/input/l2g/gold_standard/curation.json
+      step.gene_interactions_path: gs://genetics_etl_python_playground/static_assets/interaction # OTP 23.12 data
+      step.hyperparameters.n_estimators: 100
+      step.hyperparameters.max_depth: 5
+      step.hyperparameters.loss: log_loss
+      +step.session.extended_spark_conf: "{spark.kryoserializer.buffer.max:500m, spark.sql.autoBroadcastJoinThreshold:'-1'}"
 
-# - id: l2g_predict
-#   prerequisites:
-#     - l2g_train
-#   params:
-#     step: locus_to_gene
-#     step.run_mode: predict
-#     step.predictions_path: gs://ot_orchestration/releases/24.11_freeze10/locus_to_gene_predictions
-#     step.feature_matrix_path: gs://ot_orchestration/releases/24.11_freeze10/locus_to_gene_feature_matrix
-#     step.credible_set_path: gs://ot_orchestration/releases/24.11_freeze10/credible_set
-#     step.download_from_hub: true
-#     step.l2g_threshold: 0.05
-#     step.hf_hub_repo_id: opentargets/locus_to_gene
-#     step.session.write_mode: overwrite
+  - id: l2g_predict
+    prerequisites:
+      - l2g_train
+    params:
+      step: locus_to_gene
+      step.run_mode: predict
+      step.predictions_path: gs://ot_orchestration/releases/24.11_freeze10/locus_to_gene_predictions
+      step.feature_matrix_path: gs://ot_orchestration/releases/24.11_freeze10/locus_to_gene_feature_matrix
+      step.credible_set_path: gs://ot_orchestration/releases/24.11_freeze10/credible_set
+      step.download_from_hub: true
+      step.l2g_threshold: 0.05
+      step.hf_hub_repo_id: opentargets/locus_to_gene
+      step.session.write_mode: overwrite
 
-# - id: l2g_evidence
-#   prerequisites:
-#     - l2g_predict
-#   params:
-#     step: locus_to_gene_evidence
-#     step.evidence_output_path: gs://ot_orchestration/releases/24.11_freeze10/locus_to_gene_evidence
-#     step.locus_to_gene_predictions_path: gs://ot_orchestration/releases/24.11_freeze10/locus_to_gene_predictions
-#     step.credible_set_path: gs://ot_orchestration/releases/24.11_freeze10/credible_set
-#     step.study_index_path: gs://ot_orchestration/releases/24.11_freeze10/study_index
-#     step.locus_to_gene_threshold: 0.05
-#     step.session.write_mode: overwrite
+  - id: l2g_evidence
+    prerequisites:
+      - l2g_predict
+    params:
+      step: locus_to_gene_evidence
+      step.evidence_output_path: gs://ot_orchestration/releases/24.11_freeze10/locus_to_gene_evidence
+      step.locus_to_gene_predictions_path: gs://ot_orchestration/releases/24.11_freeze10/locus_to_gene_predictions
+      step.credible_set_path: gs://ot_orchestration/releases/24.11_freeze10/credible_set
+      step.study_index_path: gs://ot_orchestration/releases/24.11_freeze10/study_index
+      step.locus_to_gene_threshold: 0.05
+      step.session.write_mode: overwrite
 
-# - id: l2g_associations
-#   params:
-#     step: locus_to_gene_associations
-#     step.evidence_input_path: gs://ot_orchestration/releases/24.11_freeze10/locus_to_gene_evidence
-#     step.disease_index_path: gs://open-targets-pre-data-releases/24.06/output/etl/parquet/diseases
-#     step.direct_associations_output_path: gs://ot_orchestration/releases/24.11_freeze10/locus_to_gene_associations/direct_associations
-#     step.indirect_associations_output_path: gs://ot_orchestration/releases/24.11_freeze10/locus_to_gene_associations/indirect_associations
-#     step.session.spark_uri: yarn
-#     step.session.write_mode: overwrite
+  - id: l2g_associations
+    params:
+      step: locus_to_gene_associations
+      step.evidence_input_path: gs://ot_orchestration/releases/24.11_freeze10/locus_to_gene_evidence
+      step.disease_index_path: gs://open-targets-pre-data-releases/24.06/output/etl/parquet/diseases
+      step.direct_associations_output_path: gs://ot_orchestration/releases/24.11_freeze10/locus_to_gene_associations/direct_associations
+      step.indirect_associations_output_path: gs://ot_orchestration/releases/24.11_freeze10/locus_to_gene_associations/indirect_associations
+      step.session.spark_uri: yarn
+      step.session.write_mode: overwrite
 
-#   prerequisites:
-#     - l2g_evidence
+    prerequisites:
+      - l2g_evidence

--- a/src/ot_orchestration/dags/config/genetics_etl.yaml
+++ b/src/ot_orchestration/dags/config/genetics_etl.yaml
@@ -209,8 +209,9 @@ nodes:
       step.predictions_path: gs://ot_orchestration/releases/24.11_freeze10/locus_to_gene_predictions
       step.feature_matrix_path: gs://ot_orchestration/releases/24.11_freeze10/locus_to_gene_feature_matrix
       step.credible_set_path: gs://ot_orchestration/releases/24.11_freeze10/credible_set
-      step.download_from_hub: true
+      step.download_from_hub: false
       step.l2g_threshold: 0.05
+      step.model_path: gs://ot_orchestration/benchmarks/l2g/fm0/v5.1_best_cv/locus_to_gene_model/classifier.skops
       step.hf_hub_repo_id: opentargets/locus_to_gene
       step.session.write_mode: overwrite
 

--- a/src/ot_orchestration/dags/config/genetics_etl.yaml
+++ b/src/ot_orchestration/dags/config/genetics_etl.yaml
@@ -1,5 +1,5 @@
 l2g_gold_standard_path: gs://genetics_etl_python_playground/input/l2g/gold_standard/curation.json
-release_dir: gs://ot_orchestration/releases/24.11_freeze9
+release_dir: gs://ot_orchestration/releases/24.11_freeze10
 dataproc:
   python_main_module: gs://genetics_etl_python_playground/initialisation/gentropy/dev/cli.py
   cluster_metadata:
@@ -18,7 +18,7 @@ nodes:
     params:
       step: gene_index
       step.target_path: gs://genetics_etl_python_playground/static_assets/targets # OTP 23.12 data
-      step.gene_index_path: gs://ot_orchestration/releases/24.11_freeze9/gene_index
+      step.gene_index_path: gs://ot_orchestration/releases/24.11_freeze10/gene_index
 
   - id: biosample_index
     kind: Task
@@ -28,7 +28,7 @@ nodes:
       step.cell_ontology_input_path: gs://open-targets-pre-data-releases/24.06dev-test/input/biosamples/cl.json
       step.uberon_input_path: gs://open-targets-pre-data-releases/24.06dev-test/input/biosamples/uberon.json
       step.efo_input_path: gs://open-targets-pre-data-releases/24.06dev-test/input/biosamples/efo.json
-      step.biosample_index_path: gs://ot_orchestration/releases/24.11_freeze9/biosample_index
+      step.biosample_index_path: gs://ot_orchestration/releases/24.11_freeze10/biosample_index
 
   - id: study_validation
     kind: Task
@@ -44,11 +44,11 @@ nodes:
         - gs://eqtl_catalogue_data/study_index
         - gs://ukb_ppp_eur_data/study_index
         - gs://finngen_data/r11/study_index
-      step.target_index_path: gs://ot_orchestration/releases/24.11_freeze9/gene_index
+      step.target_index_path: gs://ot_orchestration/releases/24.11_freeze10/gene_index
       step.disease_index_path: gs://open-targets-pre-data-releases/24.06/output/etl/parquet/diseases
-      step.valid_study_index_path: gs://ot_orchestration/releases/24.11_freeze9/study_index
-      step.invalid_study_index_path: gs://ot_orchestration/releases/24.11_freeze9/invalid_study_index
-      step.biosample_index_path: gs://ot_orchestration/releases/24.11_freeze9/biosample_index
+      step.valid_study_index_path: gs://ot_orchestration/releases/24.11_freeze10/study_index
+      step.invalid_study_index_path: gs://ot_orchestration/releases/24.11_freeze10/invalid_study_index
+      step.biosample_index_path: gs://ot_orchestration/releases/24.11_freeze10/biosample_index
       step.invalid_qc_reasons:
         - UNRESOLVED_TARGET
         - UNRESOLVED_DISEASE
@@ -66,16 +66,16 @@ nodes:
       - study_validation
     params:
       step: credible_set_validation
-      step.study_index_path: gs://ot_orchestration/releases/24.11_freeze9/study_index
+      step.study_index_path: gs://ot_orchestration/releases/24.11_freeze10/study_index
       step.study_locus_path:
         - gs://gwas_catalog_top_hits/credible_sets/
         - gs://gwas_catalog_sumstats_pics/credible_sets/
         - gs://gwas_catalog_sumstats_susie/credible_set_clean/
-        - gs://eqtl_catalogue_data/credible_set_datasets/eqtl_catalogue_susie/
+        - gs://eqtl_catalogue_data/credible_set_datasets/eqtl_catalogue_susie_patched/
         - gs://ukb_ppp_eur_data/credible_set_clean/
         - gs://finngen_data/r11/credible_set_datasets/susie/
-      step.valid_study_locus_path: gs://ot_orchestration/releases/24.11_freeze9/credible_set
-      step.invalid_study_locus_path: gs://ot_orchestration/releases/24.11_freeze9/invalid_credible_set
+      step.valid_study_locus_path: gs://ot_orchestration/releases/24.11_freeze10/credible_set
+      step.invalid_study_locus_path: gs://ot_orchestration/releases/24.11_freeze10/invalid_credible_set
       step.invalid_qc_reasons:
         - DUPLICATED_STUDYLOCUS_ID
         - AMBIGUOUS_STUDY
@@ -104,13 +104,13 @@ nodes:
         - gs://open-targets-pre-data-releases/24.09/input/evidence-files/uniprot.json.gz
         - gs://open-targets-pre-data-releases/24.09/input/evidence-files/eva.json.gz
         - gs://open-targets-pre-data-releases/24.09/input/pharmacogenomics-inputs/pharmacogenomics.json.gz
-        - gs://ot_orchestration/releases/24.11_freeze9/credible_set
+        - gs://ot_orchestration/releases/24.11_freeze10/credible_set
       step.source_formats:
         - json
         - json
         - json
         - parquet
-      step.output_path: gs://ot_orchestration/releases/24.11_freeze9/variants/partitioned_variants
+      step.output_path: gs://ot_orchestration/releases/24.11_freeze10/variants/partitioned_variants
       step.partition_size: 2_000 # approximate num of variants per partition!
 
   - id: variant_annotation
@@ -131,36 +131,38 @@ nodes:
         machine_type: n1-standard-4
     params:
       vep_cache_path: gs://genetics_etl_python_playground/vep/cache
-      vcf_input_path: gs://ot_orchestration/releases/24.11_freeze9/variants/partitioned_variants
-      vep_output_path: gs://ot_orchestration/releases/24.11_freeze9/variants/annotated_variants
+      vcf_input_path: gs://ot_orchestration/releases/24.11_freeze10/variants/partitioned_variants
+      vep_output_path: gs://ot_orchestration/releases/24.11_freeze10/variants/annotated_variants
 
   - id: variant_index
     prerequisites:
       - variant_annotation
     params:
       step: variant_index
-      step.vep_output_json_path: gs://ot_orchestration/releases/24.11_freeze9/variants/annotated_variants
+      step.vep_output_json_path: gs://ot_orchestration/releases/24.11_freeze10/variants/annotated_variants
       step.gnomad_variant_annotations_path: gs://genetics_etl_python_playground/static_assets/gnomad_variants
-      step.variant_index_path: gs://ot_orchestration/releases/24.11_freeze9/variant_index
+      step.variant_index_path: gs://ot_orchestration/releases/24.11_freeze10/variant_index
 
   - id: colocalisation_ecaviar
     prerequisites:
       - credible_set_validation
     params:
       step: colocalisation
-      step.credible_set_path: gs://ot_orchestration/releases/24.11_freeze9/credible_set
-      step.coloc_path: gs://ot_orchestration/releases/24.11_freeze9/colocalisation
+      step.credible_set_path: gs://ot_orchestration/releases/24.11_freeze10/credible_set
+      step.coloc_path: gs://ot_orchestration/releases/24.11_freeze10/colocalisation
       step.colocalisation_method: ECaviar
+      +step.session.extended_spark_conf: "{spark:spark.sql.shuffle.partitions: '4000'}"
 
   - id: colocalisation_coloc
     prerequisites:
       - colocalisation_ecaviar
     params:
       step: colocalisation
-      step.credible_set_path: gs://ot_orchestration/releases/24.11_freeze9/credible_set
-      step.coloc_path: gs://ot_orchestration/releases/24.11_freeze9/colocalisation/
+      step.credible_set_path: gs://ot_orchestration/releases/24.11_freeze10/credible_set
+      step.coloc_path: gs://ot_orchestration/releases/24.11_freeze10/colocalisation/
       step.colocalisation_method: Coloc
       +step.colocalisation_method_params: "{priorc1: 1e-4, priorc2: 1e-4, priorc12: 1e-5}"
+      +step.session.extended_spark_conf: "{spark:spark.sql.shuffle.partitions: '4000'}"
 
   - id: l2g_feature_matrix
     prerequisites:
@@ -169,12 +171,12 @@ nodes:
       - variant_index
     params:
       step: locus_to_gene_feature_matrix
-      step.credible_set_path: gs://ot_orchestration/releases/24.11_freeze9/credible_set
-      step.variant_index_path: gs://ot_orchestration/releases/24.11_freeze9/variant_index
-      step.colocalisation_path: gs://ot_orchestration/releases/24.11_freeze9/colocalisation
-      step.study_index_path: gs://ot_orchestration/releases/24.11_freeze9/study_index
-      step.gene_index_path: gs://ot_orchestration/releases/24.11_freeze9/gene_index
-      step.feature_matrix_path: gs://ot_orchestration/releases/24.11_freeze9/locus_to_gene_feature_matrix
+      step.credible_set_path: gs://ot_orchestration/releases/24.11_freeze10/credible_set
+      step.variant_index_path: gs://ot_orchestration/releases/24.11_freeze10/variant_index
+      step.colocalisation_path: gs://ot_orchestration/releases/24.11_freeze10/colocalisation
+      step.study_index_path: gs://ot_orchestration/releases/24.11_freeze10/study_index
+      step.gene_index_path: gs://ot_orchestration/releases/24.11_freeze10/gene_index
+      step.feature_matrix_path: gs://ot_orchestration/releases/24.11_freeze10/locus_to_gene_feature_matrix
       +step.session.extended_spark_conf: "{spark.sql.autoBroadcastJoinThreshold:'-1'}"
       step.session.write_mode: overwrite
 
@@ -184,13 +186,13 @@ nodes:
 #   params:
 #     step: locus_to_gene
 #     step.run_mode: train
-#     step.wandb_run_name: 24.11_freeze9
+#     step.wandb_run_name: 24.11_freeze10
 #     step.hf_hub_repo_id: opentargets/locus_to_gene
-#     step.hf_model_commit_message: "chore: update model based on 24.11_freeze9 run"
-#     step.model_path: gs://ot_orchestration/releases/24.11_freeze9/locus_to_gene_model/classifier.skops
-#     step.credible_set_path: gs://ot_orchestration/releases/24.11_freeze9/credible_set
-#     step.variant_index_path: gs://ot_orchestration/releases/24.11_freeze9/variant_index
-#     step.feature_matrix_path: gs://ot_orchestration/releases/24.11_freeze9/locus_to_gene_feature_matrix
+#     step.hf_model_commit_message: "chore: update model based on 24.11_freeze10 run"
+#     step.model_path: gs://ot_orchestration/releases/24.11_freeze10/locus_to_gene_model/classifier.skops
+#     step.credible_set_path: gs://ot_orchestration/releases/24.11_freeze10/credible_set
+#     step.variant_index_path: gs://ot_orchestration/releases/24.11_freeze10/variant_index
+#     step.feature_matrix_path: gs://ot_orchestration/releases/24.11_freeze10/locus_to_gene_feature_matrix
 #     step.gold_standard_curation_path: gs://genetics_etl_python_playground/input/l2g/gold_standard/curation.json
 #     step.gene_interactions_path: gs://genetics_etl_python_playground/static_assets/interaction # OTP 23.12 data
 #     step.hyperparameters.n_estimators: 100
@@ -204,9 +206,9 @@ nodes:
 #   params:
 #     step: locus_to_gene
 #     step.run_mode: predict
-#     step.predictions_path: gs://ot_orchestration/releases/24.11_freeze9/locus_to_gene_predictions
-#     step.feature_matrix_path: gs://ot_orchestration/releases/24.11_freeze9/locus_to_gene_feature_matrix
-#     step.credible_set_path: gs://ot_orchestration/releases/24.11_freeze9/credible_set
+#     step.predictions_path: gs://ot_orchestration/releases/24.11_freeze10/locus_to_gene_predictions
+#     step.feature_matrix_path: gs://ot_orchestration/releases/24.11_freeze10/locus_to_gene_feature_matrix
+#     step.credible_set_path: gs://ot_orchestration/releases/24.11_freeze10/credible_set
 #     step.download_from_hub: true
 #     step.l2g_threshold: 0.05
 #     step.hf_hub_repo_id: opentargets/locus_to_gene
@@ -217,20 +219,20 @@ nodes:
 #     - l2g_predict
 #   params:
 #     step: locus_to_gene_evidence
-#     step.evidence_output_path: gs://ot_orchestration/releases/24.11_freeze9/locus_to_gene_evidence
-#     step.locus_to_gene_predictions_path: gs://ot_orchestration/releases/24.11_freeze9/locus_to_gene_predictions
-#     step.credible_set_path: gs://ot_orchestration/releases/24.11_freeze9/credible_set
-#     step.study_index_path: gs://ot_orchestration/releases/24.11_freeze9/study_index
+#     step.evidence_output_path: gs://ot_orchestration/releases/24.11_freeze10/locus_to_gene_evidence
+#     step.locus_to_gene_predictions_path: gs://ot_orchestration/releases/24.11_freeze10/locus_to_gene_predictions
+#     step.credible_set_path: gs://ot_orchestration/releases/24.11_freeze10/credible_set
+#     step.study_index_path: gs://ot_orchestration/releases/24.11_freeze10/study_index
 #     step.locus_to_gene_threshold: 0.05
 #     step.session.write_mode: overwrite
 
 # - id: l2g_associations
 #   params:
 #     step: locus_to_gene_associations
-#     step.evidence_input_path: gs://ot_orchestration/releases/24.11_freeze9/locus_to_gene_evidence
+#     step.evidence_input_path: gs://ot_orchestration/releases/24.11_freeze10/locus_to_gene_evidence
 #     step.disease_index_path: gs://open-targets-pre-data-releases/24.06/output/etl/parquet/diseases
-#     step.direct_associations_output_path: gs://ot_orchestration/releases/24.11_freeze9/locus_to_gene_associations/direct_associations
-#     step.indirect_associations_output_path: gs://ot_orchestration/releases/24.11_freeze9/locus_to_gene_associations/indirect_associations
+#     step.direct_associations_output_path: gs://ot_orchestration/releases/24.11_freeze10/locus_to_gene_associations/direct_associations
+#     step.indirect_associations_output_path: gs://ot_orchestration/releases/24.11_freeze10/locus_to_gene_associations/indirect_associations
 #     step.session.spark_uri: yarn
 #     step.session.write_mode: overwrite
 

--- a/src/ot_orchestration/dags/config/genetics_etl.yaml
+++ b/src/ot_orchestration/dags/config/genetics_etl.yaml
@@ -1,5 +1,5 @@
 l2g_gold_standard_path: gs://genetics_etl_python_playground/input/l2g/gold_standard/curation.json
-release_dir: gs://ot_orchestration/releases/24.10_freeze6
+release_dir: gs://ot_orchestration/releases/24.10_freeze8
 dataproc:
   python_main_module: gs://genetics_etl_python_playground/initialisation/gentropy/dev/cli.py
   cluster_metadata:
@@ -18,7 +18,7 @@ nodes:
     params:
       step: gene_index
       step.target_path: gs://genetics_etl_python_playground/static_assets/targets # OTP 23.12 data
-      step.gene_index_path: gs://ot_orchestration/releases/24.10_freeze6/gene_index
+      step.gene_index_path: gs://ot_orchestration/releases/24.10_freeze8/gene_index
 
   - id: biosample_index
     kind: Task
@@ -28,7 +28,7 @@ nodes:
       step.cell_ontology_input_path: gs://open-targets-pre-data-releases/24.06dev-test/input/biosamples/cl.json
       step.uberon_input_path: gs://open-targets-pre-data-releases/24.06dev-test/input/biosamples/uberon.json
       step.efo_input_path: gs://open-targets-pre-data-releases/24.06dev-test/input/biosamples/efo.json
-      step.biosample_index_path: gs://ot_orchestration/releases/24.10_freeze6/biosample_index
+      step.biosample_index_path: gs://ot_orchestration/releases/24.10_freeze8/biosample_index
 
   - id: study_validation
     kind: Task
@@ -44,11 +44,11 @@ nodes:
         - gs://eqtl_catalogue_data/study_index
         - gs://ukb_ppp_eur_data/study_index
         - gs://finngen_data/r11/study_index
-      step.target_index_path: gs://ot_orchestration/releases/24.10_freeze6/gene_index
+      step.target_index_path: gs://ot_orchestration/releases/24.10_freeze8/gene_index
       step.disease_index_path: gs://open-targets-pre-data-releases/24.06/output/etl/parquet/diseases
-      step.valid_study_index_path: gs://ot_orchestration/releases/24.10_freeze6/study_index
-      step.invalid_study_index_path: gs://ot_orchestration/releases/24.10_freeze6/invalid_study_index
-      step.biosample_index_path: gs://ot_orchestration/releases/24.10_freeze6/biosample_index
+      step.valid_study_index_path: gs://ot_orchestration/releases/24.10_freeze8/study_index
+      step.invalid_study_index_path: gs://ot_orchestration/releases/24.10_freeze8/invalid_study_index
+      step.biosample_index_path: gs://ot_orchestration/releases/24.10_freeze8/biosample_index
       step.invalid_qc_reasons:
         - UNRESOLVED_TARGET
         - UNRESOLVED_DISEASE
@@ -66,7 +66,7 @@ nodes:
       - study_validation
     params:
       step: credible_set_validation
-      step.study_index_path: gs://ot_orchestration/releases/24.10_freeze6/study_index
+      step.study_index_path: gs://ot_orchestration/releases/24.10_freeze8/study_index
       step.study_locus_path:
         - gs://gwas_catalog_top_hits/credible_sets/
         - gs://gwas_catalog_sumstats_pics/credible_sets/
@@ -74,8 +74,8 @@ nodes:
         - gs://eqtl_catalogue_data/credible_set_datasets/eqtl_catalogue_susie/
         - gs://ukb_ppp_eur_data/credible_set_clean/
         - gs://finngen_data/r11/credible_set_datasets/susie/
-      step.valid_study_locus_path: gs://ot_orchestration/releases/24.10_freeze6/credible_set
-      step.invalid_study_locus_path: gs://ot_orchestration/releases/24.10_freeze6/invalid_credible_set
+      step.valid_study_locus_path: gs://ot_orchestration/releases/24.10_freeze8/credible_set
+      step.invalid_study_locus_path: gs://ot_orchestration/releases/24.10_freeze8/invalid_credible_set
       step.invalid_qc_reasons:
         - DUPLICATED_STUDYLOCUS_ID
         - AMBIGUOUS_STUDY
@@ -83,7 +83,6 @@ nodes:
         - NO_GENOMIC_LOCATION_FLAG
         - COMPOSITE_FLAG
         - INCONSISTENCY_FLAG
-        - PALINDROMIC_ALLELE_FLAG
         - SUBSIGNIFICANT_FLAG
         - LD_CLUMPED
         - IN_MHC
@@ -105,13 +104,13 @@ nodes:
         - gs://open-targets-pre-data-releases/24.09/input/evidence-files/uniprot.json.gz
         - gs://open-targets-pre-data-releases/24.09/input/evidence-files/eva.json.gz
         - gs://open-targets-pre-data-releases/24.09/input/pharmacogenomics-inputs/pharmacogenomics.json.gz
-        - gs://ot_orchestration/releases/24.10_freeze6/credible_set
+        - gs://ot_orchestration/releases/24.10_freeze8/credible_set
       step.source_formats:
         - json
         - json
         - json
         - parquet
-      step.output_path: gs://ot_orchestration/releases/24.10_freeze6/variants/partitioned_variants
+      step.output_path: gs://ot_orchestration/releases/24.10_freeze8/variants/partitioned_variants
       step.partition_size: 2_000 # approximate num of variants per partition!
 
   - id: variant_annotation
@@ -132,25 +131,25 @@ nodes:
         machine_type: n1-standard-4
     params:
       vep_cache_path: gs://genetics_etl_python_playground/vep/cache
-      vcf_input_path: gs://ot_orchestration/releases/24.10_freeze6/variants/partitioned_variants
-      vep_output_path: gs://ot_orchestration/releases/24.10_freeze6/variants/annotated_variants
+      vcf_input_path: gs://ot_orchestration/releases/24.10_freeze8/variants/partitioned_variants
+      vep_output_path: gs://ot_orchestration/releases/24.10_freeze8/variants/annotated_variants
 
   - id: variant_index
     prerequisites:
       - variant_annotation
     params:
       step: variant_index
-      step.vep_output_json_path: gs://ot_orchestration/releases/24.10_freeze6/variants/annotated_variants
+      step.vep_output_json_path: gs://ot_orchestration/releases/24.10_freeze8/variants/annotated_variants
       step.gnomad_variant_annotations_path: gs://genetics_etl_python_playground/static_assets/gnomad_variants
-      step.variant_index_path: gs://ot_orchestration/releases/24.10_freeze6/variant_index
+      step.variant_index_path: gs://ot_orchestration/releases/24.10_freeze8/variant_index
 
   - id: colocalisation_ecaviar
     prerequisites:
       - credible_set_validation
     params:
       step: colocalisation
-      step.credible_set_path: gs://ot_orchestration/releases/24.10_freeze6/credible_set
-      step.coloc_path: gs://ot_orchestration/releases/24.10_freeze6/colocalisation
+      step.credible_set_path: gs://ot_orchestration/releases/24.10_freeze8/credible_set
+      step.coloc_path: gs://ot_orchestration/releases/24.10_freeze8/colocalisation
       step.colocalisation_method: ECaviar
 
   - id: colocalisation_coloc
@@ -158,8 +157,8 @@ nodes:
       - colocalisation_ecaviar
     params:
       step: colocalisation
-      step.credible_set_path: gs://ot_orchestration/releases/24.10_freeze6/credible_set
-      step.coloc_path: gs://ot_orchestration/releases/24.10_freeze6/colocalisation/
+      step.credible_set_path: gs://ot_orchestration/releases/24.10_freeze8/credible_set
+      step.coloc_path: gs://ot_orchestration/releases/24.10_freeze8/colocalisation/
       step.colocalisation_method: Coloc
       +step.colocalisation_method_params: "{priorc1: 1e-4, priorc2: 1e-4, priorc12: 1e-5}"
 
@@ -170,12 +169,12 @@ nodes:
       - variant_index
     params:
       step: locus_to_gene_feature_matrix
-      step.credible_set_path: gs://ot_orchestration/releases/24.10_freeze6/credible_set
-      step.variant_index_path: gs://ot_orchestration/releases/24.10_freeze6/variant_index
-      step.colocalisation_path: gs://ot_orchestration/releases/24.10_freeze6/colocalisation
-      step.study_index_path: gs://ot_orchestration/releases/24.10_freeze6/study_index
-      step.gene_index_path: gs://ot_orchestration/releases/24.10_freeze6/gene_index
-      step.feature_matrix_path: gs://ot_orchestration/releases/24.10_freeze6/locus_to_gene_feature_matrix
+      step.credible_set_path: gs://ot_orchestration/releases/24.10_freeze8/credible_set
+      step.variant_index_path: gs://ot_orchestration/releases/24.10_freeze8/variant_index
+      step.colocalisation_path: gs://ot_orchestration/releases/24.10_freeze8/colocalisation
+      step.study_index_path: gs://ot_orchestration/releases/24.10_freeze8/study_index
+      step.gene_index_path: gs://ot_orchestration/releases/24.10_freeze8/gene_index
+      step.feature_matrix_path: gs://ot_orchestration/releases/24.10_freeze8/locus_to_gene_feature_matrix
       +step.session.extended_spark_conf: "{spark.sql.autoBroadcastJoinThreshold:'-1'}"
       step.session.write_mode: overwrite
 
@@ -185,13 +184,13 @@ nodes:
     params:
       step: locus_to_gene
       step.run_mode: train
-      step.wandb_run_name: 24.10_freeze6
+      step.wandb_run_name: 24.10_freeze8
       step.hf_hub_repo_id: opentargets/locus_to_gene
-      step.hf_model_commit_message: "chore: update model based on 24.10_freeze6 run"
-      step.model_path: gs://ot_orchestration/releases/24.10_freeze6/locus_to_gene_model/classifier.skops
-      step.credible_set_path: gs://ot_orchestration/releases/24.10_freeze6/credible_set
-      step.variant_index_path: gs://ot_orchestration/releases/24.10_freeze6/variant_index
-      step.feature_matrix_path: gs://ot_orchestration/releases/24.10_freeze6/locus_to_gene_feature_matrix
+      step.hf_model_commit_message: "chore: update model based on 24.10_freeze8 run"
+      step.model_path: gs://ot_orchestration/releases/24.10_freeze8/locus_to_gene_model/classifier.skops
+      step.credible_set_path: gs://ot_orchestration/releases/24.10_freeze8/credible_set
+      step.variant_index_path: gs://ot_orchestration/releases/24.10_freeze8/variant_index
+      step.feature_matrix_path: gs://ot_orchestration/releases/24.10_freeze8/locus_to_gene_feature_matrix
       step.gold_standard_curation_path: gs://genetics_etl_python_playground/input/l2g/gold_standard/curation.json
       step.gene_interactions_path: gs://genetics_etl_python_playground/static_assets/interaction # OTP 23.12 data
       step.hyperparameters.n_estimators: 100
@@ -205,9 +204,9 @@ nodes:
     params:
       step: locus_to_gene
       step.run_mode: predict
-      step.predictions_path: gs://ot_orchestration/releases/24.10_freeze6/locus_to_gene_predictions
-      step.feature_matrix_path: gs://ot_orchestration/releases/24.10_freeze6/locus_to_gene_feature_matrix
-      step.credible_set_path: gs://ot_orchestration/releases/24.10_freeze6/credible_set
+      step.predictions_path: gs://ot_orchestration/releases/24.10_freeze8/locus_to_gene_predictions
+      step.feature_matrix_path: gs://ot_orchestration/releases/24.10_freeze8/locus_to_gene_feature_matrix
+      step.credible_set_path: gs://ot_orchestration/releases/24.10_freeze8/credible_set
       step.download_from_hub: true
       step.l2g_threshold: 0.05
       step.hf_hub_repo_id: opentargets/locus_to_gene
@@ -218,20 +217,20 @@ nodes:
       - l2g_predict
     params:
       step: locus_to_gene_evidence
-      step.evidence_output_path: gs://ot_orchestration/releases/24.10_freeze6/locus_to_gene_evidence
-      step.locus_to_gene_predictions_path: gs://ot_orchestration/releases/24.10_freeze6/locus_to_gene_predictions
-      step.credible_set_path: gs://ot_orchestration/releases/24.10_freeze6/credible_set
-      step.study_index_path: gs://ot_orchestration/releases/24.10_freeze6/study_index
+      step.evidence_output_path: gs://ot_orchestration/releases/24.10_freeze8/locus_to_gene_evidence
+      step.locus_to_gene_predictions_path: gs://ot_orchestration/releases/24.10_freeze8/locus_to_gene_predictions
+      step.credible_set_path: gs://ot_orchestration/releases/24.10_freeze8/credible_set
+      step.study_index_path: gs://ot_orchestration/releases/24.10_freeze8/study_index
       step.locus_to_gene_threshold: 0.05
       step.session.write_mode: overwrite
 
   - id: l2g_associations
     params:
       step: locus_to_gene_associations
-      step.evidence_input_path: gs://ot_orchestration/releases/24.10_freeze6/locus_to_gene_evidence
+      step.evidence_input_path: gs://ot_orchestration/releases/24.10_freeze8/locus_to_gene_evidence
       step.disease_index_path: gs://open-targets-pre-data-releases/24.06/output/etl/parquet/diseases
-      step.direct_associations_output_path: gs://ot_orchestration/releases/24.10_freeze6/locus_to_gene_associations/direct_associations
-      step.indirect_associations_output_path: gs://ot_orchestration/releases/24.10_freeze6/locus_to_gene_associations/indirect_associations
+      step.direct_associations_output_path: gs://ot_orchestration/releases/24.10_freeze8/locus_to_gene_associations/direct_associations
+      step.indirect_associations_output_path: gs://ot_orchestration/releases/24.10_freeze8/locus_to_gene_associations/indirect_associations
       step.session.spark_uri: yarn
       step.session.write_mode: overwrite
 

--- a/src/ot_orchestration/dags/config/genetics_etl.yaml
+++ b/src/ot_orchestration/dags/config/genetics_etl.yaml
@@ -1,5 +1,5 @@
 l2g_gold_standard_path: gs://genetics_etl_python_playground/input/l2g/gold_standard/curation.json
-release_dir: gs://ot_orchestration/releases/24.10_freeze8
+release_dir: gs://ot_orchestration/releases/24.11_freeze9
 dataproc:
   python_main_module: gs://genetics_etl_python_playground/initialisation/gentropy/dev/cli.py
   cluster_metadata:
@@ -18,7 +18,7 @@ nodes:
     params:
       step: gene_index
       step.target_path: gs://genetics_etl_python_playground/static_assets/targets # OTP 23.12 data
-      step.gene_index_path: gs://ot_orchestration/releases/24.10_freeze8/gene_index
+      step.gene_index_path: gs://ot_orchestration/releases/24.11_freeze9/gene_index
 
   - id: biosample_index
     kind: Task
@@ -28,7 +28,7 @@ nodes:
       step.cell_ontology_input_path: gs://open-targets-pre-data-releases/24.06dev-test/input/biosamples/cl.json
       step.uberon_input_path: gs://open-targets-pre-data-releases/24.06dev-test/input/biosamples/uberon.json
       step.efo_input_path: gs://open-targets-pre-data-releases/24.06dev-test/input/biosamples/efo.json
-      step.biosample_index_path: gs://ot_orchestration/releases/24.10_freeze8/biosample_index
+      step.biosample_index_path: gs://ot_orchestration/releases/24.11_freeze9/biosample_index
 
   - id: study_validation
     kind: Task
@@ -44,11 +44,11 @@ nodes:
         - gs://eqtl_catalogue_data/study_index
         - gs://ukb_ppp_eur_data/study_index
         - gs://finngen_data/r11/study_index
-      step.target_index_path: gs://ot_orchestration/releases/24.10_freeze8/gene_index
+      step.target_index_path: gs://ot_orchestration/releases/24.11_freeze9/gene_index
       step.disease_index_path: gs://open-targets-pre-data-releases/24.06/output/etl/parquet/diseases
-      step.valid_study_index_path: gs://ot_orchestration/releases/24.10_freeze8/study_index
-      step.invalid_study_index_path: gs://ot_orchestration/releases/24.10_freeze8/invalid_study_index
-      step.biosample_index_path: gs://ot_orchestration/releases/24.10_freeze8/biosample_index
+      step.valid_study_index_path: gs://ot_orchestration/releases/24.11_freeze9/study_index
+      step.invalid_study_index_path: gs://ot_orchestration/releases/24.11_freeze9/invalid_study_index
+      step.biosample_index_path: gs://ot_orchestration/releases/24.11_freeze9/biosample_index
       step.invalid_qc_reasons:
         - UNRESOLVED_TARGET
         - UNRESOLVED_DISEASE
@@ -66,7 +66,7 @@ nodes:
       - study_validation
     params:
       step: credible_set_validation
-      step.study_index_path: gs://ot_orchestration/releases/24.10_freeze8/study_index
+      step.study_index_path: gs://ot_orchestration/releases/24.11_freeze9/study_index
       step.study_locus_path:
         - gs://gwas_catalog_top_hits/credible_sets/
         - gs://gwas_catalog_sumstats_pics/credible_sets/
@@ -74,8 +74,8 @@ nodes:
         - gs://eqtl_catalogue_data/credible_set_datasets/eqtl_catalogue_susie/
         - gs://ukb_ppp_eur_data/credible_set_clean/
         - gs://finngen_data/r11/credible_set_datasets/susie/
-      step.valid_study_locus_path: gs://ot_orchestration/releases/24.10_freeze8/credible_set
-      step.invalid_study_locus_path: gs://ot_orchestration/releases/24.10_freeze8/invalid_credible_set
+      step.valid_study_locus_path: gs://ot_orchestration/releases/24.11_freeze9/credible_set
+      step.invalid_study_locus_path: gs://ot_orchestration/releases/24.11_freeze9/invalid_credible_set
       step.invalid_qc_reasons:
         - DUPLICATED_STUDYLOCUS_ID
         - AMBIGUOUS_STUDY
@@ -104,13 +104,13 @@ nodes:
         - gs://open-targets-pre-data-releases/24.09/input/evidence-files/uniprot.json.gz
         - gs://open-targets-pre-data-releases/24.09/input/evidence-files/eva.json.gz
         - gs://open-targets-pre-data-releases/24.09/input/pharmacogenomics-inputs/pharmacogenomics.json.gz
-        - gs://ot_orchestration/releases/24.10_freeze8/credible_set
+        - gs://ot_orchestration/releases/24.11_freeze9/credible_set
       step.source_formats:
         - json
         - json
         - json
         - parquet
-      step.output_path: gs://ot_orchestration/releases/24.10_freeze8/variants/partitioned_variants
+      step.output_path: gs://ot_orchestration/releases/24.11_freeze9/variants/partitioned_variants
       step.partition_size: 2_000 # approximate num of variants per partition!
 
   - id: variant_annotation
@@ -131,25 +131,25 @@ nodes:
         machine_type: n1-standard-4
     params:
       vep_cache_path: gs://genetics_etl_python_playground/vep/cache
-      vcf_input_path: gs://ot_orchestration/releases/24.10_freeze8/variants/partitioned_variants
-      vep_output_path: gs://ot_orchestration/releases/24.10_freeze8/variants/annotated_variants
+      vcf_input_path: gs://ot_orchestration/releases/24.11_freeze9/variants/partitioned_variants
+      vep_output_path: gs://ot_orchestration/releases/24.11_freeze9/variants/annotated_variants
 
   - id: variant_index
     prerequisites:
       - variant_annotation
     params:
       step: variant_index
-      step.vep_output_json_path: gs://ot_orchestration/releases/24.10_freeze8/variants/annotated_variants
+      step.vep_output_json_path: gs://ot_orchestration/releases/24.11_freeze9/variants/annotated_variants
       step.gnomad_variant_annotations_path: gs://genetics_etl_python_playground/static_assets/gnomad_variants
-      step.variant_index_path: gs://ot_orchestration/releases/24.10_freeze8/variant_index
+      step.variant_index_path: gs://ot_orchestration/releases/24.11_freeze9/variant_index
 
   - id: colocalisation_ecaviar
     prerequisites:
       - credible_set_validation
     params:
       step: colocalisation
-      step.credible_set_path: gs://ot_orchestration/releases/24.10_freeze8/credible_set
-      step.coloc_path: gs://ot_orchestration/releases/24.10_freeze8/colocalisation
+      step.credible_set_path: gs://ot_orchestration/releases/24.11_freeze9/credible_set
+      step.coloc_path: gs://ot_orchestration/releases/24.11_freeze9/colocalisation
       step.colocalisation_method: ECaviar
 
   - id: colocalisation_coloc
@@ -157,8 +157,8 @@ nodes:
       - colocalisation_ecaviar
     params:
       step: colocalisation
-      step.credible_set_path: gs://ot_orchestration/releases/24.10_freeze8/credible_set
-      step.coloc_path: gs://ot_orchestration/releases/24.10_freeze8/colocalisation/
+      step.credible_set_path: gs://ot_orchestration/releases/24.11_freeze9/credible_set
+      step.coloc_path: gs://ot_orchestration/releases/24.11_freeze9/colocalisation/
       step.colocalisation_method: Coloc
       +step.colocalisation_method_params: "{priorc1: 1e-4, priorc2: 1e-4, priorc12: 1e-5}"
 
@@ -169,70 +169,70 @@ nodes:
       - variant_index
     params:
       step: locus_to_gene_feature_matrix
-      step.credible_set_path: gs://ot_orchestration/releases/24.10_freeze8/credible_set
-      step.variant_index_path: gs://ot_orchestration/releases/24.10_freeze8/variant_index
-      step.colocalisation_path: gs://ot_orchestration/releases/24.10_freeze8/colocalisation
-      step.study_index_path: gs://ot_orchestration/releases/24.10_freeze8/study_index
-      step.gene_index_path: gs://ot_orchestration/releases/24.10_freeze8/gene_index
-      step.feature_matrix_path: gs://ot_orchestration/releases/24.10_freeze8/locus_to_gene_feature_matrix
+      step.credible_set_path: gs://ot_orchestration/releases/24.11_freeze9/credible_set
+      step.variant_index_path: gs://ot_orchestration/releases/24.11_freeze9/variant_index
+      step.colocalisation_path: gs://ot_orchestration/releases/24.11_freeze9/colocalisation
+      step.study_index_path: gs://ot_orchestration/releases/24.11_freeze9/study_index
+      step.gene_index_path: gs://ot_orchestration/releases/24.11_freeze9/gene_index
+      step.feature_matrix_path: gs://ot_orchestration/releases/24.11_freeze9/locus_to_gene_feature_matrix
       +step.session.extended_spark_conf: "{spark.sql.autoBroadcastJoinThreshold:'-1'}"
       step.session.write_mode: overwrite
 
-  - id: l2g_train
-    prerequisites:
-      - l2g_feature_matrix
-    params:
-      step: locus_to_gene
-      step.run_mode: train
-      step.wandb_run_name: 24.10_freeze8
-      step.hf_hub_repo_id: opentargets/locus_to_gene
-      step.hf_model_commit_message: "chore: update model based on 24.10_freeze8 run"
-      step.model_path: gs://ot_orchestration/releases/24.10_freeze8/locus_to_gene_model/classifier.skops
-      step.credible_set_path: gs://ot_orchestration/releases/24.10_freeze8/credible_set
-      step.variant_index_path: gs://ot_orchestration/releases/24.10_freeze8/variant_index
-      step.feature_matrix_path: gs://ot_orchestration/releases/24.10_freeze8/locus_to_gene_feature_matrix
-      step.gold_standard_curation_path: gs://genetics_etl_python_playground/input/l2g/gold_standard/curation.json
-      step.gene_interactions_path: gs://genetics_etl_python_playground/static_assets/interaction # OTP 23.12 data
-      step.hyperparameters.n_estimators: 100
-      step.hyperparameters.max_depth: 5
-      step.hyperparameters.loss: log_loss
-      +step.session.extended_spark_conf: "{spark.kryoserializer.buffer.max:500m, spark.sql.autoBroadcastJoinThreshold:'-1'}"
+# - id: l2g_train
+#   prerequisites:
+#     - l2g_feature_matrix
+#   params:
+#     step: locus_to_gene
+#     step.run_mode: train
+#     step.wandb_run_name: 24.11_freeze9
+#     step.hf_hub_repo_id: opentargets/locus_to_gene
+#     step.hf_model_commit_message: "chore: update model based on 24.11_freeze9 run"
+#     step.model_path: gs://ot_orchestration/releases/24.11_freeze9/locus_to_gene_model/classifier.skops
+#     step.credible_set_path: gs://ot_orchestration/releases/24.11_freeze9/credible_set
+#     step.variant_index_path: gs://ot_orchestration/releases/24.11_freeze9/variant_index
+#     step.feature_matrix_path: gs://ot_orchestration/releases/24.11_freeze9/locus_to_gene_feature_matrix
+#     step.gold_standard_curation_path: gs://genetics_etl_python_playground/input/l2g/gold_standard/curation.json
+#     step.gene_interactions_path: gs://genetics_etl_python_playground/static_assets/interaction # OTP 23.12 data
+#     step.hyperparameters.n_estimators: 100
+#     step.hyperparameters.max_depth: 5
+#     step.hyperparameters.loss: log_loss
+#     +step.session.extended_spark_conf: "{spark.kryoserializer.buffer.max:500m, spark.sql.autoBroadcastJoinThreshold:'-1'}"
 
-  - id: l2g_predict
-    prerequisites:
-      - l2g_train
-    params:
-      step: locus_to_gene
-      step.run_mode: predict
-      step.predictions_path: gs://ot_orchestration/releases/24.10_freeze8/locus_to_gene_predictions
-      step.feature_matrix_path: gs://ot_orchestration/releases/24.10_freeze8/locus_to_gene_feature_matrix
-      step.credible_set_path: gs://ot_orchestration/releases/24.10_freeze8/credible_set
-      step.download_from_hub: true
-      step.l2g_threshold: 0.05
-      step.hf_hub_repo_id: opentargets/locus_to_gene
-      step.session.write_mode: overwrite
+# - id: l2g_predict
+#   prerequisites:
+#     - l2g_train
+#   params:
+#     step: locus_to_gene
+#     step.run_mode: predict
+#     step.predictions_path: gs://ot_orchestration/releases/24.11_freeze9/locus_to_gene_predictions
+#     step.feature_matrix_path: gs://ot_orchestration/releases/24.11_freeze9/locus_to_gene_feature_matrix
+#     step.credible_set_path: gs://ot_orchestration/releases/24.11_freeze9/credible_set
+#     step.download_from_hub: true
+#     step.l2g_threshold: 0.05
+#     step.hf_hub_repo_id: opentargets/locus_to_gene
+#     step.session.write_mode: overwrite
 
-  - id: l2g_evidence
-    prerequisites:
-      - l2g_predict
-    params:
-      step: locus_to_gene_evidence
-      step.evidence_output_path: gs://ot_orchestration/releases/24.10_freeze8/locus_to_gene_evidence
-      step.locus_to_gene_predictions_path: gs://ot_orchestration/releases/24.10_freeze8/locus_to_gene_predictions
-      step.credible_set_path: gs://ot_orchestration/releases/24.10_freeze8/credible_set
-      step.study_index_path: gs://ot_orchestration/releases/24.10_freeze8/study_index
-      step.locus_to_gene_threshold: 0.05
-      step.session.write_mode: overwrite
+# - id: l2g_evidence
+#   prerequisites:
+#     - l2g_predict
+#   params:
+#     step: locus_to_gene_evidence
+#     step.evidence_output_path: gs://ot_orchestration/releases/24.11_freeze9/locus_to_gene_evidence
+#     step.locus_to_gene_predictions_path: gs://ot_orchestration/releases/24.11_freeze9/locus_to_gene_predictions
+#     step.credible_set_path: gs://ot_orchestration/releases/24.11_freeze9/credible_set
+#     step.study_index_path: gs://ot_orchestration/releases/24.11_freeze9/study_index
+#     step.locus_to_gene_threshold: 0.05
+#     step.session.write_mode: overwrite
 
-  - id: l2g_associations
-    params:
-      step: locus_to_gene_associations
-      step.evidence_input_path: gs://ot_orchestration/releases/24.10_freeze8/locus_to_gene_evidence
-      step.disease_index_path: gs://open-targets-pre-data-releases/24.06/output/etl/parquet/diseases
-      step.direct_associations_output_path: gs://ot_orchestration/releases/24.10_freeze8/locus_to_gene_associations/direct_associations
-      step.indirect_associations_output_path: gs://ot_orchestration/releases/24.10_freeze8/locus_to_gene_associations/indirect_associations
-      step.session.spark_uri: yarn
-      step.session.write_mode: overwrite
+# - id: l2g_associations
+#   params:
+#     step: locus_to_gene_associations
+#     step.evidence_input_path: gs://ot_orchestration/releases/24.11_freeze9/locus_to_gene_evidence
+#     step.disease_index_path: gs://open-targets-pre-data-releases/24.06/output/etl/parquet/diseases
+#     step.direct_associations_output_path: gs://ot_orchestration/releases/24.11_freeze9/locus_to_gene_associations/direct_associations
+#     step.indirect_associations_output_path: gs://ot_orchestration/releases/24.11_freeze9/locus_to_gene_associations/indirect_associations
+#     step.session.spark_uri: yarn
+#     step.session.write_mode: overwrite
 
-    prerequisites:
-      - l2g_evidence
+#   prerequisites:
+#     - l2g_evidence

--- a/src/ot_orchestration/dags/config/genetics_etl.yaml
+++ b/src/ot_orchestration/dags/config/genetics_etl.yaml
@@ -152,17 +152,17 @@ nodes:
       step.coloc_path: gs://ot_orchestration/releases/24.11_freeze10/colocalisation/
       step.colocalisation_method: Coloc
       +step.colocalisation_method_params: "{priorc1: 1e-4, priorc2: 1e-4, priorc12: 1e-5}"
-      +step.session.extended_spark_conf: "{spark.sql.shuffle.partitions: '4000'}"
+      +step.session.extended_spark_conf: "{spark.sql.shuffle.partitions: '4000', spark.executor.memory: '16g', spark.sql.files.maxPartitionBytes: '25000000', spark.executor.cores: '2'}"
 
   - id: colocalisation_ecaviar
     prerequisites:
-      - colocalisation_coloc
+      - variant_index
     params:
       step: colocalisation
       step.credible_set_path: gs://ot_orchestration/releases/24.11_freeze10/credible_set
       step.coloc_path: gs://ot_orchestration/releases/24.11_freeze10/colocalisation
       step.colocalisation_method: ECaviar
-      +step.session.extended_spark_conf: "{spark.sql.shuffle.partitions: '4000', spark.executor.memory: '8g'}"
+      +step.session.extended_spark_conf: "{spark.sql.shuffle.partitions: '3200', spark.executor.memory: '16g', spark.sql.files.maxPartitionBytes: '25000000', spark.executor.cores: '2'}"
 
   - id: l2g_feature_matrix
     prerequisites:

--- a/src/ot_orchestration/utils/dataproc.py
+++ b/src/ot_orchestration/utils/dataproc.py
@@ -30,7 +30,7 @@ from ot_orchestration.utils.path import GCSPath
 def create_cluster(
     cluster_name: str,
     master_machine_type: str = "n1-highmem-16",
-    worker_machine_type: str = "n1-standard-16",
+    worker_machine_type: str = "n1-highmem-16",
     num_workers: int = 2,
     num_preemptible_workers: int = 0,
     num_local_ssds: int = 1,
@@ -68,27 +68,17 @@ def create_cluster(
     # Create base cluster configuration.
     properties = {
         "spark:spark.sql.adaptive.enabled": "true",
+        "spark:spark.shuffle.service.enabled": "true",
     }
     if allow_efm:
         properties = {
             "dataproc:efm.spark.shuffle": "primary-worker",
             "spark:spark.sql.adaptive.enabled": "true",
             "spark:spark.sql.files.maxPartitionBytes": "1073741824",  # value proposed by the Dataproc documentation. See EFM in docstring.
-            "yarn:spark.shuffle.io.serverThreads": "128",  # ensure more threads can write default for n-standard-16 is 2 * (16 cores) threads
-            "spark:spark.shuffle.io.backlog": "8192",
-            "spark:spark.shuffle.io.maxRetries": "50",
+            "yarn:spark.shuffle.io.serverThreads": "50",  # ensure more threads can write default for n-standard-16 is 2 * (16 cores) threads
             "spark:spark.shuffle.io.numConnectionsPerPeer": "5",
-            "spark:spark.shuffle.io.retryWait": "30s",
-            "spark:spark.shuffle.io.connectionTimeout": "1m",
-            "spark:spark.io.compression.lz4.blockSize": "512KB",
-            "spark:spark.shuffle.service.enabled": "true",
-            "spark:spark.sql.shuffle.partitions": "100",
             "spark:spark.stage.maxConsecutiveAttempts": "10",  # defaults to 4, this is in case the master was lost
             "spark:spark.task.maxFailures": "10",
-            "spark:dynamicAllocationEnabled": "true",
-            "spark:spark.rpc.io.serverThreads": "50",
-            "spark:spark.shuffle.service.index.cache.size": "2048m",
-            "spark:spark.shuffle.service.removeShuffle": "true",
         }
 
     cluster_config = ClusterGenerator(

--- a/src/ot_orchestration/utils/dataproc.py
+++ b/src/ot_orchestration/utils/dataproc.py
@@ -31,7 +31,7 @@ def create_cluster(
     cluster_name: str,
     master_machine_type: str = "n1-highmem-16",
     worker_machine_type: str = "n1-standard-16",
-    num_workers: int = 1,
+    num_workers: int = 2,
     num_preemptible_workers: int = 0,
     num_local_ssds: int = 1,
     autoscaling_policy: str = GCP_AUTOSCALING_POLICY,
@@ -66,16 +66,29 @@ def create_cluster(
         DataprocCreateClusterOperator: Airflow task to create a Dataproc cluster.
     """
     # Create base cluster configuration.
-    properties = None
+    properties = {
+        "spark:spark.sql.adaptive.enabled": "true",
+    }
     if allow_efm:
         properties = {
             "dataproc:efm.spark.shuffle": "primary-worker",
+            "spark:spark.sql.adaptive.enabled": "true",
             "spark:spark.sql.files.maxPartitionBytes": "1073741824",  # value proposed by the Dataproc documentation. See EFM in docstring.
-            "spark:spark.sql.shuffle.partitions": "100",
-            "yarn:spark.shuffle.io.serverThreads": "50",  # ensure more threads can write default for n-standard-16 is 2 * (16 cores) threads
+            "yarn:spark.shuffle.io.serverThreads": "128",  # ensure more threads can write default for n-standard-16 is 2 * (16 cores) threads
+            "spark:spark.shuffle.io.backlog": "8192",
+            "spark:spark.shuffle.io.maxRetries": "50",
             "spark:spark.shuffle.io.numConnectionsPerPeer": "5",
+            "spark:spark.shuffle.io.retryWait": "30s",
+            "spark:spark.shuffle.io.connectionTimeout": "1m",
+            "spark:spark.io.compression.lz4.blockSize": "512KB",
+            "spark:spark.shuffle.service.enabled": "true",
+            "spark:spark.sql.shuffle.partitions": "100",
             "spark:spark.stage.maxConsecutiveAttempts": "10",  # defaults to 4, this is in case the master was lost
             "spark:spark.task.maxFailures": "10",
+            "spark:dynamicAllocationEnabled": "true",
+            "spark:spark.rpc.io.serverThreads": "50",
+            "spark:spark.shuffle.service.index.cache.size": "2048m",
+            "spark:spark.shuffle.service.removeShuffle": "true",
         }
 
     cluster_config = ClusterGenerator(
@@ -86,9 +99,9 @@ def create_cluster(
         zone=GCP_ZONE,
         master_machine_type=master_machine_type,
         worker_machine_type=worker_machine_type,
-        worker_disk_type="pd-ssd" if allow_efm else "pd-standard",
+        worker_disk_type="pd-ssd",
         master_disk_size=master_disk_size,
-        worker_disk_size=1024 if allow_efm else 500,
+        worker_disk_size=1024 * 2,
         num_preemptible_workers=num_preemptible_workers,
         num_workers=num_workers,
         image_version=GCP_DATAPROC_IMAGE,


### PR DESCRIPTION
# Context

- Succesful run of genetics etl at 2024.11.22 including full run in gs://ot_orchestration/releases/24.11_freeze10

- minor fix to the `create_cluster` function, as default values (num_workers == 1) fails to. build cluster. Must be more then one worker.

- Patched `eqtl_catalogue` dataset
- L2G Model training skipped (use of existing model in gcs)

- Tweaks to the colocalisation infrastructure that allowed to run eCaviar step succestully
eCaviar step succesful run - https://console.cloud.google.com/dataproc/jobs/bcfb9168-d753-466c-bd59-7ade6ce3ad60/monitoring?region=europe-west1&project=open-targets-genetics-dev
Coloc step run - https://console.cloud.google.com/dataproc/jobs/4ffde9db-b624-4c89-8f47-22ab52f60177/monitoring?region=europe-west1&project=open-targets-genetics-dev

I have experimented on both steps configuration:

```
dev_efm_config = {
     "dataproc:efm.spark.shuffle": "primary-worker",
     "spark:spark.sql.files.maxPartitionBytes": "1073741824", 
     "spark:spark.sql.shuffle.partitions": "100",
     "yarn:spark.shuffle.io.serverThreads": "50", 
     "spark:spark.shuffle.io.numConnectionsPerPeer": "5",
    "spark:spark.stage.maxConsecutiveAttempts": "10", 
    "spark:spark.task.maxFailures": "10",
}

new_efm_config = {
      "dataproc:efm.spark.shuffle": "primary-worker",
      "spark:spark.sql.adaptive.enabled": "true",
      "spark:spark.sql.files.maxPartitionBytes": "1073741824", 
      "yarn:spark.shuffle.io.serverThreads": "128",  
      "spark:spark.shuffle.io.backlog": "8192",
      "spark:spark.shuffle.io.maxRetries": "50",
      "spark:spark.shuffle.io.numConnectionsPerPeer": "5",
      "spark:spark.shuffle.io.retryWait": "30s",
      "spark:spark.shuffle.io.connectionTimeout": "1m",
      "spark:spark.io.compression.lz4.blockSize": "512KB",
      "spark:spark.shuffle.service.enabled": "true",
      "spark:spark.sql.shuffle.partitions": "100",
      "spark:spark.stage.maxConsecutiveAttempts": "10",
      "spark:spark.task.maxFailures": "10",
      "spark:dynamicAllocationEnabled": "true",
      "spark:spark.rpc.io.serverThreads": "50",
      "spark:spark.shuffle.service.index.cache.size": "2048m",
      "spark:spark.shuffle.service.removeShuffle": "true",
}
```
| Step   | efm allowed   | shuffle partitions  | tweaks |  Ellapsed Time  | efm configuration  | job id |  job status 
|---|---|---|---|---|---|---|---|
| Coloc  | True   | 100  | 2g executor memory, 2Tb ssd disk size (primary workers), spark:spark.shuffle.io.maxRetries = 10 | ~35m  |  dev  | [af27c390-15d8-47a7-961c-687daffb655b](https://console.cloud.google.com/dataproc/jobs/af27c390-15d8-47a7-961c-687daffb655b/configuration?region=europe-west1&inv=1&invt=AbiKYg&project=open-targets-genetics-dev) |  Failure (consecutive FetchFailedException) |
| Coloc  | True  | 4000  |2g executor memory, 2Tb ssd disk size (primary workers)  | ~24m  | new | [4ffde9db-b624-4c89-8f47-22ab52f60177](https://console.cloud.google.com/dataproc/jobs/4ffde9db-b624-4c89-8f47-22ab52f60177/configuration?region=europe-west1&inv=1&invt=AbiKYg&project=open-targets-genetics-dev) | Success |
| eCaviar  | True  | 4000  | 2g executor memory, 2Tb ssd disk size (primary workers) | ~30m | new | [f803e9ce-aef5-44c5-b3b6-451116337002](https://console.cloud.google.com/dataproc/jobs/f803e9ce-aef5-44c5-b3b6-451116337002/configuration?region=europe-west1&inv=1&invt=AbiKYg&project=open-targets-genetics-dev)  |  Failure (consecutive FetchFailedException) |
| eCaviar  | True  | 10_000  | 2g executor memory, 2Tb ssd disk size (primary workers), spark:spark.shuffle.io.maxRetries = 10 | ~25m | New |  [8c521f42-393e-4bd5-a00f-77046d9a63a7](https://console.cloud.google.com/dataproc/jobs/8c521f42-393e-4bd5-a00f-77046d9a63a7/monitoring?region=europe-west1&project=open-targets-genetics-dev&inv=1&invt=AbiKYg)  |  Failure (consecutive FetchFailedException) |
| eCaviar  | True  | 10_000  | 2g executor memory, 2Tb ssd disksize (primary workers), spark:spark.shuffle.io.maxRetries = 50 | ~26m | new | [b85dd7e3-2398-401e-8e0f-792984b9da83](https://console.cloud.google.com/dataproc/jobs/b85dd7e3-2398-401e-8e0f-792984b9da83/monitoring?region=europe-west1&project=open-targets-genetics-dev&inv=1&invt=AbiKYg) |  Failure (consecutive FetchFailedException) |
| eCaviar  | True  | 3000  | 2g executor memory, 4Tb ssd disksize (primary workers), spark:spark.shuffle.io.maxRetries = 50 | ~25m | New  | [021e452f-f80f-4ab3-aeaf-5eaa685cffe4](https://console.cloud.google.com/dataproc/jobs/021e452f-f80f-4ab3-aeaf-5eaa685cffe4/configuration?region=europe-west1&invt=AbiKgQ&project=open-targets-genetics-dev)  |  Failure (OOM error) |
| eCaviar  | True  | 3000  | 4g executor memory,  4Tb ssd disk size (primary workers), spark:spark.shuffle.io.maxRetries = 50, 4g executor memory overhead | ~30m | New | [3bebc91b-4eb3-4144-aad9-8c622cd71c13](https://console.cloud.google.com/dataproc/jobs/3bebc91b-4eb3-4144-aad9-8c622cd71c13/monitoring?region=europe-west1&inv=1&invt=AbiKhQ&project=open-targets-genetics-dev)  | Failure (OOM)  |
| eCaviar  | True  |  6000 | 8g executor memory,  4Tb ssd disk size (primary workers), spark:spark.shuffle.io.maxRetries = 50 | ~30m | New | [3ea91e54-cb46-43fb-bce4-878b696b7950](https://console.cloud.google.com/dataproc/jobs/3ea91e54-cb46-43fb-bce4-878b696b7950/monitoring?region=europe-west1&project=open-targets-genetics-dev) |  Failure (consecutive FetchFailed Exception, disk size issues?) |
| eCaviar  | False  | 4000  | 8g executor memory, 2Tb ssd disk size (primary and secondary workers) | ~70m | None | [bcfb9168-d753-466c-bd59-7ade6ce3ad60](https://console.cloud.google.com/dataproc/jobs/bcfb9168-d753-466c-bd59-7ade6ce3ad60/monitoring?region=europe-west1&inv=1&invt=AbiKkA&project=open-targets-genetics-dev) | Success  |

> [!NOTE]
> By summing up, I think that EFM, although benefitial for shuffling for long running tasks, is causing disk space issues as the partittions are stored just in the primary workers, the no EFM approach will use more disk space for partition storage. Although not tested in this PR context, the assumption is that coloc should also run without the EFM, but increased executor memory, just like eCaviar)

> [!NOTE]
> Due to the fact that freeze9 coloc and ecaviar worked without any workarounds and the variantIndex between the freeze9 and freeze10 has not changed a lot (freeze10 contains patched eQTL credible sets by @addramir) most likely solution is that the cause for overlap skewness is the eQTL Catalogue, rather then finngen.

> [!WARNING]
> The colocalisation is still not perfect, the succesfull runs were very fragile and more then half of the tasks at the last overlap stages were failing

