### PR TITLE
chore: update documentation after google cloud storage data cleanup

### DIFF
--- a/docs/datasources/finngen_data/README.md
+++ b/docs/datasources/finngen_data/README.md
@@ -1,6 +1,6 @@
 # Finngen
 
-This document was updated on 2025-02-05
+This document was updated on 2025-04-11
 
 This datasource is currently fixed under [Finngen Data Freeze 12 - November 4 2024](https://r12.finngen.fi/)
 

--- a/docs/datasources/finngen_data/README.md
+++ b/docs/datasources/finngen_data/README.md
@@ -50,3 +50,7 @@ The configuration of the dataproc infrastructure and individual step parameters 
 ### 2025-02-05
 
 - [fix: updating info in finngen study index ingestion (#972)](https://github.com/opentargets/gentropy/pull/972)
+
+### 2025-04-11
+
+- chore: removal of r11 and r10 data to prevent data duplication.

--- a/docs/datasources/gwas_catalog_data/README.md
+++ b/docs/datasources/gwas_catalog_data/README.md
@@ -288,16 +288,14 @@ The step that performs [PICS finemapping](https://opentargets.github.io/gentropy
 Bucket `gs://gwas_catalog_sumstats_susie` contains:
 
 ```bash
-gs://gwas_catalog_sumstats_susie/credible_set_datasets/
-gs://gwas_catalog_sumstats_susie/credible_set_clean/20241021/
 gs://gwas_catalog_sumstats_susie/credible_set_clean/20250204/
-gs://gwas_catalog_sumstats_susie/credible_set_datasets_01.25/
 gs://gwas_catalog_sumstats_susie/credible_set_datasets_20250204/
 gs://gwas_catalog_sumstats_susie/finemapping_logs/
 gs://gwas_catalog_sumstats_susie/finemapping_manifests/
 gs://gwas_catalog_sumstats_susie/logs/
 gs://gwas_catalog_sumstats_susie/study_index/
 gs://gwas_catalog_sumstats_susie/study_locus_lb_clumped/
+gs://gwas_catalog_sumstats_susie/susie_logs.parquet/
 ```
 
 > [!TIP]
@@ -379,3 +377,7 @@ To adjust the parameters for google batch infrastructure refer to the `google_ba
 ### 2025-02-05
 
 - [fix: repair SusieFinemapperStep to work with new SL schema #957](https://github.com/opentargets/gentropy/pull/957) resolved [issue](https://github.com/opentargets/issues/issues/3667)
+
+### 2025-04-11
+
+- chore: remove 2024-10-21 credible sets to prevent data duplication.

--- a/docs/datasources/gwas_catalog_data/README.md
+++ b/docs/datasources/gwas_catalog_data/README.md
@@ -1,6 +1,6 @@
 # GWAS Catalog data source
 
-This document was updated on 2025-02-05
+This document was updated on 2025-04-11
 
 Data stored under 4 buckets:
 

--- a/docs/datasources/ukb_ppp_eur_data/README.md
+++ b/docs/datasources/ukb_ppp_eur_data/README.md
@@ -1,6 +1,6 @@
 # UK Biobank Pharma Proteomics Project (UKB-PPP)
 
-This document was updated on 2025-02-05
+This document was updated on 2025-04-11
 
 Data source comes from the `https://registry.opendata.aws/ukbppp/`
 

--- a/docs/datasources/ukb_ppp_eur_data/README.md
+++ b/docs/datasources/ukb_ppp_eur_data/README.md
@@ -138,5 +138,8 @@ To adjust the parameters for google batch infrastructure refer to the `google_ba
 ### 2025-02-05
 
 - [fix: repair SusieFinemapperStep to work with new SL schema #957](https://github.com/opentargets/gentropy/pull/957) resolved [issue](https://github.com/opentargets/issues/issues/3667)
+
+### 2025-04-11
+
 - chore: harmonised summary statistics were moved from `gs://ukb_ppp_eur_data/harmonised_summary_statistics` to `gs://ukb_ppp_eur_inputs/harmonised_summary_statistics`. Summary statistics are now in the archive bucket (cold storage).
-- chore: delete of credible sets harmonised at 2024-10-21 due to data duplication.
+- chore: removal of 2024-10-21 credible sets due to data duplication.

--- a/docs/datasources/ukb_ppp_eur_data/README.md
+++ b/docs/datasources/ukb_ppp_eur_data/README.md
@@ -7,9 +7,7 @@ Data source comes from the `https://registry.opendata.aws/ukbppp/`
 Data stored under `gs://ukb_ppp_eur_data` and `gs://ukb_ppp_eur_inputs` buckets comes with following structures
 
 ```
-gs://ukb_ppp_eur_data/credible_set_datasets/susie/20241021/
 gs://ukb_ppp_eur_data/credible_set_datasets/susie/20250129/
-gs://ukb_ppp_eur_data/credible_set_clean/20241021/
 gs://ukb_ppp_eur_data/credible_set_clean/20250129/
 gs://ukb_ppp_eur_data/docs/
 gs://ukb_ppp_eur_data/finemapping_logs/
@@ -140,4 +138,5 @@ To adjust the parameters for google batch infrastructure refer to the `google_ba
 ### 2025-02-05
 
 - [fix: repair SusieFinemapperStep to work with new SL schema #957](https://github.com/opentargets/gentropy/pull/957) resolved [issue](https://github.com/opentargets/issues/issues/3667)
-- [chore: harmonised summary statistics were moved from `gs://ukb_ppp_eur_data/harmonised_summary_statistics` to `gs://ukb_ppp_eur_inputs/harmonised_summary_statistics`]. Summary statistics are now in the archive bucket (cold storage).
+- chore: harmonised summary statistics were moved from `gs://ukb_ppp_eur_data/harmonised_summary_statistics` to `gs://ukb_ppp_eur_inputs/harmonised_summary_statistics`. Summary statistics are now in the archive bucket (cold storage).
+- chore: delete of credible sets harmonised at 2024-10-21 due to data duplication.

--- a/docs/datasources/ukb_ppp_eur_data/README.md
+++ b/docs/datasources/ukb_ppp_eur_data/README.md
@@ -4,7 +4,7 @@ This document was updated on 2025-02-05
 
 Data source comes from the `https://registry.opendata.aws/ukbppp/`
 
-Data stored under `gs://ukb_ppp_eur_data` bucket comes with following structure
+Data stored under `gs://ukb_ppp_eur_data` and `gs://ukb_ppp_eur_inputs` buckets comes with following structures
 
 ```
 gs://ukb_ppp_eur_data/credible_set_datasets/susie/20241021/
@@ -14,11 +14,14 @@ gs://ukb_ppp_eur_data/credible_set_clean/20250129/
 gs://ukb_ppp_eur_data/docs/
 gs://ukb_ppp_eur_data/finemapping_logs/
 gs://ukb_ppp_eur_data/finemapping_manifests/
-gs://ukb_ppp_eur_data/harmonised_summary_statistics/
 gs://ukb_ppp_eur_data/study_index/
 gs://ukb_ppp_eur_data/study_locus_lb_clumped/
-gs://ukb_ppp_eur_data/test/
 ```
+
+```
+gs://ukb_ppp_eur_inputs/harmonised_summary_statistics/
+```
+
 > [!TIP]
 > The latest credible sets stored with 20250129 release date.
 
@@ -71,7 +74,7 @@ The process is runs on **dataproc** cluster.
 The outputs are stored in:
 
 - `gs://ukb_ppp_eur_data/study_index` - study index
-- `gs://ukb_ppp_eur_data/harmonised_summary_statistics` - summary statistics
+- `gs://ukb_ppp_eur_inputs/harmonised_summary_statistics` - summary statistics
 
 #### locus_breaker_clumping
 
@@ -137,3 +140,4 @@ To adjust the parameters for google batch infrastructure refer to the `google_ba
 ### 2025-02-05
 
 - [fix: repair SusieFinemapperStep to work with new SL schema #957](https://github.com/opentargets/gentropy/pull/957) resolved [issue](https://github.com/opentargets/issues/issues/3667)
+- [chore: harmonised summary statistics were moved from `gs://ukb_ppp_eur_data/harmonised_summary_statistics` to `gs://ukb_ppp_eur_inputs/harmonised_summary_statistics`]. Summary statistics are now in the archive bucket (cold storage).

--- a/src/ot_orchestration/dags/config/ukb_ppp_eur_harmonisation.yaml
+++ b/src/ot_orchestration/dags/config/ukb_ppp_eur_harmonisation.yaml
@@ -20,7 +20,7 @@ nodes:
       step.tmp_variant_annotation_path: gs://gentropy-tmp/variant_annotation
       step.variant_annotation_path: gs://gnomad_data_2/gnomad_variant_index
       step.study_index_output_path: gs://ukb_ppp_eur_data/study_index
-      step.summary_stats_output_path: gs://ukb_ppp_eur_data/harmonised_summary_statistics
+      step.summary_stats_output_path: gs://ukb_ppp_eur_inputs/harmonised_summary_statistics
       step.session.write_mode: overwrite
 
   - id: locus_breaker_clumping
@@ -29,7 +29,7 @@ nodes:
       - ukb_ppp_eur_sumstat_preprocess
     params:
       step: locus_breaker_clumping
-      step.summary_statistics_input_path: gs://ukb_ppp_eur_data/harmonised_summary_statistics
+      step.summary_statistics_input_path: gs://ukb_ppp_eur_inputs/harmonised_summary_statistics
       step.clumped_study_locus_output_path: gs://ukb_ppp_eur_data/study_locus_lb_clumped
       step.lbc_baseline_pvalue: 1.0e-5
       step.lbc_distance_cutoff: 250_000


### PR DESCRIPTION
# Context

Due to the cleanup performed on `gs://ukb_ppp_eur_data`, `gs://finngen_data`, `gs://gwas_catalog_sumstats_susie` we needed to update the documentation on the datasets that got deleted.

This PR attempts to update the documentation and reflect the changes.