### PR TITLE
fix: staging genetics_etl test run fixes

### DIFF
--- a/src/ot_orchestration/dags/config/genetics_etl.yaml
+++ b/src/ot_orchestration/dags/config/genetics_etl.yaml
@@ -3,7 +3,7 @@
 environment_specs:
   - name: Staging
     vars:
-      gentropy_ref: 2.0.2-rc.4
+      gentropy_ref: 2.2.0-rc.2
       release_dir: gs://ot_orchestration/releases/25.02_freeze1
       input_dir: gs://open-targets-pre-data-releases/24.12-uo_test-3/input
       # NOTE: Patched target index is required, as existing target index does not contain all columns requested by the original gene index - see https://github.com/opentargets/gentropy/pull/946
@@ -25,7 +25,10 @@ dataproc:
   cluster_metadata:
     GENTROPY_REF: 'v{gentropy_ref}'
   cluster_name: otg-etl
-  autoscaling_policy: otg-etl
+  autoscaling_policy: otg-efm
+  worker_machine_type: n1-highmem-32
+  num_workers: 20
+  allow_efm: true
 
 nodes:
   - id: biosample_index
@@ -102,6 +105,7 @@ nodes:
         - INVALID_VARIANT_IDENTIFIER
         - INVALID_CHROMOSOME
         - TOP_HIT_AND_SUMMARY_STATS
+      step.session.write_mode: overwrite
 
   - id: convert_variants_to_vcf
     kind: Task
@@ -128,7 +132,7 @@ nodes:
       - convert_variants_to_vcf
     google_batch:
       entrypoint: /bin/sh
-      image: europe-west1-docker.pkg.dev/open-targets-genetics-dev/gentropy-app/custom_ensembl_vep:{gentropy_ref}
+      image: 'europe-west1-docker.pkg.dev/open-targets-genetics-dev/gentropy-app/custom_ensembl_vep:{GENTROPY_REF}'
       resource_specs:
         cpu_milli: 2000
         memory_mib: 2000
@@ -151,8 +155,7 @@ nodes:
       step.vep_output_json_path: '{release_dir}/variants/annotated_variants'
       step.gnomad_variant_annotations_path: '{gnomad}/v4.1/variant_index'
       step.variant_index_path: '{release_dir}/variant_index'
-      step.amino_acid_change_annotations:
-        - gs://otar013-ppp/OTAR2081_foldx/foldx_variant_annotation
+      step.amino_acid_change_annotations: []
 
   - id: colocalisation_coloc
     prerequisites:
@@ -163,17 +166,20 @@ nodes:
       step.coloc_path: '{release_dir}/colocalisation/'
       step.colocalisation_method: Coloc
       +step.colocalisation_method_params: '{priorc1: 1e-4, priorc2: 1e-4, priorc12: 1e-5}'
-      +step.session.extended_spark_conf: "{spark.sql.shuffle.partitions: '4000', spark.executor.memory: '16g', spark.sql.files.maxPartitionBytes: '25000000', spark.executor.cores: '2'}"
+      +step.session.extended_spark_conf: "{spark.executor.memory: '25g',spark.executor.memoryOverhead: '1g', spark.executor.cores: '4'}"
+      step.session.write_mode: overwrite
 
   - id: colocalisation_ecaviar
     prerequisites:
       - variant_index
+      - colocalisation_coloc
     params:
       step: colocalisation
       step.credible_set_path: '{release_dir}/credible_set'
       step.coloc_path: '{release_dir}/colocalisation'
       step.colocalisation_method: ECaviar
-      +step.session.extended_spark_conf: "{spark.sql.shuffle.partitions: '4000', spark.executor.memory: '25g', spark.sql.files.maxPartitionBytes: '25000000', spark.executor.cores: '4'}"
+      +step.session.extended_spark_conf: "{spark.executor.memory: '25g', spark.executor.memoryOverhead: '1g', spark.executor.cores: '4'}"
+      step.session.write_mode: overwrite
 
   - id: l2g_feature_matrix
     prerequisites:
