### PR TITLE
feat: config changes for 25.09-ppp run

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,18 @@
 FROM apache/airflow:slim-2.10.5-python3.12
+USER root
+ENV DEBIAN_FRONTEND=noninteractive
+# Add g++
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends g++ \
+  && apt-get autoremove -yqq --purge \
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/*
+USER airflow
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /bin/uv
-
 COPY pyproject.toml README.md ./
-
 # We have to install dependencies like this because uv does not seem to install
 # `psycopg2-binary` properly when using the `--no-install-project` flag.
+
 RUN uv pip compile pyproject.toml -o requirements.txt && uv pip install -r requirements.txt
 
 USER 0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ pep621_dev_dependency_groups = ["test"]
 
 
 [tool.deptry.per_rule_ignores]
-DEP002 = ["psycopg2-binary"]
+DEP002 = ["psycopg2-binary", "flask-limiter"]
 
 [tool.pytest.ini_options]
 filterwarnings = "ignore::DeprecationWarning"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ dependencies = [
     "apache-airflow-providers-apache-beam==6.0.3",
     "deepdiff>=8.4.2",
     "deepmerge>=2.0",
+    "flask-limiter==3.12",
 ]
 
 [project.optional-dependencies]

--- a/src/orchestration/dags/config/clusters.yaml
+++ b/src/orchestration/dags/config/clusters.yaml
@@ -16,7 +16,7 @@ clusters:
     properties:
       'spark:spark.driver.memory': '478g'
       'spark:spark.sql.shuffle.partitions': '20'
-  
+
   etl_evidence:
     image_version: '2.2'
     num_masters: 1
@@ -28,7 +28,7 @@ clusters:
     properties:
       'spark:spark.shuffle.service.enabled': 'true'
       'spark:spark.sql.adaptive.enabled': 'true'
-  
+
   gentropy:
     image_version: '2.2'
     autoscaling_policy: otg-etl

--- a/src/orchestration/dags/config/clusters.yaml
+++ b/src/orchestration/dags/config/clusters.yaml
@@ -16,7 +16,19 @@ clusters:
     properties:
       'spark:spark.driver.memory': '478g'
       'spark:spark.sql.shuffle.partitions': '20'
-
+  
+  etl_evidence:
+    image_version: '2.2'
+    num_masters: 1
+    num_workers: 2
+    autoscaling_policy: otg-etl
+    worker_machine_type: 'n1-highmem-16'
+    idle_delete_ttl: 3600
+    internal_ip_only: false
+    properties:
+      'spark:spark.shuffle.service.enabled': 'true'
+      'spark:spark.sql.adaptive.enabled': 'true'
+  
   gentropy:
     image_version: '2.2'
     autoscaling_policy: otg-etl

--- a/src/orchestration/dags/config/pis.yaml
+++ b/src/orchestration/dags/config/pis.yaml
@@ -438,7 +438,7 @@ steps:
       do:
         - name: copy rE2G interval ${match_stem}
           source: ${match_prefix}/${match_path}${match_stem}.${match_ext}
-          destination: output/interval_rE2G/${uuid}.parquet
+          destination: output/interval/${uuid}.parquet
 
   ##################################################################################################
 

--- a/src/orchestration/dags/config/unified_pipeline.py
+++ b/src/orchestration/dags/config/unified_pipeline.py
@@ -100,7 +100,6 @@ class UnifiedPipelineConfig:
                 "gentropy_version": up.get("gentropy_version"),
                 "l2g_training_version": up.get("release_name"),
                 "vep_version": up.get("vep_version"),
-                "requester_pays_project_id": GCP_PROJECT_PLATFORM,
             },
         )
         """The internal configuration for GENTROPY steps."""
@@ -113,6 +112,7 @@ class UnifiedPipelineConfig:
             file_path=config_path / "clusters.yaml",
             template_context={
                 "gentropy_version": up.get("gentropy_version"),
+                "requester_pays_project_id": GCP_PROJECT_PLATFORM,
             },
         )
         """The cluster definitions."""

--- a/src/orchestration/dags/config/unified_pipeline.yaml
+++ b/src/orchestration/dags/config/unified_pipeline.yaml
@@ -1,21 +1,21 @@
 ---
-release_name: '25.09'
+release_name: '25.09-ppp'
 
 # If `is_dev` is true:
 #   * the bucket used for the run will be `open-targets-pipeline-runs`
 #   * the prefix inside the bucket will be `run_name`
 #         which defaults to a timestamp if not provided.
 is_dev: true
-run_name: 'il/25.09-testrun-1'
+run_name: 'szsz/25.09-ppp-testrun-1'
 
 # Whether this will be a partner preview platform release (PPP)
-is_ppp: false
+is_ppp: true
 
 # Versions for software and data
 pis_version: '25.2.1'
 pts_version: '25.2.1-rc.1'
 etl_version: '25.2.0-rc.1'
-gentropy_version: '2.4.0-rc.4'
+gentropy_version: '2.4.2-rc.1'
 vep_version: 'release_114.0'
 
 chembl_version: '35'

--- a/uv.lock
+++ b/uv.lock
@@ -1168,18 +1168,17 @@ wheels = [
 
 [[package]]
 name = "flask-limiter"
-version = "3.11.0"
+version = "3.12"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "flask" },
     { name = "limits" },
     { name = "ordered-set" },
     { name = "rich" },
-    { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/9c/a4/02f67783825a4207d4ae7de4c8be45596c3fba5b65ace77fd6dc3878020d/flask_limiter-3.11.0.tar.gz", hash = "sha256:57b037fb8be423ef7ebac4fbb279fbfdc42d9aa5378467ab6798d6ce3d912117", size = 303361, upload-time = "2025-03-11T20:37:59.839Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/70/75/92b237dd4f6e19196bc73007fff288ab1d4c64242603f3c401ff8fc58a42/flask_limiter-3.12.tar.gz", hash = "sha256:f9e3e3d0c4acd0d1ffbfa729e17198dd1042f4d23c130ae160044fc930e21300", size = 303162, upload-time = "2025-03-15T02:23:10.734Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0d/6b/54101d1e595686da1fb90e0fb23497de959a39c7f398d4dda7fcdcc5cd76/flask_limiter-3.11.0-py3-none-any.whl", hash = "sha256:ae7ef0b3742228df91073d72eab0ce114fe6b00e6201ad9e12aefd53fe597352", size = 28684, upload-time = "2025-03-11T20:37:58.227Z" },
+    { url = "https://files.pythonhosted.org/packages/66/ba/40dafa278ee6a4300179d2bf59a1aa415165c26f74cfa17462132996186b/flask_limiter-3.12-py3-none-any.whl", hash = "sha256:b94c9e9584df98209542686947cf647f1ede35ed7e4ab564934a2bb9ed46b143", size = 28490, upload-time = "2025-03-15T02:23:08.919Z" },
 ]
 
 [[package]]
@@ -2941,6 +2940,7 @@ dependencies = [
     { name = "apache-airflow-providers-google" },
     { name = "deepdiff" },
     { name = "deepmerge" },
+    { name = "flask-limiter" },
     { name = "google" },
     { name = "pandas" },
     { name = "psycopg2-binary" },
@@ -2969,6 +2969,7 @@ requires-dist = [
     { name = "apache-airflow-providers-google", specifier = "==14.1.0" },
     { name = "deepdiff", specifier = ">=8.4.2" },
     { name = "deepmerge", specifier = ">=2.0" },
+    { name = "flask-limiter", specifier = "==3.12" },
     { name = "google", specifier = "==3.0.0" },
     { name = "pandas", specifier = "==2.1.4" },
     { name = "psycopg2-binary", specifier = "==2.9.10" },


### PR DESCRIPTION
# Context 

See https://github.com/opentargets/issues/issues/4012#issuecomment-3321721908

## Implementations

Below one can find a short list of changes introduced for successful run of `25.09-ppp`:

* Fix to propagation of `requester_pays_project_id` to the `clusters.yaml`.
* Update to gentropy `v2.4.2-rc.1` to ensure `skops` is limited to v0.12 supressing breaking changes.
* Swap `interval_rE2G` with `interval` for interval dataset.
* Adding `gitleaks` to the pre-commit to ensure parsing repo before uploading secrets.
* Introducing new cluster definition for `etl_evidence` step run.
* Dependencies - freeze version of `flask-limiter` to 3.12 to suppress FAB authentication issue.
* Dockerfile - introduce g++ as a dependency ensuring Airflow dependency `madoka` is successfully build.
