### PR TITLE
feat: add pis_study and pis_credible_set

### DIFF
--- a/src/orchestration/dags/config/gentropy.yaml
+++ b/src/orchestration/dags/config/gentropy.yaml
@@ -30,12 +30,13 @@ steps:
         - CASE_CASE_STUDY_DESIGN
       # INPUTS
       step.study_index_path:
-        - gs://gwas_catalog_top_hits/study_index
-        - gs://gwas_catalog_sumstats_susie/study_index
-        - gs://gwas_catalog_sumstats_pics/study_index
-        - gs://eqtl_catalogue_data/study_index
-        - gs://ukb_ppp_eur_data/study_index
-        - gs://finngen_data/r12/study_index
+        - '{{release_uri}}/input/study/GCCA'
+        - '{{release_uri}}/input/study/GCSS-pics'
+        - '{{release_uri}}/input/study/GCSS-susie'
+        - '{{release_uri}}/input/study/eQTL-Catalogue'
+        - '{{release_uri}}/input/study/UKB-PPP'
+        - '{{release_uri}}/input/study/FinnGen'
+        - '{{release_uri}}/input/study/FinnGen-UKB-MVP'
       step.target_index_path: '{{release_uri}}/output/target'
       step.disease_index_path: '{{release_uri}}/output/disease'
       step.biosample_index_path: '{{release_uri}}/output/biosample'
@@ -68,12 +69,13 @@ steps:
       step.trans_qtl_threshold: 5_000_000
       # INPUTS
       step.study_locus_path:
-        - gs://gwas_catalog_top_hits/credible_sets/
-        - gs://gwas_catalog_sumstats_pics/credible_sets/
-        - gs://gwas_catalog_sumstats_susie/credible_set_clean/20250721/
-        - gs://eqtl_catalogue_data/credible_set_datasets/eqtl_catalogue_susie_patched_v2/
-        - gs://ukb_ppp_eur_data/credible_set_clean/20250129/
-        - gs://finngen_data/r12/credible_set_datasets/susie/
+        - '{{release_uri}}/input/credible_set/GCCA'
+        - '{{release_uri}}/input/credible_set/GCSS-pics'
+        - '{{release_uri}}/input/credible_set/GCSS-susie'
+        - '{{release_uri}}/input/credible_set/eQTL-Catalogue'
+        - '{{release_uri}}/input/credible_set/UKB-PPP'
+        - '{{release_uri}}/input/credible_set/FinnGen'
+        - '{{release_uri}}/input/credible_set/FinnGen-UKB-MVP'
       step.study_index_path: '{{release_uri}}/output/study'
       step.target_index_path: '{{release_uri}}/output/target'
       # OUTPUTS

--- a/src/orchestration/dags/config/pis.yaml
+++ b/src/orchestration/dags/config/pis.yaml
@@ -27,6 +27,90 @@ steps:
       destination: input/biosample/efo.json
   ##################################################################################################
 
