### PR TITLE
chore: reflect updated paths

### DIFF
--- a/src/ot_orchestration/dags/config/genetics_etl.yaml
+++ b/src/ot_orchestration/dags/config/genetics_etl.yaml
@@ -143,7 +143,7 @@ nodes:
       policy_specs:
         machine_type: n1-standard-4
     params:
-      vep_cache_path: gs://genetics_etl_python_playground/vep/cache
+      vep_cache_path: gs://vep_cache_data/vep/cache
       vcf_input_path: '{release_dir}/variants/partitioned_variants'
       vep_output_path: '{release_dir}/variants/annotated_variants'
 

--- a/src/ot_orchestration/dags/config/gentropy.yaml
+++ b/src/ot_orchestration/dags/config/gentropy.yaml
@@ -156,7 +156,7 @@ steps:
       entrypoint: /bin/sh
     params:
       # INPUTS
-      vep_cache_path: gs://genetics_etl_python_playground/vep/cache
+      vep_cache_path: gs://vep_cache_data/vep/cache
       vcf_input_path: '{release_uri}/intermediate/variant_partition'
       # OUTPUTS
       vep_output_path: '{release_uri}/intermediate/variant_annotation'

--- a/src/ot_orchestration/dags/config/gnomad_ingestion.yaml
+++ b/src/ot_orchestration/dags/config/gnomad_ingestion.yaml
@@ -14,13 +14,10 @@ nodes:
     kind: Task
     prerequisites: []
     params:
-      step.ld_index_out: gs://genetics_etl_python_playground/static_assets/ld_index
-      # The version will of the gnomad will be inferred from ld_matrix_template and appended to the ld_index_out.
-      step.use_version_from_input: false
+      step.ld_index_out: gs://gnomad_data_2/ld_index/v2.1.1
   - id: gnomad_variants
     kind: Task
     prerequisites: [ld_index]
     params:
       step: gnomad_variants
       step.variant_annotation_path: gs://gnomad_data_2/v4.1/variant_index
-      step.use_version_from_input: false

--- a/src/ot_orchestration/dags/config/gwas_catalog_sumstats_pics.yaml
+++ b/src/ot_orchestration/dags/config/gwas_catalog_sumstats_pics.yaml
@@ -40,7 +40,7 @@ nodes:
           - window_based_clumping
         params:
           step: ld_based_clumping
-          step.ld_index_path: gs://genetics_etl_python_playground/static_assets/ld_index
+          step.ld_index_path: gs://gnomad_data_2/v2.1.1/ld_index
           step.study_locus_input_path: gs://gwas_catalog_sumstats_pics/study_locus_window_based_clumped
           step.clumped_study_locus_output_path: gs://gwas_catalog_sumstats_pics/study_locus_ld_clumped
           step.study_index_path: gs://gwas_catalog_sumstats_pics/study_index

--- a/src/ot_orchestration/dags/config/gwas_catalog_top_hits.yaml
+++ b/src/ot_orchestration/dags/config/gwas_catalog_top_hits.yaml
@@ -33,7 +33,7 @@ nodes:
           - gwas_catalog_top_hit_ingestion
         params:
           step: ld_based_clumping
-          step.ld_index_path: gs://genetics_etl_python_playground/static_assets/ld_index
+          step.ld_index_path: gs://gnomad_data_2/v2.1.1/ld_index
           step.study_locus_input_path: gs://gwas_catalog_top_hits/study_locus_window_based_clumped
           step.clumped_study_locus_output_path: gs://gwas_catalog_top_hits/study_locus_ld_clumped
           step.study_index_path: gs://gwas_catalog_top_hits/study_index


### PR DESCRIPTION
# Context

Data cleanup of the `genetics_etl_python_playground` bucket resulted in move of the following dataset:
* gnomad ld index -> to `gs://gnomad_data_2`
* vep cache + plugins -> to `gs://vep_cache_data`

This PR attempts to clean up the configuration files to reflect the change
