### PR TITLE
feat: manual build for gentropy based image

### DIFF
--- a/.github/workflows/artifact.yaml
+++ b/.github/workflows/artifact.yaml
@@ -8,6 +8,7 @@ on:
     paths:
       - images/gentropy/scripts/harmonise-sumstats.sh
       - images/gentropy/Dockerfile
+  workflow_dispatch:
 
 env:
   PROJECT_ID: open-targets-genetics-dev

--- a/images/gentropy/Dockerfile
+++ b/images/gentropy/Dockerfile
@@ -1,4 +1,4 @@
-FROM europe-west1-docker.pkg.dev/open-targets-genetics-dev/gentropy-app/gentropy:v2.0.1
+FROM europe-west1-docker.pkg.dev/open-targets-genetics-dev/gentropy-app/gentropy:2.2.5.rc-5
 RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" \
     | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list \
     && curl https://packages.cloud.google.com/apt/doc/apt-key.gpg\


### PR DESCRIPTION
# Context

In order to test run the google batch job I need to be able to tweak the build for docker image for the current version (2.2.0.rc-5) of gentropy. For futureproof I want to be able to run the process manually. 