### PR TITLE
feat: changes for the unified pipeline run in gentropy part 

### DIFF
--- a/src/ot_orchestration/dags/config/cluster_registry.py
+++ b/src/ot_orchestration/dags/config/cluster_registry.py
@@ -1,0 +1,74 @@
+"""Module defining common logic to build multiple cluster definitions for a single part of the unified pipeline."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from airflow.providers.google.cloud.operators.dataproc import (
+    DataprocCreateClusterOperator,
+    DataprocDeleteClusterOperator,
+)
+from ot_orchestration.utils.common import GCP_PROJECT_PLATFORM
+from ot_orchestration.utils.dataproc import create_cluster, delete_cluster
+from ot_orchestration.utils.utils import create_cluster_name
+
+
+@dataclass
+class Cluster:
+    """Box class to store the tasks to build the dataproc cluster and the reference to it's name."""
+
+    create: DataprocCreateClusterOperator
+    delete: DataprocDeleteClusterOperator
+    name: str
+
+
+class ClusterRegistry:
+    """CLuster registry object.
+
+    This registry allows to build a dictionary of DataprocClusterOperator tasks:
+     -  `DataprocCreateClusterOperator`
+     -  `DataprocDeleteClusterOperator`
+    """
+
+    def __init__(self):
+        self.clusters: dict[str, Cluster] = {}
+
+    def _add_cluster(self, cluster_settings: dict):
+        """Method to add cluster tasks to the cluster registry.
+
+        The original name of the cluster - `cluster_name` is used as a key for the registry,
+        the actual `cluster_name` is defined at a runtime with the `clean_cluster_name` function.
+        """
+        cluster_name = cluster_settings["cluster_name"]
+        if not self.clusters.get(cluster_name):
+            clean_name = create_cluster_name(cluster_name)
+            cluster_settings.update({"cluster_name": clean_name})
+            c = create_cluster(
+                task_id=f"create_{cluster_name}",
+                project_id=GCP_PROJECT_PLATFORM,
+                **cluster_settings,
+            )
+            d = delete_cluster(
+                task_id=f"delete_{cluster_name}",
+                cluster_name=clean_name,
+                project_id=GCP_PROJECT_PLATFORM,
+            )
+            self.clusters[cluster_name] = Cluster(create=c, delete=d, name=clean_name)
+        return self
+
+    @classmethod
+    def from_dataproc_cluster_settings(cls, dataproc_cluster_settings: list[dict]) -> ClusterRegistry:
+        """Build the cluster registry directly from the unified pipeline configuration.
+
+        Args:
+            dataproc_cluster_settings (list[dict]): reference to the unified pipeline configuration.
+
+        Returns:
+            ClusterRegistry: the registry with clusters defined in the dataproc_cluster_settings
+
+
+        """
+        registry = cls()
+        for cluster_settings in dataproc_cluster_settings:
+            registry._add_cluster(cluster_settings)
+        return registry

--- a/src/ot_orchestration/dags/config/gentropy.yaml
+++ b/src/ot_orchestration/dags/config/gentropy.yaml
@@ -210,13 +210,13 @@ steps:
       step.hf_hub_repo_id: opentargets/locus_to_gene
       step.hf_model_commit_message: 'chore: update model base model for {l2g_training} run'
       # INPUTS
-      step.credible_set_path: '{release_dir}/output/credible_set'
-      step.variant_index_path: '{release_dir}/output/variant'
-      step.feature_matrix_path: '{release_dir}/output/l2g_feature_matrix'
-      step.gold_standard_curation_path: '{release_dir}/inputs/l2g/gold_standard.json'
-      step.gene_interactions_path: '{release_dir}/output/interaction'
+      step.credible_set_path: '{release_uri}/output/credible_set'
+      step.variant_index_path: '{release_uri}/output/variant'
+      step.feature_matrix_path: '{release_uri}/output/l2g_feature_matrix'
+      step.gold_standard_curation_path: '{release_uri}/inputs/l2g/gold_standard.json'
+      step.gene_interactions_path: '{release_uri}/output/interaction'
       # OUTPUTS
-      step.model_path: '{release_dir}/etc/models/locus_to_gene_model/classifier.skops'
+      step.model_path: '{release_uri}/etc/models/locus_to_gene_model/classifier.skops'
 
   l2g_prediction:
     cluster_name: otg-etl
@@ -231,7 +231,7 @@ steps:
       # INPUTS
       step.feature_matrix_path: '{release_uri}/output/l2g_feature_matrix'
       step.credible_set_path: '{release_uri}/output/credible_set'
-      step.model_path: '{release_dir}/etc/models/locus_to_gene_model/classifier.skops'
+      step.model_path: '{release_uri}/etc/models/locus_to_gene_model/classifier.skops'
       # OUTPUTS
       step.predictions_path: '{release_uri}/output/l2g_prediction'
 

