### PR TITLE
chore: set local instance as default in make

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 VERSION := $$(grep '^version' pyproject.toml | sed 's%version = "\(.*\)"%\1%')
-.DEFAULT_GOAL := cloud-dev
+.DEFAULT_GOAL := dev
 LOCAL_DEV_CREDENTIALS ?= ~/.config/gcloud/adc.json
 
 ### HOUSEKEEPING TARGETS ###


### PR DESCRIPTION
This makes more sense, as the cloud instance is usually reserved for pipeline runs and will be used more sparingly. Also, by defaults users should not accidentally spawn a cloud instance.