@@ -191,62 +197,62 @@ nodes:
       +step.session.extended_spark_conf: "{spark.sql.autoBroadcastJoinThreshold:'-1'}"
       step.session.write_mode: overwrite
 
-# - id: l2g_train
-#   prerequisites:
-#     - l2g_feature_matrix
-#   params:
-#     step: locus_to_gene
-#     step.run_mode: train
-#     step.wandb_run_name: 24.11_freeze10
-#     step.hf_hub_repo_id: opentargets/locus_to_gene
-#     step.hf_model_commit_message: 'chore: update model based on 24.11_freeze10 run'
-#     step.model_path: '{release_dir}/locus_to_gene_model/classifier.skops'
-#     step.credible_set_path: '{release_dir}/credible_set'
-#     step.variant_index_path: '{release_dir}/variant_index'
-#     step.feature_matrix_path: '{release_dir}/locus_to_gene_feature_matrix'
-#     step.gold_standard_curation_path: gs://genetics_etl_python_playground/input/l2g/gold_standard/curation.json
-#     step.gene_interactions_path: gs://genetics_etl_python_playground/static_assets/interaction # OTP 23.12 data
-#     step.hyperparameters.n_estimators: 100
-#     step.hyperparameters.max_depth: 5
-#     step.hyperparameters.loss: log_loss
-#     +step.session.extended_spark_conf: "{spark.kryoserializer.buffer.max:500m, spark.sql.autoBroadcastJoinThreshold:'-1'}"
+  - id: l2g_train
+    prerequisites:
+      - l2g_feature_matrix
+    params:
+      step: locus_to_gene
+      step.run_mode: train
+      step.wandb_run_name: 24.11_freeze10
+      step.hf_hub_repo_id: opentargets/locus_to_gene
+      step.hf_model_commit_message: 'chore: update model based on 24.11_freeze10 run'
+      step.model_path: '{release_dir}/locus_to_gene_model/classifier.skops'
+      step.credible_set_path: '{release_dir}/credible_set'
+      step.variant_index_path: '{release_dir}/variant_index'
+      step.feature_matrix_path: '{release_dir}/locus_to_gene_feature_matrix'
+      step.gold_standard_curation_path: gs://genetics_etl_python_playground/input/l2g/gold_standard/curation.json
+      step.gene_interactions_path: gs://genetics_etl_python_playground/static_assets/interaction # OTP 23.12 data
+      step.hyperparameters.n_estimators: 100
+      step.hyperparameters.max_depth: 5
+      step.hyperparameters.loss: log_loss
+      +step.session.extended_spark_conf: "{spark.kryoserializer.buffer.max:500m, spark.sql.autoBroadcastJoinThreshold:'-1'}"
 
-# - id: l2g_predict
-#   prerequisites:
-#     - l2g_train
-#   params:
-#     step: locus_to_gene
-#     step.run_mode: predict
-#     step.predictions_path: '{release_dir}/locus_to_gene_predictions'
-#     step.feature_matrix_path: '{release_dir}/locus_to_gene_feature_matrix'
-#     step.credible_set_path: '{release_dir}/credible_set'
-#     step.download_from_hub: false
-#     step.l2g_threshold: 0.05
-#     step.model_path: gs://ot_orchestration/benchmarks/l2g/fm0/v5.1_best_cv/locus_to_gene_model/classifier.skops
-#     step.hf_hub_repo_id: opentargets/locus_to_gene
-#     step.session.write_mode: overwrite
+  - id: l2g_predict
+    prerequisites:
+      - l2g_train
+    params:
+      step: locus_to_gene
+      step.run_mode: predict
+      step.predictions_path: '{release_dir}/locus_to_gene_predictions'
+      step.feature_matrix_path: '{release_dir}/locus_to_gene_feature_matrix'
+      step.credible_set_path: '{release_dir}/credible_set'
+      step.download_from_hub: false
+      step.l2g_threshold: 0.05
+      step.model_path: gs://ot_orchestration/benchmarks/l2g/fm0/v5.1_best_cv/locus_to_gene_model/classifier.skops
+      step.hf_hub_repo_id: opentargets/locus_to_gene
+      step.session.write_mode: overwrite
 