--- a/src/ot_orchestration/dags/config/gentropy.yaml
+++ b/src/ot_orchestration/dags/config/gentropy.yaml
@@ -4,14 +4,14 @@ dataproc_cluster_settings:
 
   - cluster_name: otg-etl
     cluster_metadata:
-      GENTROPY_REF: '{gentropy_version}'
+      GENTROPY_REF: 'v{gentropy_version}'
     autoscaling_policy: otg-etl
     num_workers: 2
     idle_delete_ttl: 3600 # in seconds
 
   - cluster_name: otg-etl-coloc
     cluster_metadata:
-      GENTROPY_REF: '{gentropy_version}'
+      GENTROPY_REF: 'v{gentropy_version}'
     autoscaling_policy: otg-efm
     worker_machine_type: n1-highmem-32
     num_workers: 20
@@ -129,7 +129,7 @@ steps:
         max_run_duration: '2h'
       policy_specs:
         machine_type: n1-standard-4
-      image: europe-west1-docker.pkg.dev/open-targets-genetics-dev/gentropy-app/custom_ensembl_vep:v{vep_version}
+      image: europe-west1-docker.pkg.dev/open-targets-genetics-dev/gentropy-app/custom_ensembl_vep:{vep_version}
       entrypoint: /bin/sh
     params:
       # INPUTS

--- a/src/ot_orchestration/dags/config/gentropy.yaml
+++ b/src/ot_orchestration/dags/config/gentropy.yaml
@@ -1,7 +1,5 @@
 ---
 
-python_main_module: gs://genetics_etl_python_playground/initialisation/cli.py
-
 dataproc_cluster_settings:
 
   - cluster_name: otg-etl
@@ -150,10 +148,9 @@ steps:
       step.vep_output_json_path: '{release_uri}/intermediate/variant_annotation'
       step.variant_annotations_path:
         - gs://gnomad_data_2/v4.1/variant_index
-        - gs://otar013-ppp/OTAR2075_lof_curation/lof_curation_variant_annotations
-      # TODO: Temporary disabled until gnetropy is updated
-      # step.amino_acid_change_annotations:
-      #   - gs://genetics_etl_python_playground/static_assets/foldx_variant_annotation
+      # - gs://otar013-ppp/OTAR2075_lof_curation/lof_curation_variant_annotations # PPP ONLY!
+      step.amino_acid_change_annotations:
+        - gs://otar013-ppp/OTAR2081_foldx/foldx_variant_annotation
       # OUTPUTS
       step.variant_index_path: '{release_uri}/output/variant'
 
@@ -165,7 +162,7 @@ steps:
       step.session.output_partitions: 25
       step.colocalisation_method: Coloc
       +step.colocalisation_method_params: '{priorc1: 1e-4, priorc2: 1e-4, priorc12: 1e-5}'
-      +step.session.extended_spark_conf: "{spark.sql.shuffle.partitions: '4000', spark.executor.memory: '25g', spark.sql.files.maxPartitionBytes: '25000000', spark.executor.cores: '4'}"
+      +step.session.extended_spark_conf: "{spark.executor.memory: '25g', spark.executor.memoryOverhead: '1g', spark.executor.cores: '4'}"
       # INPUTS
       step.credible_set_path: '{release_uri}/output/credible_set'
       # OUTPUTS
@@ -178,7 +175,7 @@ steps:
       step.session.write_mode: ignore
       step.session.output_partitions: 25
       step.colocalisation_method: ECaviar
-      +step.session.extended_spark_conf: "{spark.sql.shuffle.partitions: '4000', spark.executor.memory: '25g', spark.sql.files.maxPartitionBytes: '25000000', spark.executor.cores: '4'}"
+      +step.session.extended_spark_conf: "{spark.executor.memory: '25g', spark.executor.memoryOverhead: '1g', spark.executor.cores: '4'}"
       # INPUTS
       step.credible_set_path: '{release_uri}/output/credible_set'
       # OUTPUTS
@@ -199,6 +196,28 @@ steps:
       # OUTPUTS
       step.feature_matrix_path: '{release_uri}/output/l2g_feature_matrix'
 
+  l2g_training:
+    cluster_name: otg-etl
+    params:
+      step: locus_to_gene
+      step.session.write_mode: ignore
+      +step.session.extended_spark_conf: "{spark.kryoserializer.buffer.max:500m, spark.sql.autoBroadcastJoinThreshold:'-1'}"
+      step.run_mode: train
+      step.hyperparameters.n_estimators: 100
+      step.hyperparameters.max_depth: 5
+      step.hyperparameters.loss: log_loss
+      step.wandb_run_name: '{l2g_training}'
+      step.hf_hub_repo_id: opentargets/locus_to_gene
+      step.hf_model_commit_message: 'chore: update model base model for {l2g_training} run'
+      # INPUTS
+      step.credible_set_path: '{release_dir}/output/credible_set'
+      step.variant_index_path: '{release_dir}/output/variant'
+      step.feature_matrix_path: '{release_dir}/output/l2g_feature_matrix'
+      step.gold_standard_curation_path: '{release_dir}/inputs/l2g/gold_standard.json'
+      step.gene_interactions_path: '{release_dir}/output/interaction'
+      # OUTPUTS
+      step.model_path: '{release_dir}/etc/models/locus_to_gene_model/classifier.skops'
+
   l2g_prediction:
     cluster_name: otg-etl
     params:
@@ -207,12 +226,12 @@ steps:
       step.session.output_partitions: 1
       step.run_mode: predict
       step.l2g_threshold: 0.05
-      # INPUTS
       step.download_from_hub: false
       step.hf_hub_repo_id: opentargets/locus_to_gene
+      # INPUTS
       step.feature_matrix_path: '{release_uri}/output/l2g_feature_matrix'
       step.credible_set_path: '{release_uri}/output/credible_set'
-      step.model_path: '{release_uri}/input/l2g_prediction/classifier.skops'
+      step.model_path: '{release_dir}/etc/models/locus_to_gene_model/classifier.skops'
       # OUTPUTS
       step.predictions_path: '{release_uri}/output/l2g_prediction'
 
@@ -225,6 +244,6 @@ steps:
       # INPUTS
       step.credible_set_path: '{release_uri}/output/credible_set'
       step.locus_to_gene_predictions_path: '{release_uri}/output/l2g_prediction'
-      step.study_index_path: '{release_uri}/output/genetics/parquet/study_index'
+      step.study_index_path: '{release_uri}/output/study_index'
       # OUTPUTS
       step.evidence_output_path: '{release_uri}/intermediate/evidence/gentropy'

--- a/src/ot_orchestration/dags/config/gentropy.yaml
+++ b/src/ot_orchestration/dags/config/gentropy.yaml
@@ -54,7 +54,7 @@ steps:
         - gs://gwas_catalog_sumstats_pics/study_index
         - gs://eqtl_catalogue_data/study_index
         - gs://ukb_ppp_eur_data/study_index
-        - gs://finngen_data/r11/study_index
+        - gs://finngen_data/r12/study_index
       step.target_index_path: '{release_uri}/output/target'
       step.disease_index_path: '{release_uri}/output/disease'
       step.biosample_index_path: '{release_uri}/output/biosample'
@@ -85,15 +85,17 @@ steps:
         - INVALID_VARIANT_IDENTIFIER
         - INVALID_CHROMOSOME
         - TOP_HIT_AND_SUMMARY_STATS
+      step.trans_qtl_threshold: 5_000_000
       # INPUTS
       step.study_locus_path:
         - gs://gwas_catalog_top_hits/credible_sets/
         - gs://gwas_catalog_sumstats_pics/credible_sets/
         - gs://gwas_catalog_sumstats_susie/credible_set_clean/20250204/
-        - gs://eqtl_catalogue_data/credible_set_datasets/eqtl_catalogue_susie_patched/
+        - gs://eqtl_catalogue_data/credible_set_datasets/eqtl_catalogue_susie_patched_v2/
         - gs://ukb_ppp_eur_data/credible_set_clean/20250129/
-        - gs://finngen_data/r11/credible_set_datasets/susie/
+        - gs://finngen_data/r12/credible_set_datasets/susie/
       step.study_index_path: '{release_uri}/output/study'
+      step.target_index_path: '{release_uri}/output/target'
       # OUTPUTS
       step.valid_study_locus_path: '{release_uri}/output/credible_set'
       step.invalid_study_locus_path: '{release_uri}/log/credible_set_failed'

--- a/src/ot_orchestration/dags/config/gentropy.yaml
+++ b/src/ot_orchestration/dags/config/gentropy.yaml
@@ -3,15 +3,25 @@
 python_main_module: gs://genetics_etl_python_playground/initialisation/cli.py
 
 dataproc_cluster_settings:
-  cluster_metadata:
-    GENTROPY_REF: '{gentropy_version}'
-  cluster_init_script: gs://genetics_etl_python_playground/initialisation/install_dependencies_on_cluster.sh
-  autoscaling_policy: otg-etl
-  allow_efm: false
-  num_workers: 2
+
+  - cluster_name: otg-etl
+    cluster_metadata:
+      GENTROPY_REF: '{gentropy_version}'
+    autoscaling_policy: otg-etl
+    num_workers: 2
+    idle_delete_ttl: 3600 # in seconds
+
+  - cluster_name: otg-etl-coloc
+    cluster_metadata:
+      GENTROPY_REF: '{gentropy_version}'
+    autoscaling_policy: otg-efm
+    worker_machine_type: n1-highmem-32
+    num_workers: 20
+    allow_efm: true
 
 steps:
   biosample:
+    cluster_name: otg-etl
     params:
       step: biosample_index
       step.session.write_mode: ignore
@@ -24,6 +34,7 @@ steps:
       step.biosample_index_path: '{release_uri}/output/biosample'
 
   study:
+    cluster_name: otg-etl
     params:
       step: study_validation
       step.session.write_mode: ignore
@@ -54,6 +65,7 @@ steps:
       step.invalid_study_index_path: '{release_uri}/log/study_failed'
 
   credible_set:
+    cluster_name: otg-etl
     params:
       step: credible_set_validation
       step.session.write_mode: ignore
@@ -89,6 +101,7 @@ steps:
       step.invalid_study_locus_path: '{release_uri}/log/credible_set_failed'
 
   variant_partition:
+    cluster_name: otg-etl
     params:
       step: variant_to_vcf
       step.partition_size: 2_000 # approximate num of variants per partition!
@@ -128,6 +141,7 @@ steps:
       vep_output_path: '{release_uri}/intermediate/variant_annotation'
 
   variant:
+    cluster_name: otg-etl
     params:
       step: variant_index
       step.session.write_mode: ignore
@@ -144,6 +158,7 @@ steps:
       step.variant_index_path: '{release_uri}/output/variant'
 
   colocalisation_coloc:
+    cluster_name: otg-etl-coloc
     params:
       step: colocalisation
       step.session.write_mode: ignore
@@ -157,6 +172,7 @@ steps:
       step.coloc_path: '{release_uri}/output/colocalisation'
 
   colocalisation_ecaviar:
+    cluster_name: otg-etl-coloc
     params:
       step: colocalisation
       step.session.write_mode: ignore
@@ -169,6 +185,7 @@ steps:
       step.coloc_path: '{release_uri}/output/colocalisation'
 
   l2g_feature_matrix:
+    cluster_name: otg-etl
     params:
       step: locus_to_gene_feature_matrix
       step.session.write_mode: ignore
@@ -183,6 +200,7 @@ steps:
       step.feature_matrix_path: '{release_uri}/output/l2g_feature_matrix'
 
   l2g_prediction:
+    cluster_name: otg-etl
     params:
       step: locus_to_gene
       step.session.write_mode: ignore
@@ -199,6 +217,7 @@ steps:
       step.predictions_path: '{release_uri}/output/l2g_prediction'
 
   l2g_evidence:
+    cluster_name: otg-etl
     params:
       step: locus_to_gene_evidence
       step.session.write_mode: ignore

--- a/src/ot_orchestration/dags/config/gentropy.yaml
+++ b/src/ot_orchestration/dags/config/gentropy.yaml
@@ -216,7 +216,7 @@ steps:
       step.gold_standard_curation_path: '{release_uri}/inputs/l2g/gold_standard.json'
       step.gene_interactions_path: '{release_uri}/output/interaction'
       # OUTPUTS
-      step.model_path: '{release_uri}/etc/models/locus_to_gene_model/classifier.skops'
+      step.model_path: '{release_uri}/etc/model/locus_to_gene_model/classifier.skops'
 
   l2g_prediction:
     cluster_name: otg-etl
@@ -231,7 +231,7 @@ steps:
       # INPUTS
       step.feature_matrix_path: '{release_uri}/output/l2g_feature_matrix'
       step.credible_set_path: '{release_uri}/output/credible_set'
-      step.model_path: '{release_uri}/etc/models/locus_to_gene_model/classifier.skops'
+      step.model_path: '{release_uri}/etc/model/locus_to_gene_model/classifier.skops'
       # OUTPUTS
       step.predictions_path: '{release_uri}/output/l2g_prediction'
 

--- a/src/ot_orchestration/dags/config/pis.yaml
+++ b/src/ot_orchestration/dags/config/pis.yaml
@@ -211,6 +211,11 @@ steps:
       source: http://purl.obolibrary.org/obo/go.obo
       destination: go/go.obo
 
+  gold_standard:
+    - name: download L2G gold standard
+      source: gs://genetics-portal-dev-analysis/xg1/L2G_intervals/training_set_v5_1_efo.json
+      destination: l2g/gold_standard.json
+
   interaction:
     - name: download ensembl interactions grch38
       source: https://ftp.ensembl.org/pub/release-${ensembl_version}/gtf/homo_sapiens/Homo_sapiens.GRCh38.${ensembl_version}.chr.gtf.gz
@@ -227,11 +232,6 @@ steps:
     - name: download_latest string interactions
       source: gs://otar001-core/stringInteractions
       destination: interaction/string-interactions.txt.gz
-
-  l2g_prediction:
-    - name: download model
-      source: gs://ot_orchestration/benchmarks/l2g/fm0/v5.1_best_cv/locus_to_gene_model/classifier.skops
-      destination: l2g_prediction/classifier.skops
 
   literature:
     - name: download literature