+
+  #: CREDIBLE_SET STEP :########################################################################
+
+  credible_set:
+    - name: explode_glob gwas catalog top hits credible_set
+      glob: gs://gwas_catalog_top_hits/credible_sets/*.parquet
+      do:
+        - name: copy gwas_catalog top hits credible_set ${match_stem}
+          source: ${match_prefix}/${match_path}${match_stem}.${match_ext}
+          destination: input/credible_set/GCCA/${uuid}.parquet
+
+    - name: explode_glob gwas catalog sumstats susie credible_set
+      glob: gs://gwas_catalog_sumstats_susie/credible_set_clean/20250721/*.parquet
+      do:
+        - name: copy gwas_catalog sumstats susie credible_set ${match_stem}
+          source: ${match_prefix}/${match_path}${match_stem}.${match_ext}
+          destination: input/credible_set/GCSS-susie/${uuid}.parquet
+
+    - name: explode_glob gwas catalog sumstats pics credible_set
+      glob: gs://gwas_catalog_sumstats_pics/credible_sets/*.parquet
+      do:
+        - name: copy gwas catalog sumstats pics credible_set ${match_stem}
+          source: ${match_prefix}/${match_path}${match_stem}.${match_ext}
+          destination: input/credible_set/GCSS-pics/${uuid}.parquet
+
+    - name: explode_glob finngen credible_set
+      glob: gs://finngen_data/r12/credible_set_datasets/susie/*.parquet
+      do:
+        - name: copy finngen credible_set ${match_stem}
+          source: ${match_prefix}/${match_path}${match_stem}.${match_ext}
+          destination: input/credible_set/FinnGen/${uuid}.parquet
+
+    - name: explode_glob eqtl catalogue credible_set
+      glob: gs://eqtl_catalogue_data/credible_set_datasets/eqtl_catalogue_susie_patched_v2/*.parquet
+      do:
+        - name: copy eqtl catalogue credible_set ${match_stem}
+          source: ${match_prefix}/${match_path}${match_stem}.${match_ext}
+          destination: input/credible_set/eQTL-Catalogue/${uuid}.parquet
+
+    - name: explode_glob ukb ppp eur credible_set
+      glob: gs://ukb_ppp_eur_data/credible_set_clean/20250129/*.parquet
+      do:
+        - name: copy ukb ppp eur credible_set ${match_stem}
+          source: ${match_prefix}/${match_path}${match_stem}.${match_ext}
+          destination: input/credible_set/UKB-PPP/${uuid}.parquet
+
+    - name: explode_glob finngen ukb mvp meta credible_set
+      glob: gs://finngen_ukb_mvp_meta_data/credible_sets/*.parquet
+      do:
+        - name: copy finngen ukb mvp meta credible_set ${match_stem}
+          source: ${match_prefix}/${match_path}${match_stem}.${match_ext}
+          destination: input/credible_set/FinnGen-UKB-MVP/${uuid}.parquet
+
+  ##################################################################################################
+
+  #: CREDIBLE_SET PPP STEP :####################################################################
+
+  credible_set_ppp:
+    - name: explode_glob ppp microglia credible_set
+      glob: gs://eqtl_catalogue_processed_otar_internal_data/otar2077/microglia/gentropy/study_locus/*/*.parquet
+      do:
+        - name: copy ppp microglia credible_set ${uri}
+          source: ${uri}
+          # Flattens the directory structure
+          destination: input/credible_set/microglia/${match_stem}.${match_ext}
+
+    - name: explode_glob ppp mage_otar credible_set
+      glob: gs://eqtl_catalogue_processed_otar_internal_data/otar2077/MAGE_OTAR/gentropy/study_locus/*/*.parquet
+      do:
+        - name: copy ppp mage_otar credible_set ${uri}
+          source: ${uri}
+          # Flattens the directory structure
+          destination: input/credible_set/MAGE_OTAR/${match_stem}.${match_ext}
+
+    - name: explode_glob ppp ibdverse credible_set
+      glob: gs://eqtl_catalogue_processed_otar_internal_data/otar2077/IBDverse/gentropy/study_locus/*/*.parquet
+      do:
+        - name: copy ppp ibdverse credible_set ${uri}
+          source: ${uri}
+          # Flattens the directory structure
+          destination: input/credible_set/IBDverse/${match_stem}.${match_ext}
+
+  ##################################################################################################
+
   #: DISEASE STEP :#################################################################################
   disease:
     - name: copy efo otar_slim
@@ -536,6 +620,85 @@ steps:
     - name: copy sequence ontology
       source: https://raw.githubusercontent.com/The-Sequence-Ontology/SO-Ontologies/master/Ontology_Files/so.json
       destination: input/so/so.json
