### PR TITLE
fix: do not run action on branch and tag release

### DIFF
--- a/.github/workflows/artifact.yaml
+++ b/.github/workflows/artifact.yaml
@@ -1,12 +1,11 @@
 ---
 name: Build and Push to Artifact Registry
 
-"on":
+on:
   push:
-    branches: ["*"]
-    tags: ["*"]
     paths:
-      - images/**
+      - images/gentropy/scripts/harmonise-sumstats.sh
+      - images/gentropy/Dockerfile
 
 env:
   PROJECT_ID: open-targets-genetics-dev


### PR DESCRIPTION
# Context

I want to run the docker build for gentropy image used during the harmonisation of GWAS Catalog summary statitics **only when files in the `images/`** directory change, these include the image itself and pipeline script

