### PR TITLE
chore: update gentropy version in genetic dags

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -15,5 +15,14 @@
       "pis.yaml",
       "pts.yaml"
     ]
-  }
+  },
+  "cSpell.words": [
+    "cpus",
+    "GCST",
+    "harmonisation",
+    "harmonise",
+    "harmonised",
+    "sumstat",
+    "sumstats"
+  ]
 }

--- a/README.md
+++ b/README.md
@@ -9,11 +9,16 @@ following software requirements:
 - [Docker](https://docs.docker.com/get-docker/)
 - [Docker Compose](https://docs.docker.com/compose/install/)
 - [Google Cloud SDK](https://cloud.google.com/sdk/docs/install)
+- [Terraform](https://www.terraform.io/downloads.html) (optional, for cloud instance setup)
 
 > [!WARNING]
 > On macOS, the default amount of memory available for Docker might not be enough
 > to get Airflow up and running. Allocate at least 4GB of memory for the Docker
 > Engine (ideally 8GB). [More info](https://airflow.apache.org/docs/apache-airflow/stable/howto/docker-compose/index.html#)
+
+> [!WARNING]
+> On macOS with if you already have vscode installed, make sure to enable the terminal shortcut
+> see [thread](https://code.visualstudio.com/docs/setup/mac#_manually-configure-the-path)
 
 > [!NOTE]
 > The terraform script used in creating the cloud instance is currently heavily
@@ -52,17 +57,34 @@ LOCAL_DEV_CREDENTIALS=path/to/your/credentials.json make dev
 
 ### Google Cloud
 
+#### Prerequisites
+
+Make sure that you have enabled the application default credentials to run the terraform.
+
+```bash
+gcloud auth application-default login
+```
+
+#### Setup
+
 Run `make`. This will set up and/or connect you to an airflow dev instance in
 Google Cloud; and open vscode into that instance code as well as a the Airflow UI
 in a browser automatically. The default credentials are `airflow`/`airflow`.
+
+The port `8081` is used for the remote Airflow UI. This port is forwarded from the machine to your local host.
+In case you lose the connection to the remote instance, you can re-run the `make` command or setup the tunnel directly with
+
+```bash
+make tunnel
+```
 
 > [!TIP]
 > You should accept the prompt to install the recommended extensions in vscode,
 > those are very helpful for working with Airflow DAGs and code.
 
-# Additional information
+## Additional information
 
-## Managing Airflow and DAGs
+### Managing Airflow and DAGs
 
 The airflow DAGs sit in the `orchestration` package inside the `dags` directory.
 The configuration for the DAGs is located in the `orchestration.dags.config`
@@ -72,11 +94,11 @@ Currently the DAGs are under heavy development, so there can be issues while
 Airflow tries to parse them. Current development focuses on unification of the
 `gwas_catalog_*` dags in `gwas_catalog_dag.py` file in a single DAG. To be able
 to run it one need to provide the configuration from the `configs/config.json`
-to the dag trigger as in the exaple picture.
+to the dag trigger as in the example picture.
 
 ![alt text](docs/image.png)
 
-## Cleaning up
+### Cleaning up
 
 You can clean up the repository with:
 
@@ -102,7 +124,7 @@ To cleanup the Airflow database, run:
 docker compose down --volumes --remove-orphans
 ```
 
-## Advanced configuration
+### Advanced configuration
 
 More information on running Airflow with Docker Compose can be found in the
 [official docs](https://airflow.apache.org/docs/apache-airflow/stable/howto/docker-compose/index.html).
@@ -121,7 +143,7 @@ More information on running Airflow with Docker Compose can be found in the
 
 1. **Additional pip packages**. They can be added to the `requirements.txt` file.
 
-## Troubleshooting
+### Troubleshooting
 
 Note that when you a a new workflow under `dags/`, Airflow will not pick that up
 immediately. By default the filesystem is only scanned for new DAGs every 300s.

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ following software requirements:
 > Engine (ideally 8GB). [More info](https://airflow.apache.org/docs/apache-airflow/stable/howto/docker-compose/index.html#)
 
 > [!WARNING]
-> On macOS with if you already have vscode installed, make sure to enable the terminal shortcut
+> On macOS if you already have vscode installed, make sure to enable the terminal shortcut
 > see [thread](https://code.visualstudio.com/docs/setup/mac#_manually-configure-the-path)
 
 > [!NOTE]

--- a/docs/datasources/gwas_catalog_data/README.md
+++ b/docs/datasources/gwas_catalog_data/README.md
@@ -288,8 +288,8 @@ The step that performs [PICS finemapping](https://opentargets.github.io/gentropy
 Bucket `gs://gwas_catalog_sumstats_susie` contains:
 
 ```bash
-gs://gwas_catalog_sumstats_susie/credible_set_clean/20250204/
-gs://gwas_catalog_sumstats_susie/credible_set_datasets_20250204/
+gs://gwas_catalog_sumstats_susie/credible_set_clean/20250611/
+gs://gwas_catalog_sumstats_susie/credible_set_datasets/
 gs://gwas_catalog_sumstats_susie/finemapping_logs/
 gs://gwas_catalog_sumstats_susie/finemapping_manifests/
 gs://gwas_catalog_sumstats_susie/logs/
@@ -297,9 +297,6 @@ gs://gwas_catalog_sumstats_susie/study_index/
 gs://gwas_catalog_sumstats_susie/study_locus_lb_clumped/
 gs://gwas_catalog_sumstats_susie/susie_logs.parquet/
 ```
-
-> [!TIP]
-> The latest credible sets are stored under the `20250204` release.
 
 Data is produced by 2 dags:
 
@@ -381,3 +378,7 @@ To adjust the parameters for google batch infrastructure refer to the `google_ba
 ### 2025-04-11
 
 - chore: remove 2024-10-21 credible sets to prevent data duplication.
+
+### 2025-06-11
+
+- chore: unifiy credible sets output directory structure to be now in `gs://gwas_catalog_sumstats_susie/credible_set_datasets`

--- a/images/gentropy/Dockerfile
+++ b/images/gentropy/Dockerfile
@@ -1,6 +1,6 @@
 FROM google/cloud-sdk:489.0.0-stable AS gcloud-builder
 
-FROM europe-west1-docker.pkg.dev/open-targets-genetics-dev/gentropy-app/gentropy:2.3.0-rc.5
+FROM europe-west1-docker.pkg.dev/open-targets-genetics-dev/gentropy-app/gentropy:2.3.0-internal.13
 RUN ln -s /app/.venv/bin/python3 /usr/bin/python3
 COPY --from=gcloud-builder /usr/lib/google-cloud-sdk /opt/google-cloud-sdk
 ENV PATH="/opt/google-cloud-sdk/bin:${PATH}"

--- a/images/gentropy/Dockerfile
+++ b/images/gentropy/Dockerfile
@@ -1,4 +1,4 @@
-FROM europe-west1-docker.pkg.dev/open-targets-genetics-dev/gentropy-app/gentropy:2.2.0-rc.5
+FROM europe-west1-docker.pkg.dev/open-targets-genetics-dev/gentropy-app/gentropy:2.3.0-rc.5
 RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" \
     | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list \
     && curl https://packages.cloud.google.com/apt/doc/apt-key.gpg\

--- a/images/gentropy/Dockerfile
+++ b/images/gentropy/Dockerfile
@@ -1,7 +1,7 @@
+FROM google/cloud-sdk:489.0.0-stable AS gcloud-builder
+
 FROM europe-west1-docker.pkg.dev/open-targets-genetics-dev/gentropy-app/gentropy:2.3.0-rc.5
-RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" \
-    | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list \
-    && curl https://packages.cloud.google.com/apt/doc/apt-key.gpg\
-    | gpg --dearmor -o /usr/share/keyrings/cloud.google.gpg \
-    && apt-get update -y && apt-get install google-cloud-cli -y
+RUN ln -s /app/.venv/bin/python3 /usr/bin/python3
+COPY --from=gcloud-builder /usr/lib/google-cloud-sdk /opt/google-cloud-sdk
+ENV PATH="/opt/google-cloud-sdk/bin:${PATH}"
 COPY --chmod=0755 images/gentropy/scripts/harmonise-sumstats.sh harmonise-sumstats.sh

--- a/images/gentropy/Dockerfile
+++ b/images/gentropy/Dockerfile
@@ -1,6 +1,6 @@
 FROM google/cloud-sdk:489.0.0-stable AS gcloud-builder
 
-FROM europe-west1-docker.pkg.dev/open-targets-genetics-dev/gentropy-app/gentropy:2.3.0-internal.13
+FROM europe-west1-docker.pkg.dev/open-targets-genetics-dev/gentropy-app/gentropy:2.3.0-rc.9
 RUN ln -s /app/.venv/bin/python3 /usr/bin/python3
 COPY --from=gcloud-builder /usr/lib/google-cloud-sdk /opt/google-cloud-sdk
 ENV PATH="/opt/google-cloud-sdk/bin:${PATH}"

--- a/images/gentropy/scripts/harmonise-sumstats.sh
+++ b/images/gentropy/scripts/harmonise-sumstats.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 # Script for running harmonisation and qc steps by the google batch job
 # Requirements:
-# 1. Gentropy & poetry
-# 2. gsutil
+# 1. Gentropy
+# 2. gcloud
 # 3. gzip
 
 # set -x
@@ -38,7 +38,7 @@ if [ -f ${LOCAL_LOG_FILE} ]; then
 fi
 
 logging "Copying raw summary statistics from ${RAW_FILE} to ${RAW_LOCAL_FILE}"
-gsutil cp $RAW_FILE $RAW_LOCAL_FILE
+gcloud storage cp $RAW_FILE $RAW_LOCAL_FILE
 
 RAW_FILE_SIZE=$(du -sh ${RAW_LOCAL_FILE} | cut -f1)
 logging "Raw file size ${RAW_FILE_SIZE}"
@@ -87,11 +87,11 @@ clean_up() {
     REMOTE_SUMMARY_FILE="${OUTPUT_PATH}/harmonisation_summary/${STUDY_ID}/${DATE}/harmonisation.csv"
     LATEST_REMOTE_SUMMARY_FILE="${OUTPUT_PATH}/harmonisation_summary/${STUDY_ID}/latest/harmonisation.csv"
 
-    gsutil cp ${LOCAL_LOG_FILE} ${REMOTE_LOG_FILE}
-    gsutil cp ${LOCAL_LOG_FILE} ${LATEST_REMOTE_LOG_FILE}
+    gcloud storage cp ${LOCAL_LOG_FILE} ${REMOTE_LOG_FILE}
+    gcloud storage cp ${LOCAL_LOG_FILE} ${LATEST_REMOTE_LOG_FILE}
 
-    gsutil cp ${LOCAL_SUMMARY_FILE} ${REMOTE_SUMMARY_FILE}
-    gsutil cp ${LOCAL_SUMMARY_FILE} ${LATEST_REMOTE_SUMMARY_FILE}
+    gcloud storage cp ${LOCAL_SUMMARY_FILE} ${REMOTE_SUMMARY_FILE}
+    gcloud storage cp ${LOCAL_SUMMARY_FILE} ${LATEST_REMOTE_SUMMARY_FILE}
 
 }
 

--- a/images/gentropy/scripts/harmonise-sumstats.sh
+++ b/images/gentropy/scripts/harmonise-sumstats.sh
@@ -50,7 +50,7 @@ UNZIPPED_FILE_SIZE=$(du -sh ${UNZIPPED_RAW_LOCAL_FILE} | cut -f1)
 logging "Unzipped file size ${UNZIPPED_FILE_SIZE}"
 
 logging "Running harmonisation on ${UNZIPPED_RAW_LOCAL_FILE} file"
-poetry run gentropy step=gwas_catalog_sumstat_preprocess \
+gentropy step=gwas_catalog_sumstat_preprocess \
     step.raw_sumstats_path=$UNZIPPED_RAW_LOCAL_FILE \
     step.out_sumstats_path=$HARMONISED_FILE \
     step.session.write_mode=overwrite \
@@ -64,7 +64,7 @@ HARMONISATION_EXIT_CODE=$?
 logging "Harmonisation exit code: ${HARMONISATION_EXIT_CODE}"
 
 logging "Running qc on ${HARMONISED_FILE} file"
-poetry run gentropy step=summary_statistics_qc \
+gentropy step=summary_statistics_qc \
     step.gwas_path=$HARMONISED_FILE \
     step.output_path=$QC_FILE \
     step.pval_threshold=$QC_THRESHOLD \

--- a/src/orchestration/dags/config/credible_set_qc.yaml
+++ b/src/orchestration/dags/config/credible_set_qc.yaml
@@ -2,7 +2,7 @@
 dataproc:
   python_main_module: gs://genetics_etl_python_playground/initialisation/cli.py
   cluster_metadata:
-    GENTROPY_REF: v2.0.2-rc.2
+    GENTROPY_REF:  v2.3.0-rc.5
   cluster_init_script: gs://genetics_etl_python_playground/initialisation/install_dependencies_on_cluster.sh
   cluster_name: otg-credible-set-qc
   autoscaling_policy: otg-etl

--- a/src/orchestration/dags/config/credible_set_qc.yaml
+++ b/src/orchestration/dags/config/credible_set_qc.yaml
@@ -13,11 +13,11 @@ nodes:
     prerequisites: []
     params:
       step: credible_set_qc
-      step.credible_sets_path: gs://gwas_catalog_sumstats_susie/credible_set_datasets_20250204
-      step.output_path: gs://gwas_catalog_sumstats_susie/credible_set_clean/20250204
+      step.credible_sets_path: gs://gwas_catalog_sumstats_susie/credible_set_datasets
+      step.output_path: gs://gwas_catalog_sumstats_susie/credible_set_clean/20250611
       step.p_value_threshold: 1.0e-5
       step.purity_min_r2: 0.25
-      step.n_partitions: 250
+      step.n_partitions: 350
       step.clump: false
       step.session.write_mode: overwrite
       step.session.start_hail: true

--- a/src/orchestration/dags/config/credible_set_qc.yaml
+++ b/src/orchestration/dags/config/credible_set_qc.yaml
@@ -2,7 +2,7 @@
 dataproc:
   python_main_module: gs://genetics_etl_python_playground/initialisation/cli.py
   cluster_metadata:
-    GENTROPY_REF:  v2.3.0-rc.5
+    GENTROPY_REF: v2.3.0-rc.5
   cluster_init_script: gs://genetics_etl_python_playground/initialisation/install_dependencies_on_cluster.sh
   cluster_name: otg-credible-set-qc
   autoscaling_policy: otg-etl

--- a/src/orchestration/dags/config/eqtl_catalogue_ingestion.yaml
+++ b/src/orchestration/dags/config/eqtl_catalogue_ingestion.yaml
@@ -6,7 +6,7 @@ decompression_logs: gs://eqtl_catalogue_data/ebi_ftp/susie_decompressed_tmp/logs
 dataproc:
   python_main_module: gs://genetics_etl_python_playground/initialisation/cli.py
   cluster_metadata:
-    GENTROPY_REF: v2.0.2-rc.3
+    GENTROPY_REF:  v2.3.0-rc.5
   cluster_init_script: gs://genetics_etl_python_playground/initialisation/install_dependencies_on_cluster.sh
   cluster_name: otg-preprocess-eqtl
   autoscaling_policy: eqtl-preprocess

--- a/src/orchestration/dags/config/eqtl_catalogue_ingestion.yaml
+++ b/src/orchestration/dags/config/eqtl_catalogue_ingestion.yaml
@@ -6,7 +6,7 @@ decompression_logs: gs://eqtl_catalogue_data/ebi_ftp/susie_decompressed_tmp/logs
 dataproc:
   python_main_module: gs://genetics_etl_python_playground/initialisation/cli.py
   cluster_metadata:
-    GENTROPY_REF:  v2.3.0-rc.5
+    GENTROPY_REF: v2.3.0-rc.5
   cluster_init_script: gs://genetics_etl_python_playground/initialisation/install_dependencies_on_cluster.sh
   cluster_name: otg-preprocess-eqtl
   autoscaling_policy: eqtl-preprocess

--- a/src/orchestration/dags/config/finngen_ingestion.yaml
+++ b/src/orchestration/dags/config/finngen_ingestion.yaml
@@ -2,7 +2,7 @@
 dataproc:
   python_main_module: gs://genetics_etl_python_playground/initialisation/cli.py
   cluster_metadata:
-    GENTROPY_REF: v2.0.1
+    GENTROPY_REF:  v2.3.0-rc.5
   cluster_init_script: gs://genetics_etl_python_playground/initialisation/install_dependencies_on_cluster.sh
   cluster_name: otg-ingestion-finngen
   autoscaling_policy: finngen-preprocess

--- a/src/orchestration/dags/config/finngen_ingestion.yaml
+++ b/src/orchestration/dags/config/finngen_ingestion.yaml
@@ -2,7 +2,7 @@
 dataproc:
   python_main_module: gs://genetics_etl_python_playground/initialisation/cli.py
   cluster_metadata:
-    GENTROPY_REF:  v2.3.0-rc.5
+    GENTROPY_REF: v2.3.0-rc.5
   cluster_init_script: gs://genetics_etl_python_playground/initialisation/install_dependencies_on_cluster.sh
   cluster_name: otg-ingestion-finngen
   autoscaling_policy: finngen-preprocess

--- a/src/orchestration/dags/config/foldx_ingestion.yaml
+++ b/src/orchestration/dags/config/foldx_ingestion.yaml
@@ -2,7 +2,7 @@
 dataproc:
   python_main_module: gs://genetics_etl_python_playground/initialisation/cli.py
   cluster_metadata:
-    GENTROPY_REF: v2.0.1
+    GENTROPY_REF:  v2.3.0-rc.5
   cluster_init_script: gs://genetics_etl_python_playground/initialisation/install_dependencies_on_cluster.sh
 
   cluster_name: foldx-ingestion

--- a/src/orchestration/dags/config/foldx_ingestion.yaml
+++ b/src/orchestration/dags/config/foldx_ingestion.yaml
@@ -2,7 +2,7 @@
 dataproc:
   python_main_module: gs://genetics_etl_python_playground/initialisation/cli.py
   cluster_metadata:
-    GENTROPY_REF:  v2.3.0-rc.5
+    GENTROPY_REF: v2.3.0-rc.5
   cluster_init_script: gs://genetics_etl_python_playground/initialisation/install_dependencies_on_cluster.sh
 
   cluster_name: foldx-ingestion

--- a/src/orchestration/dags/config/gentropy.yaml
+++ b/src/orchestration/dags/config/gentropy.yaml
@@ -70,11 +70,10 @@ steps:
       step.study_locus_path:
         - gs://gwas_catalog_top_hits/credible_sets/
         - gs://gwas_catalog_sumstats_pics/credible_sets/
-        - gs://gwas_catalog_sumstats_susie/credible_set_clean/20250204/
+        - gs://gwas_catalog_sumstats_susie/credible_set_clean/20250611/
         - gs://eqtl_catalogue_data/credible_set_datasets/eqtl_catalogue_susie_patched_v2/
         - gs://ukb_ppp_eur_data/credible_set_clean/20250129/
         - gs://finngen_data/r12/credible_set_datasets/susie/
-        - gs://gwas_catalog_sumstats_susie/credible_set_clean/202505/
       step.study_index_path: '{{release_uri}}/output/study'
       step.target_index_path: '{{release_uri}}/output/target'
       # OUTPUTS
@@ -198,11 +197,11 @@ steps:
       step: locus_to_gene
       step.run_mode: predict
       step.session.write_mode: overwrite
-      step.session.output_partitions: 1
+      step.session.output_partitions: 5
       step.l2g_threshold: 0.05
       step.download_from_hub: true
       step.explain_predictions: true
-      +step.session.extended_spark_conf: "{spark.rpc.message.maxSize:'1024'}"
+      +step.session.extended_spark_conf: "{spark.rpc.message.maxSize:'2046'}"
       # INPUTS
       step.hf_hub_repo_id: opentargets/locus_to_gene
       step.feature_matrix_path: '{{release_uri}}/intermediate/l2g_feature_matrix'

--- a/src/orchestration/dags/config/gnomad_ingestion.yaml
+++ b/src/orchestration/dags/config/gnomad_ingestion.yaml
@@ -2,7 +2,7 @@
 dataproc:
   python_main_module: gs://genetics_etl_python_playground/initialisation/cli.py
   cluster_metadata:
-    GENTROPY_REF: v2.0.2-rc.3
+    GENTROPY_REF:  v2.3.0-rc.5
   cluster_init_script: gs://genetics_etl_python_playground/initialisation/install_dependencies_on_cluster.sh
   cluster_name: gnomad-preprocess
   autoscaling_policy: otg-etl

--- a/src/orchestration/dags/config/gnomad_ingestion.yaml
+++ b/src/orchestration/dags/config/gnomad_ingestion.yaml
@@ -2,7 +2,7 @@
 dataproc:
   python_main_module: gs://genetics_etl_python_playground/initialisation/cli.py
   cluster_metadata:
-    GENTROPY_REF:  v2.3.0-rc.5
+    GENTROPY_REF: v2.3.0-rc.5
   cluster_init_script: gs://genetics_etl_python_playground/initialisation/install_dependencies_on_cluster.sh
   cluster_name: gnomad-preprocess
   autoscaling_policy: otg-etl

--- a/src/orchestration/dags/config/gwas_catalog_sumstat_harmonisation.yaml
+++ b/src/orchestration/dags/config/gwas_catalog_sumstat_harmonisation.yaml
@@ -36,8 +36,9 @@ nodes:
     prerequisites:
       - generate_sumstat_index
     google_batch:
-      entrypoint: /bin/sh
-      image: europe-west1-docker.pkg.dev/open-targets-genetics-dev/gentropy-app/gentropy:orchestration
+      entrypoint: /usr/bin/bash
+      parallelism: 200
+      image: europe-west1-docker.pkg.dev/open-targets-genetics-dev/gentropy-app/ot_gentropy:dev
       resource_specs:
         cpu_milli: 4000
         memory_mib: 8000

--- a/src/orchestration/dags/config/gwas_catalog_sumstats_pics.yaml
+++ b/src/orchestration/dags/config/gwas_catalog_sumstats_pics.yaml
@@ -51,7 +51,7 @@ nodes:
           step.session.write_mode: overwrite
           step.session.spark_uri: yarn
           +step.session.extended_spark_conf: "{spark.executor.memory: '25g', spark.executor.cores: '4', spark.shuffle.mapOutput.minSizeForBroadcast: '10m'}"
-      
+
       - id: pics
         kind: Task
         prerequisites:

--- a/src/orchestration/dags/config/gwas_catalog_sumstats_pics.yaml
+++ b/src/orchestration/dags/config/gwas_catalog_sumstats_pics.yaml
@@ -26,6 +26,7 @@ nodes:
           step.session.write_mode: overwrite
           step.session.spark_uri: yarn
           step.session.output_partitions: 1
+
       - id: window_based_clumping
         kind: Task
         prerequisites: []
@@ -35,6 +36,8 @@ nodes:
           step.study_locus_output_path: gs://gwas_catalog_sumstats_pics/study_locus_window_based_clumped
           step.session.write_mode: overwrite
           step.session.spark_uri: yarn
+          +step.session.extended_spark_conf: "{spark.executor.memory: '25g', spark.executor.cores: '4', spark.shuffle.mapOutput.minSizeForBroadcast: '10m'}"
+
       - id: ld_based_clumping
         kind: Task
         prerequisites:
@@ -47,6 +50,8 @@ nodes:
           step.study_index_path: gs://gwas_catalog_sumstats_pics/study_index
           step.session.write_mode: overwrite
           step.session.spark_uri: yarn
+          +step.session.extended_spark_conf: "{spark.executor.memory: '25g', spark.executor.cores: '4', spark.shuffle.mapOutput.minSizeForBroadcast: '10m'}"
+      
       - id: pics
         kind: Task
         prerequisites:

--- a/src/orchestration/dags/config/gwas_catalog_sumstats_pics.yaml
+++ b/src/orchestration/dags/config/gwas_catalog_sumstats_pics.yaml
@@ -4,7 +4,7 @@ dataproc:
   autoscaling_policy: otg-preprocess-gwascatalog
   python_main_module: gs://genetics_etl_python_playground/initialisation/cli.py
   cluster_metadata:
-    GENTROPY_REF: v2.0.2-rc.3
+    GENTROPY_REF: v2.3.0-rc.5
   cluster_init_script: gs://genetics_etl_python_playground/initialisation/install_dependencies_on_cluster.sh
   num_workers: 5
 

--- a/src/orchestration/dags/config/gwas_catalog_sumstats_susie_clumping.yaml
+++ b/src/orchestration/dags/config/gwas_catalog_sumstats_susie_clumping.yaml
@@ -13,7 +13,7 @@ env: Prod
 
 dataproc:
   cluster_metadata:
-    GENTROPY_REF: v2.0.2-rc.2
+    GENTROPY_REF: v2.3.0-rc.5
   cluster_name: otg-gwas-catalog-sumstat-susie-clumping
   autoscaling_policy: otg-etl
 

--- a/src/orchestration/dags/config/gwas_catalog_sumstats_susie_clumping.yaml
+++ b/src/orchestration/dags/config/gwas_catalog_sumstats_susie_clumping.yaml
@@ -13,7 +13,7 @@ env: Prod
 
 dataproc:
   cluster_metadata:
-    GENTROPY_REF: v2.3.0-internal.13
+    GENTROPY_REF: v2.3.0-rc.9
   cluster_name: otg-gwas-catalog-sumstat-susie-clumping
   autoscaling_policy: otg-etl
 
@@ -28,7 +28,7 @@ nodes:
       step.catalog_ancestry_files:
         - "{input_path}/gwas_catalog_download_ancestries.tsv"
       step.study_index_path: "{output_path}/study_index"
-      step.gwas_catalog_study_curation_file: "{input_path}/curation/202505/GWAS_Catalog_study_curation.tsv"
+      step.gwas_catalog_study_curation_file: "{input_path}/curation/202506/GWAS_Catalog_study_curation.tsv"
       step.sumstats_qc_path: "{input_path}/summary_statistics_qc"
       step.session.write_mode: overwrite
       step.session.output_partitions: 1

--- a/src/orchestration/dags/config/gwas_catalog_sumstats_susie_clumping.yaml
+++ b/src/orchestration/dags/config/gwas_catalog_sumstats_susie_clumping.yaml
@@ -13,7 +13,7 @@ env: Prod
 
 dataproc:
   cluster_metadata:
-    GENTROPY_REF: v2.3.0-rc.5
+    GENTROPY_REF: v2.3.0-internal.13
   cluster_name: otg-gwas-catalog-sumstat-susie-clumping
   autoscaling_policy: otg-etl
 

--- a/src/orchestration/dags/config/gwas_catalog_sumstats_susie_finemapping.yaml
+++ b/src/orchestration/dags/config/gwas_catalog_sumstats_susie_finemapping.yaml
@@ -3,11 +3,11 @@ environment_specs:
   - name: Test
     vars:
       output_path: gs://ot_orchestration/test/gwas_catalog_sumstats_susie
-      GENTROPY_REF: 2.3.0-internal.13
+      GENTROPY_REF: 2.3.0-rc.9
   - name: Prod
     vars:
       output_path: gs://gwas_catalog_sumstats_susie
-      GENTROPY_REF: 2.3.0-internal.13
+      GENTROPY_REF: 2.3.0-rc.9
 
 env: Prod
 nodes:

--- a/src/orchestration/dags/config/gwas_catalog_sumstats_susie_finemapping.yaml
+++ b/src/orchestration/dags/config/gwas_catalog_sumstats_susie_finemapping.yaml
@@ -3,14 +3,13 @@ environment_specs:
   - name: Test
     vars:
       output_path: gs://ot_orchestration/test/gwas_catalog_sumstats_susie
-      GENTROPY_REF: 2.0.2-rc2
+      GENTROPY_REF: 2.3.0-internal.13
   - name: Prod
     vars:
       output_path: gs://gwas_catalog_sumstats_susie
-      GENTROPY_REF: 2.0.2-rc2
+      GENTROPY_REF: 2.3.0-internal.13
 
 env: Prod
-
 nodes:
   - id: generate_manifests
     kind: Task
@@ -19,6 +18,7 @@ nodes:
       collected_loci_path: '{output_path}/study_locus_lb_clumped'
       manifest_prefix: '{output_path}/finemapping_manifests/20250204'
       output_path: '{output_path}/credible_set_datasets_20250204'
+      #!WARNING: DO NOT CHANGE THE DATE for the log_path, as it is used to back reference the already fine-mapped loci.
       log_path: '{output_path}/finemapping_logs/20250204'
       max_records_per_chunk: 40_000
 
@@ -29,8 +29,8 @@ nodes:
     params:
       study_index_path: '{output_path}/study_index'
     google_batch:
-      entrypoint: /bin/sh
       image: 'europe-west1-docker.pkg.dev/open-targets-genetics-dev/gentropy-app/gentropy:{GENTROPY_REF}'
+      entrypoint: /usr/bin/bash
       resource_specs:
         cpu_milli: 4000
         memory_mib: 25_000

--- a/src/orchestration/dags/config/gwas_catalog_top_hits.yaml
+++ b/src/orchestration/dags/config/gwas_catalog_top_hits.yaml
@@ -4,7 +4,7 @@ dataproc:
   autoscaling_policy: otg-gwascatalog-tophit
   python_main_module: gs://genetics_etl_python_playground/initialisation/cli.py
   cluster_metadata:
-    GENTROPY_REF: v2.0.2-rc.3
+    GENTROPY_REF:  v2.3.0-rc.5
   cluster_init_script: gs://genetics_etl_python_playground/initialisation/install_dependencies_on_cluster.sh
   num_workers: 2
 

--- a/src/orchestration/dags/config/gwas_catalog_top_hits.yaml
+++ b/src/orchestration/dags/config/gwas_catalog_top_hits.yaml
@@ -4,7 +4,7 @@ dataproc:
   autoscaling_policy: otg-gwascatalog-tophit
   python_main_module: gs://genetics_etl_python_playground/initialisation/cli.py
   cluster_metadata:
-    GENTROPY_REF:  v2.3.0-rc.5
+    GENTROPY_REF: v2.3.0-rc.5
   cluster_init_script: gs://genetics_etl_python_playground/initialisation/install_dependencies_on_cluster.sh
   num_workers: 2
 

--- a/src/orchestration/dags/config/lof_curation_ingestion.yaml
+++ b/src/orchestration/dags/config/lof_curation_ingestion.yaml
@@ -2,7 +2,7 @@
 dataproc:
   python_main_module: gs://genetics_etl_python_playground/initialisation/cli.py
   cluster_metadata:
-    GENTROPY_REF: v2.0.1
+    GENTROPY_REF:  v2.3.0-rc.5
   cluster_init_script: gs://genetics_etl_python_playground/initialisation/install_dependencies_on_cluster.sh
 
   cluster_name: lof-curation-ingestion

--- a/src/orchestration/dags/config/lof_curation_ingestion.yaml
+++ b/src/orchestration/dags/config/lof_curation_ingestion.yaml
@@ -2,7 +2,7 @@
 dataproc:
   python_main_module: gs://genetics_etl_python_playground/initialisation/cli.py
   cluster_metadata:
-    GENTROPY_REF:  v2.3.0-rc.5
+    GENTROPY_REF: v2.3.0-rc.5
   cluster_init_script: gs://genetics_etl_python_playground/initialisation/install_dependencies_on_cluster.sh
 
   cluster_name: lof-curation-ingestion

--- a/src/orchestration/dags/config/ukb_ppp_eur_harmonisation.yaml
+++ b/src/orchestration/dags/config/ukb_ppp_eur_harmonisation.yaml
@@ -2,7 +2,7 @@
 dataproc:
   python_main_module: gs://genetics_etl_python_playground/initialisation/cli.py
   cluster_metadata:
-    GENTROPY_REF: v2.0.1
+    GENTROPY_REF:  v2.3.0-rc.5
   cluster_init_script: gs://genetics_etl_python_playground/initialisation/install_dependencies_on_cluster.sh
   cluster_name: otg-ukb-ppp-eur
   autoscaling_policy: otg-etl

--- a/src/orchestration/dags/config/ukb_ppp_eur_harmonisation.yaml
+++ b/src/orchestration/dags/config/ukb_ppp_eur_harmonisation.yaml
@@ -2,7 +2,7 @@
 dataproc:
   python_main_module: gs://genetics_etl_python_playground/initialisation/cli.py
   cluster_metadata:
-    GENTROPY_REF:  v2.3.0-rc.5
+    GENTROPY_REF: v2.3.0-rc.5
   cluster_init_script: gs://genetics_etl_python_playground/initialisation/install_dependencies_on_cluster.sh
   cluster_name: otg-ukb-ppp-eur
   autoscaling_policy: otg-etl

--- a/src/orchestration/dags/config/unified_pipeline.yaml
+++ b/src/orchestration/dags/config/unified_pipeline.yaml
@@ -15,7 +15,7 @@ is_ppp: false
 pis_version: '25.2.1'
 pts_version: '25.0.2-beta.4'
 etl_version: '25.2.0-beta.4'
-gentropy_version: '2.3.0-rc.4'
+gentropy_version: '2.3.0-rc.9'
 vep_version: 'release_114.0'
 
 chembl_version: '35'

--- a/src/orchestration/operators/batch/finemapping.py
+++ b/src/orchestration/operators/batch/finemapping.py
@@ -154,7 +154,7 @@ class FinemappingBatchJobManifestOperator(BaseOperator):
         manifest_rows = self._generate_manifest_rows(study_locus_ids)
         manifest_chunks = self._partition_rows_by_range(manifest_rows)
         environments = self._prepare_batch_task_env(manifest_chunks)
-        return environments[0:1]
+        return environments
 
 
 class FinemappingBatchOperator(CloudBatchSubmitJobOperator):
@@ -184,12 +184,13 @@ class FinemappingBatchOperator(CloudBatchSubmitJobOperator):
                     resource_specs=google_batch["resource_specs"],
                     lifecycle_policies=[
                         LifecyclePolicy(
-                            action=LifecyclePolicy.Action.FAIL_TASK,
+                            action=LifecyclePolicy.Action.RETRY_TASK,
                             action_condition=LifecyclePolicy.ActionCondition(
-                                exit_codes=[50005]  # Execution time exceeded.
+                                exit_codes=[50001]  # Task failed due to preemption.
                             ),
-                        )
+                        ),
                     ],
+                    entrypoint=google_batch["entrypoint"],
                 ),
                 task_env=create_task_env(var_list=[{"LOCUS_INDEX": str(idx)} for idx in range(manifest[2])]),
                 policy_specs=google_batch["policy_specs"],
@@ -203,7 +204,9 @@ class FinemappingBatchOperator(CloudBatchSubmitJobOperator):
     def susie_finemapping_command(self) -> list[str]:
         """Get the command for running the fine-mapping batch job."""
         return [
+            "-c",
             (
+                "gentropy "
                 "step=susie_finemapping "
                 f"step.study_index_path={self.study_index_path} "
                 f"step.study_locus_manifest_path={self.study_locus_manifest_path} "

--- a/src/orchestration/operators/batch/finemapping.py
+++ b/src/orchestration/operators/batch/finemapping.py
@@ -153,8 +153,7 @@ class FinemappingBatchJobManifestOperator(BaseOperator):
         study_locus_ids = list(all_study_locus_ids - finemapped_study_locus_ids)
         manifest_rows = self._generate_manifest_rows(study_locus_ids)
         manifest_chunks = self._partition_rows_by_range(manifest_rows)
-        environments = self._prepare_batch_task_env(manifest_chunks)
-        return environments
+        return self._prepare_batch_task_env(manifest_chunks)
 
 
 class FinemappingBatchOperator(CloudBatchSubmitJobOperator):

--- a/src/orchestration/operators/batch/finemapping.py
+++ b/src/orchestration/operators/batch/finemapping.py
@@ -182,7 +182,6 @@ class FinemappingBatchOperator(CloudBatchSubmitJobOperator):
                     commands=self.susie_finemapping_command,
                     task_specs=google_batch["task_specs"],
                     resource_specs=google_batch["resource_specs"],
-                    entrypoint=google_batch["entrypoint"],
                     lifecycle_policies=[
                         LifecyclePolicy(
                             action=LifecyclePolicy.Action.FAIL_TASK,
@@ -194,7 +193,7 @@ class FinemappingBatchOperator(CloudBatchSubmitJobOperator):
                 ),
                 task_env=create_task_env(var_list=[{"LOCUS_INDEX": str(idx)} for idx in range(manifest[2])]),
                 policy_specs=google_batch["policy_specs"],
-                labels=Labels({"gentropy_dag": "UKB-PPP-EUR-SuSiE-Finemapping", "run_id": timestamp}),
+                labels=Labels({"gentropy_dag": "SuSiE-fine-mapping", "run_id": timestamp}),
             ),
             deferrable=False,
             **kwargs,
@@ -202,11 +201,9 @@ class FinemappingBatchOperator(CloudBatchSubmitJobOperator):
 
     @property
     def susie_finemapping_command(self) -> list[str]:
-        """Get the command for running the finemapping batch job."""
+        """Get the command for running the fine-mapping batch job."""
         return [
-            "-c",
             (
-                "uv run gentropy "
                 "step=susie_finemapping "
                 f"step.study_index_path={self.study_index_path} "
                 f"step.study_locus_manifest_path={self.study_locus_manifest_path} "
@@ -229,7 +226,7 @@ class FinemappingBatchOperator(CloudBatchSubmitJobOperator):
                 "+step.session.extended_spark_conf={spark.driver.memory:30g} "
                 "+step.session.extended_spark_conf={spark.kryoserializer.buffer.max:500m} "
                 "+step.session.extended_spark_conf={spark.driver.maxResultSize:5g} "
-                "step.session.write_mode=overwrite"
+                "step.session.write_mode=overwrite "
                 "step.session.output_partitions=1"
             ),
         ]

--- a/src/orchestration/operators/batch/manifest_generators/harmonisation.py
+++ b/src/orchestration/operators/batch/manifest_generators/harmonisation.py
@@ -194,7 +194,6 @@ class HarmonisationManifestGenerator(ProtoManifestGenerator):
         manifest = manifest[["rawSumstatPath", "harmonisedSumstatPath", "qcPath"]]
         # Rename var_list so we have a clear names
         manifest.rename(columns=self.fields, inplace=True)
-        # convert to list of dictionaries
         var_list = manifest.to_dict("records")
         if var_list:
             logger.info("Variable list is not empty!")

--- a/src/orchestration/operators/batch/manifest_generators/harmonisation.py
+++ b/src/orchestration/operators/batch/manifest_generators/harmonisation.py
@@ -89,10 +89,10 @@ class HarmonisationManifestGenerator(ProtoManifestGenerator):
             dict[Literal["sumstat", "study"], list[str]],
         ] = {}
         for key, pattern in globs.items():
-            protocol = pattern.segments.get("protocol")
-            root = pattern.segments.get("root")
-            prefix = pattern.segments.get("prefix")
-            match_glob = pattern.segments.get("filename")
+            protocol = pattern.segments["protocol"]
+            root = pattern.segments["root"]
+            prefix = pattern.segments["prefix"]
+            match_glob = pattern.segments["filename"]
 
             files = self.gcs_hook.list(
                 bucket_name=root,
@@ -100,7 +100,7 @@ class HarmonisationManifestGenerator(ProtoManifestGenerator):
                 # only list files that are in subdirs of this path, not in
                 # any other path that share the last directory name with
                 # target path.
-                prefix=prefix + "/",
+                prefix=f"{prefix}/",
                 match_glob=match_glob,
             )
             if len(files) == 0 and key == "raw_sumstat":

--- a/src/orchestration/operators/batch/manifest_generators/harmonisation.py
+++ b/src/orchestration/operators/batch/manifest_generators/harmonisation.py
@@ -224,8 +224,7 @@ class HarmonisationManifestGenerator(ProtoManifestGenerator):
         Raises:
             ValueError: when identifier is not found.
         """
-        pattern = r"\/(GCST\d+)(\.parquet)?\/"
-        pattern = re.compile(pattern)
+        pattern = re.compile(r"\/(GCST\d+)(\.parquet)?\/")
         result = pattern.search(path)
         if not result:
             raise ValueError("Gwas Catalog identifier was not found in %s", path)

--- a/src/orchestration/operators/batch/vep.py
+++ b/src/orchestration/operators/batch/vep.py
@@ -238,6 +238,7 @@ class VepAnnotateOperator(GoogleCloudBaseOperator):
                 --cache \
                 --offline \
                 --format vcf \
+                --fork 4 \
                 --force_overwrite \
                 --no_stats \
                 --dir_cache {self.pm.cache_dir} \

--- a/src/orchestration/utils/path.py
+++ b/src/orchestration/utils/path.py
@@ -39,8 +39,11 @@ class PathSegments(TypedDict):
 
 
 class ProtoPath(Protocol):
-    segments: PathSegments
-    path: str
+    @cached_property
+    def segments(self) -> PathSegments: ...
+
+    @cached_property
+    def path(self) -> str: ...
 
     @abstractmethod
     def dump(self, data: Any) -> None:


### PR DESCRIPTION
# Context

This PR introduces changes to the:
* harmonisation script to capture new gentropy docker image after refactoring https://github.com/opentargets/gentropy/pull/1023 including:
  * replace gsutil with google cloud storage
  * use latest gentropy base image
  * cli command run without uv
* README update reflecting terraform
* fix for mypy issues in the harmonisation.py