+  ##################################################################################################
+
+  #: STUDY STEP :########################################################################
+
+  study:
+    - name: explode_glob gwas catalog top hits study
+      glob: gs://gwas_catalog_top_hits/study_index/*.parquet
+      do:
+        - name: copy gwas_catalog top hits study ${match_stem}
+          source: ${match_prefix}/${match_path}${match_stem}.${match_ext}
+          destination: input/study/GCCA/${uuid}.parquet
+
+    - name: explode_glob gwas catalog sumstats susie study
+      glob: gs://gwas_catalog_sumstats_susie/study_index/*.parquet
+      do:
+        - name: copy gwas_catalog sumstats susie study ${match_stem}
+          source: ${match_prefix}/${match_path}${match_stem}.${match_ext}
+          destination: input/study/GCSS-susie/${uuid}.parquet
+
+    - name: explode_glob gwas catalog sumstats pics study
+      glob: gs://gwas_catalog_sumstats_pics/study_index/*.parquet
+      do:
+        - name: copy finngen sumstats pics study ${match_stem}
+          source: ${match_prefix}/${match_path}${match_stem}.${match_ext}
+          destination: input/study/GCSS-pics/${uuid}.parquet
+
+    - name: explode_glob finngen study
+      glob: gs://finngen_data/r12/study_index/*.parquet
+      do:
+        - name: copy finngen study ${match_stem}
+          source: ${match_prefix}/${match_path}${match_stem}.${match_ext}
+          destination: input/study/FinnGen/${uuid}.parquet
+
+    - name: explode_glob eqtl catalogue study
+      glob: gs://eqtl_catalogue_data/study_index/*.parquet
+      do:
+        - name: copy eqtl catalogue study ${match_stem}
+          source: ${match_prefix}/${match_path}${match_stem}.${match_ext}
+          destination: input/study/eQTL-Catalogue/${uuid}.parquet
+    
+    - name: explode_glob ukb ppp eur study
+      glob: gs://ukb_ppp_eur_data/study_index/*.parquet
+      do:
+        - name: copy ukb ppp eur study ${match_stem}
+          source: ${match_prefix}/${match_path}${match_stem}.${match_ext}
+          destination: input/study/UKB-PPP/${uuid}.parquet
+    
+    - name: explode_glob finngen ukb mvp meta study
+      glob: gs://finngen_ukb_mvp_meta_data/study_index/*.parquet
+      do:
+        - name: copy finngen ukb mvp meta study ${match_stem}
+          source: ${match_prefix}/${match_path}${match_stem}.${match_ext}
+          destination: input/study/FinnGen-UKB-MVP/${uuid}.parquet
+
+  ##################################################################################################
+
+  #: STUDY PPP STEP :########################################################################
+  study_ppp:
+    - name: explode_glob ppp microglia study
+      glob: gs://eqtl_catalogue_processed_otar_internal_data/otar2077/microglia/gentropy/study_index/*/*.parquet
+      do:
+        - name: copy ppp microglia study ${uri}
+          source: ${uri}
+          destination: input/study/microglia/${match_stem}.${match_ext}
+
+    - name: explode_glob ppp mage_otar study
+      glob: gs://eqtl_catalogue_processed_otar_internal_data/otar2077/MAGE_OTAR/gentropy/study_index/*/*.parquet
+      do:
+        - name: copy ppp mage_otar study ${uri}
+          source: ${uri}
+          destination: input/study/MAGE_OTAR/${match_stem}.${match_ext}
+
+    - name: explode_glob ppp ibdverse study
+      glob: gs://eqtl_catalogue_processed_otar_internal_data/otar2077/IBDverse/gentropy/study_index/*/*.parquet
+      do:
+        - name: copy ppp ibdverse study ${uri}
+          source: ${uri}
+          destination: input/study/IBDverse/${match_stem}.${match_ext}
+
   ##################################################################################################
 
   #: TARGET STEP :##################################################################################

--- a/src/orchestration/dags/config/pis.yaml
+++ b/src/orchestration/dags/config/pis.yaml
@@ -27,9 +27,7 @@ steps:
       destination: input/biosample/efo.json
   ##################################################################################################
 
-
   #: CREDIBLE_SET STEP :########################################################################