-# - id: l2g_evidence
-#   prerequisites:
-#     - l2g_predict
-#   params:
-#     step: locus_to_gene_evidence
-#     step.evidence_output_path: '{release_dir}/locus_to_gene_evidence
-#     step.locus_to_gene_predictions_path: '{release_dir}/locus_to_gene_predictions
-#     step.credible_set_path: '{release_dir}/credible_set
-#     step.study_index_path: '{release_dir}/study_index
-#     step.locus_to_gene_threshold: 0.05
-#     step.session.write_mode: overwrite
+  - id: l2g_evidence
+    prerequisites:
+      - l2g_predict
+    params:
+      step: locus_to_gene_evidence
+      step.evidence_output_path: '{release_dir}/locus_to_gene_evidence'
+      step.locus_to_gene_predictions_path: '{release_dir}/locus_to_gene_predictions'
+      step.credible_set_path: '{release_dir}/credible_sets/'
+      step.study_index_path: '{release_dir}/study_index'
+      step.locus_to_gene_threshold: 0.05
+      step.session.write_mode: overwrite
 
-# - id: l2g_associations
-#   params:
-#     step: locus_to_gene_associations
-#     step.evidence_input_path: '{release_dir}/locus_to_gene_evidence
-#     step.disease_index_path: gs://open-targets-pre-data-releases/24.06/output/etl/parquet/diseases
-#     step.direct_associations_output_path: '{release_dir}/locus_to_gene_associations/direct_associations
-#     step.indirect_associations_output_path: '{release_dir}/locus_to_gene_associations/indirect_associations
-#     step.session.spark_uri: yarn
-#     step.session.write_mode: overwrite
+  - id: l2g_associations
+    params:
+      step: locus_to_gene_associations
+      step.evidence_input_path: '{release_dir}/locus_to_gene_evidence'
+      step.disease_index_path: '{output_path}/etl/parquet/diseases'
+      step.direct_associations_output_path: '{release_dir}/locus_to_gene_associations/direct_associations'
+      step.indirect_associations_output_path: '{release_dir}/locus_to_gene_associations/indirect_associations'
+      step.session.spark_uri: yarn
+      step.session.write_mode: overwrite
 
-#   prerequisites:
-#     - l2g_evidence
+    prerequisites:
+      - l2g_evidence

--- a/src/ot_orchestration/dags/config/genetics_etl.yaml
+++ b/src/ot_orchestration/dags/config/genetics_etl.yaml
@@ -3,12 +3,12 @@
 environment_specs:
   - name: Staging
     vars:
-      gentropy_ref: 2.0.2-rc4
+      gentropy_ref: 2.0.2-rc.4
       release_dir: gs://ot_orchestration/releases/25.02_freeze1
-      input_dir: gs://open-targets-pre-data-releases/24.06dev-test/input
+      input_dir: gs://open-targets-pre-data-releases/24.12-uo_test-3/input
       # NOTE: Patched target index is required, as existing target index does not contain all columns requested by the original gene index - see https://github.com/opentargets/gentropy/pull/946
       target_index: gs://ot-team/vivien/gentropy_patched_datasets/target_index_with_tss_column
-      output_path: gs://open-targets-pre-data-releases/24.06dev-test/output
+      output_path: gs://open-targets-pre-data-releases/24.12-uo_test-3/output
 
       # data buckets
       gc_susie: gs://gwas_catalog_sumstats_susie
@@ -16,14 +16,14 @@ environment_specs:
       top_hits: gs://gwas_catalog_top_hits
       eqtl: gs://eqtl_catalogue_data
       ukb: gs://ukb_ppp_eur_data
