### PR TITLE
feat: sum pips to 0.95 in susie finemapper

### DIFF
--- a/src/ot_orchestration/operators/batch/finemapping.py
+++ b/src/ot_orchestration/operators/batch/finemapping.py
@@ -214,7 +214,7 @@ class FinemappingBatchOperator(CloudBatchSubmitJobOperator):
                 "step.lead_pval_threshold=1e-5 "
                 "step.purity_mean_r2_threshold=0.25 "
                 "step.purity_min_r2_threshold=0.25 "
-                "step.cs_lbf_thr=2 step.sum_pips=0.99 "
+                "step.cs_lbf_thr=2 step.sum_pips=0.95 "
                 "step.susie_est_tausq=False "
                 "step.run_carma=False "
                 "step.run_sumstat_imputation=False "


### PR DESCRIPTION
# Context
Currently the SusieFinemapperStep has purity filtering calculated for the full credible set (at the threshold of 99%). For the downstream analysis we filter the credible sets by 95% confidence interval.

The 99% credible set will have a lower purity than 95%. So putting 95% into the finemapper step parameters will mean we save some credible sets which were originally filtered due to bad purity.

## Implementation

This PR changes the `pips_sum` paramter from 0.99 to 0.95 for the SusieFinemapperStep.