-
   credible_set:
     - name: explode_glob gwas catalog top hits credible_set
       glob: gs://gwas_catalog_top_hits/credible_sets/*.parquet
@@ -79,11 +77,9 @@ steps:
         - name: copy finngen ukb mvp meta credible_set ${match_stem}
           source: ${match_prefix}/${match_path}${match_stem}.${match_ext}
           destination: input/credible_set/FinnGen-UKB-MVP/${uuid}.parquet
-
   ##################################################################################################
 
   #: CREDIBLE_SET PPP STEP :####################################################################
-
   credible_set_ppp:
     - name: explode_glob ppp microglia credible_set
       glob: gs://eqtl_catalogue_processed_otar_internal_data/otar2077/microglia/gentropy/study_locus/*/*.parquet
@@ -108,7 +104,6 @@ steps:
           source: ${uri}
           # Flattens the directory structure
           destination: input/credible_set/IBDverse/${match_stem}.${match_ext}
-
   ##################################################################################################
 
   #: DISEASE STEP :#################################################################################
@@ -623,7 +618,6 @@ steps:
   ##################################################################################################
 
   #: STUDY STEP :########################################################################
-
   study:
     - name: explode_glob gwas catalog top hits study
       glob: gs://gwas_catalog_top_hits/study_index/*.parquet
@@ -659,21 +653,20 @@ steps:
         - name: copy eqtl catalogue study ${match_stem}
           source: ${match_prefix}/${match_path}${match_stem}.${match_ext}
           destination: input/study/eQTL-Catalogue/${uuid}.parquet
-    
+
     - name: explode_glob ukb ppp eur study
       glob: gs://ukb_ppp_eur_data/study_index/*.parquet
       do:
         - name: copy ukb ppp eur study ${match_stem}
           source: ${match_prefix}/${match_path}${match_stem}.${match_ext}
           destination: input/study/UKB-PPP/${uuid}.parquet
-    
+
     - name: explode_glob finngen ukb mvp meta study
       glob: gs://finngen_ukb_mvp_meta_data/study_index/*.parquet
       do:
         - name: copy finngen ukb mvp meta study ${match_stem}
           source: ${match_prefix}/${match_path}${match_stem}.${match_ext}
           destination: input/study/FinnGen-UKB-MVP/${uuid}.parquet
-
   ##################################################################################################
 
   #: STUDY PPP STEP :########################################################################
@@ -698,7 +691,6 @@ steps:
         - name: copy ppp ibdverse study ${uri}
           source: ${uri}
           destination: input/study/IBDverse/${match_stem}.${match_ext}
-
   ##################################################################################################
 
   #: TARGET STEP :##################################################################################

--- a/src/orchestration/dags/config/ppp/gentropy.overrides.yaml
+++ b/src/orchestration/dags/config/ppp/gentropy.overrides.yaml
@@ -7,30 +7,32 @@ steps:
   study:
     params:
       step.study_index_path:
-        - gs://gwas_catalog_top_hits/study_index
-        - gs://gwas_catalog_sumstats_susie/study_index
-        - gs://gwas_catalog_sumstats_pics/study_index
-        - gs://eqtl_catalogue_data/study_index
-        - gs://ukb_ppp_eur_data/study_index
-        - gs://finngen_data/r12/study_index
+        - '{{release_uri}}/input/study/GCCA'
+        - '{{release_uri}}/input/study/GCSS-pics'
+        - '{{release_uri}}/input/study/GCSS-susie'
+        - '{{release_uri}}/input/study/eQTL-Catalogue'
+        - '{{release_uri}}/input/study/UKB-PPP'
+        - '{{release_uri}}/input/study/FinnGen'
+        - '{{release_uri}}/input/study/FinnGen-UKB-MVP'
         # PPP
