### PR TITLE
feat: add literature_dating input to etl evidence config

### DIFF
--- a/src/orchestration/dags/config/etl.conf
+++ b/src/orchestration/dags/config/etl.conf
@@ -170,7 +170,7 @@ steps {
         ]
       }
     }
-    output = {
+    output {
       interactions {
         format = ${common.output_format}
         path = ${common.path}"/output/interaction"
@@ -188,15 +188,15 @@ steps {
 
   target {
     input {
-      chembl = {
+      chembl {
         format = "json"
         path = ${common.path}"/input/target/chembl/chembl_target.jsonl"
       }
-      chemical_probes = {
+      chemical_probes {
         format = "json"
         path = ${common.path}"/input/target/chemicalprobes/chemicalprobes.json.gz"
       }
-      diseases = {
+      diseases {
         format = "parquet"
         path = ${common.path}"/output/disease"
       }
@@ -204,7 +204,7 @@ steps {
         format = ${common.output_format}
         path = ${common.path}"/intermediate/target/ensembl/homo_sapiens.parquet"
       }
-      gene_code = {
+      gene_code {
         format = "csv"
         path = ${common.path}"/input/target/gencode/gencode.gff3.gz"
         options = [
@@ -212,7 +212,7 @@ steps {
           {k: "sep", v: "\\t"}
         ]
       }
-      genetic_constraints = {
+      genetic_constraints {
         format = "csv"
         path = ${common.path}"/input/target/gnomad/gnomad.v4.1.constraint_metrics.tsv"
         options = [
@@ -315,11 +315,11 @@ steps {
         format = "parquet"
         path = ${common.path}"/intermediate/target/project-scores/04_binaryDepScores.parquet"
       }
-      reactome_etl = {
+      reactome_etl {
         format = "parquet"
         path = ${common.path}"/output/reactome/part*"
       }
-      reactome_pathways = {
+      reactome_pathways {
         format = "csv"
         path = ${common.path}"/input/target/reactome/Ensembl2Reactome.txt"
         options = [
@@ -334,7 +334,7 @@ steps {
         format = "json"
         path = ${common.path}"/input/target/tep/tep.json.gz"
       },
-      tractability = {
+      tractability {
         format = "csv"
         path = ${common.path}"/input/target/tractability/tractability.tsv"
         options = [
@@ -408,7 +408,7 @@ steps {
 
   drug {
     input {
-      chemical_probes = {
+      chemical_probes {
         format = "json"
         path = ${common.path}"/input/drug/chemicalprobes.json.gz"
       }
@@ -432,7 +432,7 @@ steps {
         format = "json"
         path = ${common.path}"/input/drug/chembl_drug_warning.jsonl"
       }
-      disease_etl = {
+      disease_etl {
         format = "parquet"
         path = ${common.path}"/output/disease"
       }
@@ -500,11 +500,11 @@ steps {
       }
     }
     input {
-      raw_input_evidences = {
+      raw_input_evidences {
         format = "json"
         path = ${common.path}"/input/evidence/*"
       }
-      raw_intermediate_evidences = {
+      raw_intermediate_evidences {
         format = "json"
         path = ${common.path}"/intermediate/evidence/*"
       }
@@ -514,6 +514,10 @@ steps {
       }
       targets = ${steps.target.output.target}
       mechanism_of_action = ${steps.drug.output.mechanism_of_action}
+      literature_dating {
+        format = "json"
+        path = "gs://otar000-evidence_input/literature_export/*"
+      }
     }
     direction_of_effect {
       var_filter_lof = [
@@ -1064,7 +1068,7 @@ steps {
   }
 
   go {
-    input = {
+    input {
       go {
         format = "csv"
         path = ${common.path}"/input/go/go.obo"
@@ -1080,27 +1084,27 @@ steps {
 
   association {
     output {
-      direct_by_datatype = {
+      direct_by_datatype {
         format = ${common.output_format}
         path = ${common.path}"/output/association_by_datatype_direct"
       }
-      direct_by_datasource = {
+      direct_by_datasource {
         format = ${common.output_format}
         path = ${common.path}"/output/association_by_datasource_direct"
       }
-      direct_by_overall = {
+      direct_by_overall {
         format = ${common.output_format}
         path = ${common.path}"/output/association_overall_direct"
       }
-      indirect_by_datasource = {
+      indirect_by_datasource {
         format = ${common.output_format}
         path = ${common.path}"/output/association_by_datasource_indirect"
       }
-      indirect_by_datatype = {
+      indirect_by_datatype {
         format = ${common.output_format}
         path = ${common.path}"/output/association_by_datatype_indirect"
       }
-      indirect_by_overall = {
+      indirect_by_overall {
         format = ${common.output_format}
         path = ${common.path}"/output/association_by_overall_indirect"
       }
@@ -1129,7 +1133,7 @@ steps {
   }
 
   association_otf {
-    input = {
+    input {
       diseases {
         format = "parquet"
         path = ${common.path}"/output/disease"
@@ -1137,8 +1141,8 @@ steps {
       evidences = ${steps.evidence.output.succeeded}
       targets = ${steps.target.output.target}
     }
-    output = {
-      clickhouse = {
+    output {
+      clickhouse {
         format = ${common.output_format}
         path = ${common.path}"/view/association_otf"
       }
@@ -1146,17 +1150,17 @@ steps {
   }
 
   search {
-    input = {
+    input {
       evidence = ${steps.evidence.output.succeeded}
       disease {
         format = "parquet"
         path = ${common.path}"/output/disease"
       }
-      disease_hpo = {
+      disease_hpo {
         format = "parquet"
         path = ${common.path}"/output/disease_phenotype"
       }
-      hpo = {
+      hpo {
         format = "parquet"
         path = ${common.path}"/output/disease_hpo"
       }
@@ -1165,15 +1169,15 @@ steps {
       mechanism = ${steps.drug.output.mechanism_of_action}
       indication = ${steps.drug.output.indications}
       association = ${steps.association.output.indirect_by_overall}
-      credible_sets = {
+      credible_sets {
         format = "parquet"
         path = ${common.path}"/output/credible_set"
       }
-      studies = {
+      studies {
         format = "parquet"
         path = ${common.path}"/output/study"
       }
-      variants = {
+      variants {
         format = "parquet"
         path = ${common.path}"/output/variant"
       }
@@ -1278,7 +1282,7 @@ steps {
       }
       association = ${steps.association.output.direct_by_overall}
     }
-    output = {
+    output {
       associations {
         format = ${common.output_format}
         path = ${common.path}"/view/search_ebi_associations"
@@ -1324,7 +1328,7 @@ steps {
   }
 
   literature {
-    common = {
+    common {
       publication_section_ranks = [
         {section: "title",    rank: 1, weight: 1.0}
         {section: "abstract", rank: 1, weight: 0.8}
@@ -1402,11 +1406,11 @@ steps {
           {k: "compression", v: "gzip"},
         ]
       }
-      embedding_model = {
+      embedding_model {
         format = ${common.output_format}
         path = ${common.path}"/etc/model/w2v_model"
       }
-      embedding_training_set = {
+      embedding_training_set {
         format = ${common.output_format}
         path = ${common.path}"/intermediate/literature_training_set"
       }
@@ -1487,15 +1491,15 @@ steps {
       targets = ${steps.target.output.target}
       molecule = ${steps.drug.output.drug}
       mechanism_of_action = ${steps.drug.output.mechanism_of_action}
-      mouse_phenotypes = {
+      mouse_phenotypes {
         format = "json"
         path = ${common.path}"/input/mouse_phenotype/mouse_phenotypes.json.gz"
       }
-      hpa_data = {
+      hpa_data {
         format = "json"
         path = ${common.path}"/input/target_engine/proteinatlas.json.gz"
       }
-      uniprot_slterms = {
+      uniprot_slterms {
         format = "csv"
         path = ${common.path}"/input/target_engine/uniprot_locations.tsv.gz"
         options = [
@@ -1503,7 +1507,7 @@ steps {
           {k: "sep", v: "\t"},
         ]
       }
-      mouse_pheno_scores = {
+      mouse_pheno_scores {
         format = "csv"
         path = ${common.path}"/input/target_engine/mouse_pheno_scores.csv"
         options = [
@@ -1514,7 +1518,7 @@ steps {
       }
     }
     output {
-      target_engine = {
+      target_engine {
         path = ${common.path}"/output/target_prioritisation"
         format = ${common.output_format}
       }


### PR DESCRIPTION
Simple change to add the config related to https://github.com/opentargets/platform-etl-backend/pull/392 into the ETL configuration. Also fixes a couple of formatting issues.