### PR TITLE
fix: change latest image to 2.10.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM apache/airflow:slim-latest
+FROM apache/airflow:slim-2.10.5-python3.12
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /bin/uv
 
 COPY pyproject.toml README.md ./


### PR DESCRIPTION
# Context:

Since release of airflow 3.0.0, using the latest image will force us to use 3.0.0, which breaks the service. This PR freezes the version of airflow image to 2.10.5