### PR TITLE
chore: allow specifying ADC from makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 VERSION := $$(grep '^version' pyproject.toml | sed 's%version = "\(.*\)"%\1%')
 .DEFAULT_GOAL := cloud-dev
+LOCAL_DEV_CREDENTIALS ?= ~/.config/gcloud/adc.json
 
 ### HOUSEKEEPING TARGETS ###
 .PHONY: help version clean test check cloud-dev tunnel upload-ukb-ppp-bucket-readme upload-eqtl-catalogue-bucket-readme upload-finngen-bucket-readme upload-gwas-catalog-buckets-readme update-bucket-docs build-gentropy-gcs-image setup-harmonisation-test
@@ -24,7 +25,7 @@ check: format test ## run all checks
 dev: .git/hooks/commit-msg  ## Prepare the local development environment
 	@uv sync --all-extras --dev
 	@uv run pre-commit install --hook-type commit-msg
-	@GOOGLE_APPLICATION_CREDENTIALS=~/.config/gcloud/up-airflow-dev.json docker compose -f compose.yaml -f compose.local.yaml up -d
+	@GOOGLE_APPLICATION_CREDENTIALS=$(LOCAL_DEV_CREDENTIALS) docker compose -f compose.yaml -f compose.local.yaml up -d
 
 cloud-dev: ## Start the remote development environment and connect to it (default goal)
 	@./deployment/start.sh

--- a/Makefile
+++ b/Makefile
@@ -27,13 +27,9 @@ sync:
 
 .git/hooks/commit-msg:
 	@uv run pre-commit install --hook-type commit-msg
-<<<<<<< Updated upstream
-	@GOOGLE_APPLICATION_CREDENTIALS=$(LOCAL_DEV_CREDENTIALS) docker compose -f compose.yaml -f compose.local.yaml up -d
-=======
 
 dev: sync .git/hooks/commit-msg  ## Prepare the local development environment
-	@GOOGLE_APPLICATION_CREDENTIALS=~/.config/gcloud/up-airflow-dev.json docker compose -f compose.yaml -f compose.local.yaml up -d
->>>>>>> Stashed changes
+	@GOOGLE_APPLICATION_CREDENTIALS=$(LOCAL_DEV_CREDENTIALS) docker compose -f compose.yaml -f compose.local.yaml up -d
 
 cloud-dev: ## Start the remote development environment and connect to it (default goal)
 	@./deployment/start.sh

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ VERSION := $$(grep '^version' pyproject.toml | sed 's%version = "\(.*\)"%\1%')
 LOCAL_DEV_CREDENTIALS ?= ~/.config/gcloud/adc.json
 
 ### HOUSEKEEPING TARGETS ###
-.PHONY: help version clean test check cloud-dev tunnel upload-ukb-ppp-bucket-readme upload-eqtl-catalogue-bucket-readme upload-finngen-bucket-readme upload-gwas-catalog-buckets-readme update-bucket-docs build-gentropy-gcs-image setup-harmonisation-test
+.PHONY: help sync version clean test check cloud-dev tunnel upload-ukb-ppp-bucket-readme upload-eqtl-catalogue-bucket-readme upload-finngen-bucket-readme upload-gwas-catalog-buckets-readme update-bucket-docs build-gentropy-gcs-image setup-harmonisation-test
 
 help: ## Show the help message
 	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z_-]+:.*?## / {printf "\033[36m%-36s\033[0m %s\n", $$1, $$2}' $(MAKEFILE_LIST)
@@ -22,17 +22,24 @@ test: ## Run unit tests
 
 check: format test ## run all checks
 
-dev: .git/hooks/commit-msg  ## Prepare the local development environment
+sync:
 	@uv sync --all-extras --dev
+
+.git/hooks/commit-msg:
 	@uv run pre-commit install --hook-type commit-msg
+<<<<<<< Updated upstream
 	@GOOGLE_APPLICATION_CREDENTIALS=$(LOCAL_DEV_CREDENTIALS) docker compose -f compose.yaml -f compose.local.yaml up -d