-        - gs://eqtl_catalogue_processed_otar_internal_data/otar2077/microglia/gentropy/study_index/*
-        - gs://eqtl_catalogue_processed_otar_internal_data/otar2077/MAGE_OTAR/gentropy/study_index/*
-        - gs://eqtl_catalogue_processed_otar_internal_data/otar2077/IBDverse/gentropy/study_index/*
+        - '{{release_uri}}/input/study/microglia'
+        - '{{release_uri}}/input/study/MAGE_OTAR'
+        - '{{release_uri}}/input/study/IBDverse'
 
   credible_set:
     params:
       step.study_locus_path:
-        - gs://gwas_catalog_top_hits/credible_sets/
-        - gs://gwas_catalog_sumstats_pics/credible_sets/
-        - gs://gwas_catalog_sumstats_susie/credible_set_clean/20250611/
-        - gs://eqtl_catalogue_data/credible_set_datasets/eqtl_catalogue_susie_patched_v2/
-        - gs://ukb_ppp_eur_data/credible_set_clean/20250129/
-        - gs://finngen_data/r12/credible_set_datasets/susie/
+        - '{{release_uri}}/input/credible_set/GCCA'
+        - '{{release_uri}}/input/credible_set/GCSS-pics'
+        - '{{release_uri}}/input/credible_set/GCSS-susie'
+        - '{{release_uri}}/input/credible_set/eQTL-Catalogue'
+        - '{{release_uri}}/input/credible_set/UKB-PPP'
+        - '{{release_uri}}/input/credible_set/FinnGen'
+        - '{{release_uri}}/input/credible_set/FinnGen-UKB-MVP'
         # PPP
-        - gs://eqtl_catalogue_processed_otar_internal_data/otar2077/microglia/gentropy/study_locus/*
-        - gs://eqtl_catalogue_processed_otar_internal_data/otar2077/MAGE_OTAR/gentropy/study_locus/*
-        - gs://eqtl_catalogue_processed_otar_internal_data/otar2077/IBDverse/gentropy/study_locus/*
+        - '{{release_uri}}/input/credible_set/microglia'
+        - '{{release_uri}}/input/credible_set/MAGE_OTAR'
+        - '{{release_uri}}/input/credible_set/IBDverse'
 
   variant:
     params:

--- a/src/orchestration/dags/config/unified_pipeline.yaml
+++ b/src/orchestration/dags/config/unified_pipeline.yaml
@@ -45,6 +45,9 @@ steps:
   # PIS STEPS
   pis_biosample:
   pis_disease:
+  pis_credible_set:
+  pis_credible_set_ppp:
+    ppp_only: true
   pis_drug:
   pis_evidence:
   pis_evidence_ppp:
@@ -62,6 +65,9 @@ steps:
   pis_pharmacogenomics:
   pis_reactome:
   pis_so:
+  pis_study:
+  pis_study_ppp:
+    ppp_only: true
   pis_target:
   pis_target_engine:
 
@@ -183,14 +189,20 @@ steps:
 
   gentropy_study:
     depends_on:
+      - pis_study
       - pts_target
       - pts_disease
       - etl_target
       - gentropy_biosample
+    depends_on_ppp:
+      - pis_study_ppp
 
   gentropy_credible_set:
     depends_on:
       - gentropy_study
+      - pis_credible_set
+    depends_on_ppp:
+      - pis_credible_set_ppp
 
   gentropy_colocalisation_coloc:
     depends_on:


### PR DESCRIPTION
# Context

This PR closes https://github.com/opentargets/issues/issues/3734

## Implementations

1. Add jobs to download studies and credible_sets from the staging buckets and put the raw data into `${release_uri}/input`
2. Update overwrites for the gentropy ppp config to include the  input paths
3. Add `pis_study`, `pis_credible_set` and ppp versions of the steps to the up config

>[!NOTE]
> study and credible set dataset names are following the [platform docs](https://platform-docs.opentargets.org/gentropy/fine-mapping

>[!WARNING]
> This is still WIP, as the otter may use the copy_dir job that would make this much easier

>[!NOTE]
> ppp credible sets and studies have additional folder component that needs to be flattened before passing 
> to gentropy.

## Tests

I had tested the jobs on local PIS instance.