### PR TITLE
fix: ensure the correct project is used to fetch ssh config

### DIFF
--- a/deployment/start.sh
+++ b/deployment/start.sh
@@ -21,6 +21,7 @@ open_browser() {
 # set the env var for the orchestration git branch we want to use in the machine
 export TF_VAR_orchestration_git_branch
 TF_VAR_orchestration_git_branch=$(git branch --show-current)
+PROJECT_ID="open-targets-eu-dev"
 
 # check requirements
 if ! command -v terraform &> /dev/null || ! command -v gcloud &> /dev/null || ! command -v code &> /dev/null;
@@ -50,23 +51,23 @@ fi
 
 # wait for the machine to be ready
 AIRFLOW_DEV_MACHINE_NAME=$(terraform -chdir=./deployment output -raw up_airflow_dev_vm)
-while ! gcloud compute -q ssh --zone="europe-west1-d" --project="open-targets-eu-dev" "$AIRFLOW_DEV_MACHINE_NAME" --command="test -f /ready" > /dev/null 2>&1; do
+while ! gcloud compute -q ssh --zone="europe-west1-d" --project="${PROJECT_ID}" "$AIRFLOW_DEV_MACHINE_NAME" --command="test -f /ready" > /dev/null 2>&1; do
   echo "  ...waiting 10 more seconds..."
   sleep 10
 done
 
 # install local dependencies in the machine's environment (used by vscode)
 cecho "Installing local dependencies in the airflow dev machine"
-gcloud -q compute ssh --zone="europe-west1-d" --project="open-targets-eu-dev" "$AIRFLOW_DEV_MACHINE_NAME" -- 'bash -s' < ./deployment/startup_user.sh
+gcloud -q compute ssh --zone="europe-west1-d" --project="${PROJECT_ID}" "$AIRFLOW_DEV_MACHINE_NAME" -- 'bash -s' < ./deployment/startup_user.sh
 
 # tunnel to the machine
 cecho "Tunneling to the airflow dev machine ${AIRFLOW_DEV_MACHINE_NAME}..."
-gcloud -q compute ssh --zone="europe-west1-d" --project="open-targets-eu-dev" "$AIRFLOW_DEV_MACHINE_NAME" -- -fNL 8081:localhost:8080
+gcloud -q compute ssh --zone="europe-west1-d" --project="${PROJECT_ID}" "$AIRFLOW_DEV_MACHINE_NAME" -- -fNL 8081:localhost:8080
 
 # start vs code remote
 cecho "Starting vscode remote..."
-gcloud -q compute config-ssh > /dev/null 2>&1
-code --folder-uri "vscode-remote://ssh-remote+${AIRFLOW_DEV_MACHINE_NAME}.europe-west1-d.open-targets-eu-dev/opt/orchestration"
+gcloud -q compute config-ssh --project="${PROJECT_ID}" > /dev/null 2>&1
+code --folder-uri "vscode-remote://ssh-remote+${AIRFLOW_DEV_MACHINE_NAME}.europe-west1-d.${PROJECT_ID}/opt/orchestration"
 
 # open the browser to the airflow web interface
 cecho "Starting airflow web interface..."


### PR DESCRIPTION
# Context

While testing the cloud deployment, I have bumped into an issue, that my ssh config does not sync the provisionned machines. This was due to the missing `--project` flag in the `gcloud config-ssh` command. (Only relevant if default project is not `open-targets-eu-dev`)