### PR TITLE
chore: removing CADD from VEP annotation

### DIFF
--- a/src/ot_orchestration/operators/batch/vep.py
+++ b/src/ot_orchestration/operators/batch/vep.py
@@ -259,6 +259,5 @@ class VepAnnotateOperator(GoogleCloudBaseOperator):
                 --distance 500000 \
                 --plugin Conservation,{self.pm.cache_dir}/gerp_conservation_scores.homo_sapiens.GRCh38.bw,MAX \
                 --plugin LoF,loftee_path:{self.pm.cache_dir}/VEP_plugins,gerp_bigwig:{self.pm.cache_dir}/gerp_conservation_scores.homo_sapiens.GRCh38.bw,human_ancestor_fa:{self.pm.cache_dir}/human_ancestor.fa.gz,conservation_file:/opt/vep/loftee.sql \
-                --plugin AlphaMissense,file={self.pm.cache_dir}/AlphaMissense_hg38.tsv.gz,transcript_match=1 \
-                --plugin CADD,snv={self.pm.cache_dir}/CADD_GRCh38_whole_genome_SNVs.tsv.gz",
+                --plugin AlphaMissense,file={self.pm.cache_dir}/AlphaMissense_hg38.tsv.gz,transcript_match=1",
         ]


### PR DESCRIPTION
Due to licensing issues, CADD scores are removed from in silico predictors.