-      finngen: gs://ginngen_data/r12
+      finngen: gs://finngen_data/r12
       gnomad: gs://gnomad_data_2
 env: Staging
 
 l2g_gold_standard_path: gs://genetics_etl_python_playground/input/l2g/gold_standard/curation.json
 dataproc:
   cluster_metadata:
-    GENTROPY_REF: v'{gentropy_ref}'
+    GENTROPY_REF: 'v{gentropy_ref}'
   cluster_name: otg-etl
   autoscaling_policy: otg-etl
 
@@ -37,6 +37,7 @@ nodes:
       step.uberon_input_path: '{input_dir}/biosamples/uberon.json'
       step.efo_input_path: '{input_dir}/biosamples/efo.json'
       step.biosample_index_path: '{release_dir}/biosample_index'
+      step.session.write_mode: overwrite
   - id: study_validation
     kind: Task
     prerequisites:
@@ -45,7 +46,7 @@ nodes:
       step: study_validation
       step.study_index_path:
         - '{top_hits}/study_index'
-        - '{gc_susie_bucket}/study_index'
+        - '{gc_susie}/study_index'
         - '{gc_pics}/study_index'
         - '{eqtl}/study_index'
         - '{ukb}/study_index'
@@ -79,9 +80,11 @@ nodes:
         - '{gc_susie}/credible_set_clean/20250204/'
         - '{eqtl}/credible_set_datasets/eqtl_catalogue_susie_patched_v2/'
         - '{ukb}/credible_set_clean/20250129/'
-        - '{finngen}/r12/credible_set_datasets/susie/'
+        - '{finngen}/credible_set_datasets/susie/'
       step.valid_study_locus_path: '{release_dir}/credible_set'
       step.invalid_study_locus_path: '{release_dir}/invalid_credible_set'
+      step.target_index_path: '{target_index}'
+      step.trans_qtl_threshold: 5_000_000
       step.invalid_qc_reasons:
         - DUPLICATED_STUDYLOCUS_ID
         - AMBIGUOUS_STUDY

--- a/src/ot_orchestration/dags/genetics_etl.py
+++ b/src/ot_orchestration/dags/genetics_etl.py
@@ -18,14 +18,12 @@ from ot_orchestration.utils import (
     find_node_in_config,
     read_yaml_config,
 )
-from ot_orchestration.utils.common import (
-    shared_dag_args,
-    shared_dag_kwargs,
-)
+from ot_orchestration.utils.common import shared_dag_args, shared_dag_kwargs
 from ot_orchestration.utils.dataproc import (
     generate_dataproc_task_chain,
     submit_gentropy_step,
 )
+from ot_orchestration.utils.labels import GentropyDagLabels
 
 SOURCE_CONFIG_FILE_PATH = Path(__file__).parent / "config" / "genetics_etl.yaml"
 config = read_yaml_config(SOURCE_CONFIG_FILE_PATH)
@@ -42,7 +40,7 @@ with DAG(
     description="Open Targets Genetics ETL workflow",
     default_args=shared_dag_args,
     **shared_dag_kwargs,
-):
+) as genetics_etl_dag:
     with TaskGroup(group_id="genetics_etl") as genetics_etl:
         task_config = find_node_in_config(nodes, "variant_annotation")
         if task_config:
@@ -74,4 +72,5 @@ with DAG(
         generate_dataproc_task_chain(
             tasks=list(node_map.values()),
             **config["dataproc"],
+            labels=GentropyDagLabels(gentropy_dag="genetics_etl", run_id="airflow"),
         )


### PR DESCRIPTION
# Context

## Changes implemented to run the colocalisation steps:

- [efm mode](https://cloud.google.com/dataproc/docs/concepts/configuring-clusters/enhanced-flexibility-mode)
- 20x primary workers to keep the cache allocated
- Change to `otg_efm` allocation policy to allow for 20 primary workers

## Fixes 

- config typos


> [!NOTE] 
> The colocalisation steps will be run in a separate cluster (pending changes)