--- a/src/ot_orchestration/dags/config/pis.yaml
+++ b/src/ot_orchestration/dags/config/pis.yaml
@@ -211,7 +211,7 @@ steps:
       source: http://purl.obolibrary.org/obo/go.obo
       destination: go/go.obo
 
-  gold_standard:
+  l2g_gold_standard:
     - name: download L2G gold standard
       source: gs://genetics-portal-dev-analysis/xg1/L2G_intervals/training_set_v5_1_efo.json
       destination: l2g/gold_standard.json

--- a/src/ot_orchestration/dags/config/unified_pipeline.py
+++ b/src/ot_orchestration/dags/config/unified_pipeline.py
@@ -85,11 +85,11 @@ class UnifiedPipelineConfig:
 
         # GENTROPY-specific settings.
         self.gentropy_version = settings["gentropy_version"]
+        self.l2g_training = settings["l2g_training"]
         self.vep_version = settings["vep_version"]
         self.gentropy_config = self.init_gentropy_settings()
         self.gentropy_dataproc_cluster_settings = self.gentropy_config["dataproc_cluster_settings"]
         self.gentropy_step_list = [s for s in settings["steps"].keys() if s.startswith("gentropy_")]
-        self.gentropy_python_main_module = self.gentropy_config["python_main_module"]
 
     def pis_config_uri(self, step_name: str) -> str:
         """Return the google cloud url of the PIS configuration file for a step."""
