### PR TITLE
feat: move intervals with pis

### DIFF
--- a/src/orchestration/dags/config/pis.yaml
+++ b/src/orchestration/dags/config/pis.yaml
@@ -437,7 +437,7 @@ steps:
     - name: explode_glob rE2G interval
       glob: gs://interval_data/datasets/ENCODE-rE2G/processed_E2G_2507.parquet/*.parquet
       do:
-        - name: copy rE2G intervalt
+        - name: copy rE2G intervalt ${match_stem}
           source: ${match_prefix}/${match_path}${match_stem}.${match_ext}
           destination: output/interval_rE2G/${uuid}.parquet
 

--- a/src/orchestration/dags/config/pis.yaml
+++ b/src/orchestration/dags/config/pis.yaml
@@ -431,6 +431,20 @@ steps:
       destination: input/interaction/string-interactions.txt.gz
   ##################################################################################################
 
+
+  #: INTERVAL STEP
+  interval:
+    - name: explode_glob rE2G interval
+      glob: gs://interval_data/datasets/ENCODE-rE2G/processed_E2G_2507.parquet/*.parquet
+      do:
+        - name: copy rE2G intervalt
+          source: ${match_prefix}/${match_path}${match_stem}.${match_ext}
+          destination: output/interval_rE2G/${uuid}.parquet
+
+      
+
+  ##################################################################################################
+
   #: L2G STEP :#####################################################################################
   l2g:
     # - name: copy l2g model

--- a/src/orchestration/dags/config/pis.yaml
+++ b/src/orchestration/dags/config/pis.yaml
@@ -436,7 +436,7 @@ steps:
     - name: explode_glob rE2G interval
       glob: gs://interval_data/datasets/ENCODE-rE2G/processed_E2G_2507.parquet/*.parquet
       do:
-        - name: copy rE2G intervalt ${match_stem}
+        - name: copy rE2G interval ${match_stem}
           source: ${match_prefix}/${match_path}${match_stem}.${match_ext}
           destination: output/interval_rE2G/${uuid}.parquet
 

--- a/src/orchestration/dags/config/pis.yaml
+++ b/src/orchestration/dags/config/pis.yaml
@@ -431,7 +431,6 @@ steps:
       destination: input/interaction/string-interactions.txt.gz
   ##################################################################################################
 
-
   #: INTERVAL STEP
   interval:
     - name: explode_glob rE2G interval
@@ -440,8 +439,6 @@ steps:
         - name: copy rE2G intervalt ${match_stem}
           source: ${match_prefix}/${match_path}${match_stem}.${match_ext}
           destination: output/interval_rE2G/${uuid}.parquet
-
-      
 
   ##################################################################################################
 

--- a/src/orchestration/dags/config/unified_pipeline.yaml
+++ b/src/orchestration/dags/config/unified_pipeline.yaml
@@ -53,6 +53,7 @@ steps:
   pis_go:
   pis_l2g:
   pis_interaction:
+  pis_interval:
   pis_literature:
   pis_mouse_phenotype:
   pis_openfda:


### PR DESCRIPTION
# Context

This PR adds the `copy` job for the interval rE2G interval dataset to the unified pipeline.

The dataset is contained in the `gs://interval_data/datasets/ENCODE-rE2G/processed_E2G_2507.parquet` directory with N partitions
```
gs://interval_data/datasets/ENCODE-rE2G/processed_E2G_2507.parquet/part-00056-a669d5d2-bfb4-4c60-828a-d614308cc8a8-c000.snappy.parquet
gs://interval_data/datasets/ENCODE-rE2G/processed_E2G_2507.parquet/part-00057-a669d5d2-bfb4-4c60-828a-d614308cc8a8-c000.snappy.parquet
gs://interval_data/datasets/ENCODE-rE2G/processed_E2G_2507.parquet/part-00058-a669d5d2-bfb4-4c60-828a-d614308cc8a8-c000.snappy.parquet
gs://interval_data/datasets/ENCODE-rE2G/processed_E2G_2507.parquet/part-00059-a669d5d2-bfb4-4c60-828a-d614308cc8a8-c000.snappy.parquet
gs://interval_data/datasets/ENCODE-rE2G/processed_E2G_2507.parquet/part-00060-a669d5d2-bfb4-4c60-828a-d614308cc8a8-c000.snappy.parquet
...
```

To download the file I assumed `explode_glob` task as it it similar to the `l2g` pis task.