+=======
+
+dev: sync .git/hooks/commit-msg  ## Prepare the local development environment
+	@GOOGLE_APPLICATION_CREDENTIALS=~/.config/gcloud/up-airflow-dev.json docker compose -f compose.yaml -f compose.local.yaml up -d
+>>>>>>> Stashed changes
 
 cloud-dev: ## Start the remote development environment and connect to it (default goal)
 	@./deployment/start.sh
 
 tunnel: ## Tunnel to the remote development environment
 	@./deployment/tunnel.sh
-
 
 ### OTHER TARGETS ###
 upload-ukb-ppp-bucket-readme: ## ppload ukb_ppp_eur_data readme to the bucket

--- a/README.md
+++ b/README.md
@@ -5,9 +5,10 @@
 The code in this repository is compatible with Linux and Mac only. There are the
 following software requirements:
 
-* [uv](https://github.com/astral-sh/uv)
-* [Docker](https://docs.docker.com/get-docker/)
-* [Google Cloud SDK](https://cloud.google.com/sdk/docs/install)
+- [uv](https://github.com/astral-sh/uv)
+- [Docker](https://docs.docker.com/get-docker/)
+- [Docker Compose](https://docs.docker.com/compose/install/)
+- [Google Cloud SDK](https://cloud.google.com/sdk/docs/install)
 
 > [!WARNING]
 > On macOS, the default amount of memory available for Docker might not be enough
@@ -18,24 +19,39 @@ following software requirements:
 > The terraform script used in creating the cloud instance is currently heavily
 > tailored to our internal structure, with many hardcoded values and assumptions.
 
-
 ## Running
 
 ### Local
-You need to set up local access to the `up-airflow-dev` service account.
 
-Then, run `make dev`. This will start airflow locally and create a virtualenv you
-can use with your IDE.
+Local development sets up the Airflow service using Docker Compose with LocalExecutor. Local service is exposed to the `localhost:8080` by default.
 
-Open http://localhost:8081 in a browser to access the Airflow UI. The default
-credentials are `airflow`/`airflow`.
+> [!NOTE]
+> The directory containing the orchestration code is mounted into the Airflow service containers, so you can edit the code locally in your IDE and see the changes reflected in the Airflow UI.
+
+The default credentials used in airflow UI are `airflow`/`airflow`.
+
+To spin the local Airflow instance, run:
+
+```bash
+make dev
+```
+
+This will start airflow service and install the required dependencies using uv.
 
 > [!WARNING]
 > If you run `docker compose up` by itself, to get a working dev environment you
 > must add the override file `compose-local.yaml` as well as set the
 > `GOOGLE_APPLICATION_CREDENTIALS` environment variable.
 
+In order to use the local Airflow instance yoy need to have the google cloud credentials set up on local machine.
+By default the `make dev` comamnd will link the `~/.config/gcloud/up-airflow-dev.json` file to the Airflow container. If you store the credentials in different file, you can set them with
+
+```bash
+LOCAL_DEV_CREDENTIALS=path/to/your/credentials.json make dev
+```
+
 ### Google Cloud
+
 Run `make`. This will set up and/or connect you to an airflow dev instance in
 Google Cloud; and open vscode into that instance code as well as a the Airflow UI
 in a browser automatically. The default credentials are `airflow`/`airflow`.
@@ -43,7 +59,6 @@ in a browser automatically. The default credentials are `airflow`/`airflow`.
 > [!TIP]
 > You should accept the prompt to install the recommended extensions in vscode,
 > those are very helpful for working with Airflow DAGs and code.
-
 
 # Additional information
 
@@ -60,7 +75,6 @@ to run it one need to provide the configuration from the `configs/config.json`
 to the dag trigger as in the exaple picture.
 
 ![alt text](docs/image.png)
-
 
 ## Cleaning up
 
@@ -88,7 +102,6 @@ To cleanup the Airflow database, run:
 docker compose down --volumes --remove-orphans
 ```
 
-
 ## Advanced configuration
 
 More information on running Airflow with Docker Compose can be found in the
@@ -107,7 +120,6 @@ More information on running Airflow with Docker Compose can be found in the
    ```
 
 1. **Additional pip packages**. They can be added to the `requirements.txt` file.
-
 
 ## Troubleshooting
 


### PR DESCRIPTION
This PR includes:

1. Allow user to specify the google credentials from a custom file when spinning the local instance of airflow service
2. Readme update to reflect the change.