@@ -156,6 +156,7 @@ class UnifiedPipelineConfig:
         return read_yaml_config(
             self.gentropy_config_local_path,
             sentinels={
+                "l2g_training": self.l2g_training,
                 "release_uri": self.release_uri,
                 "gentropy_version": self.gentropy_version,
                 "vep_version": self.vep_version,

--- a/src/ot_orchestration/dags/config/unified_pipeline.yaml
+++ b/src/ot_orchestration/dags/config/unified_pipeline.yaml
@@ -43,7 +43,7 @@ steps:
     ppp_only: true
   pis_expression:
   pis_go:
-  pis_gold_standard:
+  pis_l2g_gold_standard:
   pis_interaction:
   pis_literature:
   pis_openfda:
@@ -204,7 +204,7 @@ steps:
       - gentropy_credible_set
       - gentropy_variant
       - gentropy_l2g_feature_matrix
-      - pis_gold_standard
+      - pis_l2g_gold_standard
       - etl_interaction
 
   gentropy_l2g_prediction:

--- a/src/ot_orchestration/dags/config/unified_pipeline.yaml
+++ b/src/ot_orchestration/dags/config/unified_pipeline.yaml
@@ -10,6 +10,7 @@ vep_version: '2.0.1'
 chembl_version: '35'
 efo_version: '3.71.0'
 ensembl_version: '113'
+l2g_training: '2025-02'
 
 is_ppp: false
 
@@ -42,6 +43,7 @@ steps:
     ppp_only: true
   pis_expression:
   pis_go:
+  pis_gold_standard:
   pis_interaction:
   pis_literature:
   pis_openfda:
@@ -197,9 +199,16 @@ steps:
       - gentropy_colocalisation_ecaviar
       - gentropy_variant
 
+  gentropy_l2g_training:
+    depends_on:
+      - gentropy_credible_set
+      - gentropy_variant
+      - gentropy_l2g_feature_matrix
+      - pis_gold_standard
+      - etl_interaction
+
   gentropy_l2g_prediction:
     depends_on:
-      - etl_interaction
       - gentropy_l2g_feature_matrix
 
   gentropy_l2g_evidence:

--- a/src/ot_orchestration/dags/config/unified_pipeline.yaml
+++ b/src/ot_orchestration/dags/config/unified_pipeline.yaml
@@ -210,6 +210,7 @@ steps:
   gentropy_l2g_prediction:
     depends_on:
       - gentropy_l2g_feature_matrix
+      - gentropy_l2g_training
 
   gentropy_l2g_evidence:
     depends_on:

--- a/src/ot_orchestration/dags/unified_pipeline.py
+++ b/src/ot_orchestration/dags/unified_pipeline.py
@@ -250,6 +250,10 @@ with DAG(
     # ==============================================================================================
     # Gentropy stage of the DAG.
     #
+    # The process parses the list of dataproc_cluster_settings found in the gentropy.yaml
+    # to obtain all clusters required by the steps, then based on the `cluster_name` defined
+    # in each step it assigns the gentropy step to a correct cluster.
+    #
     # c. Prepare the Gentropy Dataproc cluster.
     # r. The Gentropy steps are run in parallel, as their prerequisites are met.
     #       There are different types of Gentropy steps. We match special cases by
@@ -262,22 +266,26 @@ with DAG(
     #       management functions into operators.
     # ==============================================================================================
     if len(config.gentropy_step_list):
-        # Split the tasks into separate task groups
         clusters = {}
         for cluster_settings in config.gentropy_dataproc_cluster_settings:
             name = cluster_settings["cluster_name"]
             clean_name = create_cluster_name(name)
-            # update the cluster settings,
-            # the name of the cluster must be adjusted to match the clean name
+            # The name of the cluster must be adjusted to match the clean name
             cluster_settings["cluster_name"] = clean_name
             create_cluster_task_id = f"create_{name}_cluster"
             delete_cluster_task_id = f"delete_{name}_cluster"
-            # Collect all clusters by their original names, so they can be
-            # referenced by the steps config.
+            # Collect all cluster_create tasks by the original cluster names, so they can be
+            # referenced by the step `cluster_name` config.
+            labels = StepLabels(
+                "gentropy",
+                step_name="create_cluster",
+                is_ppp=config.is_ppp,
+            )
             clusters[name] = {}
             clusters[name]["create"] = create_cluster(
                 task_id=create_cluster_task_id,
                 project_id=GCP_PROJECT_PLATFORM,
+                labels=labels,
                 **cluster_settings,
             )
             clusters[name]["delete"] = delete_cluster(
@@ -318,7 +326,6 @@ with DAG(
 
                 steps[step_name] = r
                 if r not in clusterless_steps:
-                    # print(clusters[step_config])
                     c = clusters[step_config["cluster_name"]]["create"]
                     d = clusters[step_config["cluster_name"]]["delete"]
                     chain(c, r, d)

--- a/src/ot_orchestration/dags/unified_pipeline.py
+++ b/src/ot_orchestration/dags/unified_pipeline.py
@@ -16,6 +16,7 @@ from airflow.providers.google.cloud.operators.dataproc import (
 from airflow.utils.edgemodifier import Label
 from airflow.utils.trigger_rule import TriggerRule
 
+from ot_orchestration.dags.config.cluster_registry import ClusterRegistry
 from ot_orchestration.dags.config.unified_pipeline import (
     UnifiedPipelineConfig,
 )
@@ -41,8 +42,6 @@ from ot_orchestration.utils.common import (
     unified_pipeline_dag_kwargs,
 )
 from ot_orchestration.utils.dataproc import (
-    create_cluster,
-    delete_cluster,
     submit_gentropy_step,
 )
 from ot_orchestration.utils.labels import StepLabels
@@ -266,37 +265,8 @@ with DAG(
     #       management functions into operators.
     # ==============================================================================================
     if len(config.gentropy_step_list):
-        clusters = {}
-        for cluster_settings in config.gentropy_dataproc_cluster_settings:
-            name = cluster_settings["cluster_name"]
-            clean_name = create_cluster_name(name)
-            # The name of the cluster must be adjusted to match the clean name
-            cluster_settings["cluster_name"] = clean_name
-            create_cluster_task_id = f"create_{name}_cluster"
-            delete_cluster_task_id = f"delete_{name}_cluster"
-            # Collect all cluster_create tasks by the original cluster names, so they can be
-            # referenced by the step `cluster_name` config.
-            labels = StepLabels(
-                "gentropy",
-                step_name="create_cluster",
-                is_ppp=config.is_ppp,
-            )
-            clusters[name] = {}
-            clusters[name]["create"] = create_cluster(
-                task_id=create_cluster_task_id,
-                project_id=GCP_PROJECT_PLATFORM,
-                labels=labels,
-                **cluster_settings,
-            )
-            clusters[name]["delete"] = delete_cluster(
-                task_id=delete_cluster_task_id,
-                project_id=GCP_PROJECT_PLATFORM,
-                cluster_name=cluster_settings["cluster_name"],
-            )
-            clusters[name]["create_id"] = create_cluster_task_id
-            clusters[name]["delete_id"] = delete_cluster_task_id
-
         clusterless_steps = []
+        cluster_registry = ClusterRegistry.from_dataproc_cluster_settings(config.gentropy_dataproc_cluster_settings)
 
         @task_group(group_id="gentropy_stage")
         def gentropy_stage() -> None:
@@ -316,19 +286,20 @@ with DAG(
                         )
                         clusterless_steps.append(r)
                     case _:
+                        cluster_name = step_config["cluster_name"]
+                        current_cluster = cluster_registry.clusters[cluster_name]
                         r = submit_gentropy_step(
-                            cluster_name=clusters[step_config["cluster_name"]],
+                            cluster_name=current_cluster.name,
                             step_name=step_name,
                             project_id=GCP_PROJECT_PLATFORM,
                             params=step_config["params"],
                             labels=labels,
                         )
+                        c = current_cluster.create
+                        d = current_cluster.delete
+                        chain(c, r, d)
 
                 steps[step_name] = r
-                if r not in clusterless_steps:
-                    c = clusters[step_config["cluster_name"]]["create"]
-                    d = clusters[step_config["cluster_name"]]["delete"]
-                    chain(c, r, d)
 
         r = gentropy_stage()
 

--- a/src/ot_orchestration/dags/unified_pipeline.py
+++ b/src/ot_orchestration/dags/unified_pipeline.py
@@ -334,7 +334,6 @@ with DAG(
 
     # ==============================================================================================
     # After creating all the tasks, we tie them together by creating dependencies.
-    print(steps)
     for step_name in steps:
         if step_config := config.steps.get(step_name):
             for dep in step_config.get("depends_on", []):

--- a/src/ot_orchestration/dags/unified_pipeline.py
+++ b/src/ot_orchestration/dags/unified_pipeline.py
@@ -262,20 +262,33 @@ with DAG(
     #       management functions into operators.
     # ==============================================================================================
     if len(config.gentropy_step_list):
-        gentropy_cluster_name = create_cluster_name("gentropy")
+        # Split the tasks into separate task groups
+        clusters = {}
+        for cluster_settings in config.gentropy_dataproc_cluster_settings:
+            name = cluster_settings["cluster_name"]
+            clean_name = create_cluster_name(name)
+            # update the cluster settings,
+            # the name of the cluster must be adjusted to match the clean name
+            cluster_settings["cluster_name"] = clean_name
+            create_cluster_task_id = f"create_{name}_cluster"
+            delete_cluster_task_id = f"delete_{name}_cluster"
+            # Collect all clusters by their original names, so they can be
+            # referenced by the steps config.
+            clusters[name] = {}
+            clusters[name]["create"] = create_cluster(
+                task_id=create_cluster_task_id,
+                project_id=GCP_PROJECT_PLATFORM,
+                **cluster_settings,
+            )
+            clusters[name]["delete"] = delete_cluster(
+                task_id=delete_cluster_task_id,
+                project_id=GCP_PROJECT_PLATFORM,
+                cluster_name=cluster_settings["cluster_name"],
+            )
+            clusters[name]["create_id"] = create_cluster_task_id
+            clusters[name]["delete_id"] = delete_cluster_task_id
+
         clusterless_steps = []
-
-        c = create_cluster(
-            cluster_name=gentropy_cluster_name,
-            project_id=GCP_PROJECT_PLATFORM,
-            **config.gentropy_dataproc_cluster_settings,
-            idle_delete_ttl=90 * 60,
-        )
-
-        d = delete_cluster(
-            gentropy_cluster_name,
-            project_id=GCP_PROJECT_PLATFORM,
-        )
 
         @task_group(group_id="gentropy_stage")
         def gentropy_stage() -> None:
@@ -296,22 +309,25 @@ with DAG(
                         clusterless_steps.append(r)
                     case _:
                         r = submit_gentropy_step(
-                            cluster_name=gentropy_cluster_name,
+                            cluster_name=clusters[step_config["cluster_name"]],
                             step_name=step_name,
                             project_id=GCP_PROJECT_PLATFORM,
-                            python_main_module=config.gentropy_python_main_module,
                             params=step_config["params"],
                             labels=labels,
                         )
 
                 steps[step_name] = r
                 if r not in clusterless_steps:
+                    # print(clusters[step_config])
+                    c = clusters[step_config["cluster_name"]]["create"]
+                    d = clusters[step_config["cluster_name"]]["delete"]
                     chain(c, r, d)
 
         r = gentropy_stage()
 
     # ==============================================================================================
     # After creating all the tasks, we tie them together by creating dependencies.
+    print(steps)
     for step_name in steps:
         if step_config := config.steps.get(step_name):
             for dep in step_config.get("depends_on", []):

--- a/src/ot_orchestration/utils/dataproc.py
+++ b/src/ot_orchestration/utils/dataproc.py
@@ -14,7 +14,7 @@ from airflow.providers.google.cloud.operators.dataproc import (
 )
 from airflow.utils.trigger_rule import TriggerRule
 
-from ot_orchestration.utils import convert_params_to_hydra_positional_arg, create_cluster_name
+from ot_orchestration.utils import convert_params_to_hydra_positional_arg
 
 # from ot_orchestration.utils import GCSPath
 from ot_orchestration.utils.common import (
@@ -135,7 +135,7 @@ def create_cluster(
         project_id=project_id,
         cluster_config=cluster_config,
         region=GCP_REGION,
-        cluster_name=create_cluster_name(cluster_name),
+        cluster_name=cluster_name,
         trigger_rule=TriggerRule.ALL_SUCCESS,
         labels=labels.as_dict(),
     )
@@ -303,7 +303,7 @@ def delete_cluster(
     return DataprocDeleteClusterOperator(
         task_id=task_id,
         project_id=project_id,
-        cluster_name=create_cluster_name(cluster_name),
+        cluster_name=cluster_name,
         region=GCP_REGION,
         trigger_rule=TriggerRule.ALL_SUCCESS,
     )

--- a/src/ot_orchestration/utils/dataproc.py
+++ b/src/ot_orchestration/utils/dataproc.py
@@ -14,7 +14,7 @@ from airflow.providers.google.cloud.operators.dataproc import (
 )
 from airflow.utils.trigger_rule import TriggerRule
 
-from ot_orchestration.utils import convert_params_to_hydra_positional_arg
+from ot_orchestration.utils import convert_params_to_hydra_positional_arg, create_cluster_name
 
 # from ot_orchestration.utils import GCSPath
 from ot_orchestration.utils.common import (
@@ -48,6 +48,7 @@ def create_cluster(
     allow_efm: bool = False,
     idle_delete_ttl: int = 30 * 60,
     labels: Labels | None = None,
+    task_id: str = "create_cluster",
     **kwargs: Any,
 ) -> DataprocCreateClusterOperator:
     """Generate an Airflow task to create a Dataproc cluster. Common parameters are reused, and varying parameters can be specified as needed.
@@ -67,6 +68,7 @@ def create_cluster(
         allow_efm (bool): Wether to allow for Enhanced Flexibility Mode in spark cluster to store the shuffle partitions in the primary workers only.
         idle_delete_ttl (int): Time in seconds to wait before deleting the cluster after it becomes idle. Defaults to 30 minutes.
         labels (Labels): Optional labels to add to the cluster.
+        task_id (str): task id used to during the dataproc cluster creation
         **kwargs (Any): Other parameters to the ClusterGenerator.
 
         NOTE: When `allow_efm` is enabled, the autoscaling policy can not use the graceful decommissioning for primary workers!
@@ -127,14 +129,13 @@ def create_cluster(
             cluster_config[worker_section].setdefault("disk_config", {})
             # Specify the number of local SSDs.
             cluster_config[worker_section]["disk_config"]["num_local_ssds"] = num_local_ssds
-
     # Return the cluster creation operator.
     return DataprocCreateClusterOperator(
-        task_id="create_cluster",
+        task_id=task_id,
         project_id=project_id,
         cluster_config=cluster_config,
         region=GCP_REGION,
-        cluster_name=cluster_name,
+        cluster_name=create_cluster_name(cluster_name),
         trigger_rule=TriggerRule.ALL_SUCCESS,
         labels=labels.as_dict(),
     )
@@ -286,21 +287,23 @@ def submit_job(
 
 def delete_cluster(
     cluster_name: str,
+    task_id: str = "delete_cluster",
     project_id: str = GCP_PROJECT_GENETICS,
 ) -> DataprocDeleteClusterOperator:
     """Generate an Airflow task to delete a Dataproc cluster.
 
     Args:
         cluster_name (str): Name of the cluster.
+        task_id (str): Dataproc delete cluster task id.
         project_id (str): Project ID. Defaults to GCP_PROJECT_GENETICS.
 
     Returns:
         DataprocDeleteClusterOperator: Airflow task to delete a Dataproc cluster.
     """
     return DataprocDeleteClusterOperator(
-        task_id="delete_cluster",
+        task_id=task_id,
         project_id=project_id,
-        cluster_name=cluster_name,
+        cluster_name=create_cluster_name(cluster_name),
         region=GCP_REGION,
         trigger_rule=TriggerRule.ALL_SUCCESS,
     )


### PR DESCRIPTION
# Context

1. Allow to create multiple clusters in gentropy part of unified pipeline
2. Unified pipeline configuration update to reflect changes to `genentics_etl.yaml`
3. Addition of the `l2g_training` and `pis_gold_standard` steps for the training of the L2G model.

## Notes about the coloc steps

Ability to run the colocalisation (coloc + ecaviar) steps within the gentropy part of the `unified_pipelien` requires to change the cluster configuration to allow for arbitrary number of primary workers. This is due to the fact that the cluster with `ogt_etl` autoscaling policy scales down secondary workers after `overlaps` step resulting in cache misses when the actual coloc methods are running.

To make sure the cache is only stored on the primary workers we need to use different autoscaling policy and enable the [efm mode](https://cloud.google.com/dataproc/docs/concepts/configuring-clusters/enhanced-flexibility-mode). The easiest solution for this problem with current code base it to create additional cluster **only for coloc steps** and delete it afterwards.


> [!NOTE]
> There is a possibilitity to tweak the cluster autoscaling policy to decrease the scale down factor for the secondary workers, and/or update the number of workers (the EFM mode is not feasible with neighter solution, since it has to be requrested upon cluster creation). Both solutions (although affecting a single cluster) will have to be experimented on to see the most optimal solution for the run of the coloc steps. They would also require a way to set the `DataprocUpdateClusterOperator` in a correct locations (before and afer coloc steps) to upate the cluster.


