### PR TITLE
fix: gnomad annotation path update

### DIFF
--- a/src/ot_orchestration/dags/config/genetics_etl.yaml
+++ b/src/ot_orchestration/dags/config/genetics_etl.yaml
@@ -131,7 +131,7 @@ nodes:
     params:
       step: variant_index
       step.vep_output_json_path: gs://ot_orchestration/releases/24.11_freeze10/variants/annotated_variants
-      step.gnomad_variant_annotations_path: gs://genetics_etl_python_playground/static_assets/gnomad_variants
+      step.gnomad_variant_annotations_path: gs://gnomad_data_2/v4.1/variant_index
       step.variant_index_path: gs://ot_orchestration/releases/24.11_freeze10/variant_index
       step.amino_acid_change_annotations:
         - gs://otar013-ppp/OTAR2081_foldx/foldx_variant_annotation

--- a/src/ot_orchestration/operators/batch/vep.py
+++ b/src/ot_orchestration/operators/batch/vep.py
@@ -242,7 +242,6 @@ class VepAnnotateOperator(GoogleCloudBaseOperator):
                 --json \
                 --dir_plugins {self.pm.cache_dir}/VEP_plugins \
                 --sift b \
-                --polyphen b \
                 --fasta {self.pm.cache_dir}/Homo_sapiens.GRCh38.dna.primary_assembly.fa.gz \
                 --mane_select \
                 --appris \


### PR DESCRIPTION
Variant index genration depends on `gnomad_variant_annotations_path`, which has been moved from python playground, however not all occurrences were updated. 