### PR TITLE
feat: updating colocalisation steps to use colocpip_and_ecaviar

### DIFF
--- a/src/orchestration/dags/config/gentropy.yaml
+++ b/src/orchestration/dags/config/gentropy.yaml
@@ -105,6 +105,18 @@ steps:
       # OUTPUTS
       step.coloc_path: '{{release_uri}}/output/colocalisation_ecaviar'
 
+  colocalisation_colocpip_and_ecaviar:
+    params:
+      step: colocalisation
+      step.session.write_mode: overwrite
+      step.session.output_partitions: 25
+      step.colocalisation_method: coloc_pip_ecaviar
+      +step.session.extended_spark_conf: "{spark.executor.memory: '25g', spark.executor.memoryOverhead: '1g', spark.executor.cores: '4'}"
+      # INPUTS
+      step.credible_set_path: '{{release_uri}}/output/credible_set'
+      # OUTPUTS
+      step.colocpip_ecaviar_path: '{{release_uri}}/output/colocalisation'
+
   variant_partition:
     params:
       step: variant_to_vcf
@@ -168,7 +180,7 @@ steps:
       # INPUTS
       step.credible_set_path: '{{release_uri}}/output/credible_set'
       step.variant_index_path: '{{release_uri}}/output/variant'
-      step.colocalisation_path: '{{release_uri}}/output/colocalisation_*'
+      step.colocalisation_path: '{{release_uri}}/output/colocalisation'
       step.study_index_path: '{{release_uri}}/output/study'
       step.target_index_path: '{{release_uri}}/output/target'
       # OUTPUTS

--- a/src/orchestration/dags/config/gentropy.yaml
+++ b/src/orchestration/dags/config/gentropy.yaml
@@ -115,7 +115,7 @@ steps:
       # INPUTS
       step.credible_set_path: '{{release_uri}}/output/credible_set'
       # OUTPUTS
-      step.colocpip_ecaviar_path: '{{release_uri}}/output/colocalisation'
+      step.coloc_path: '{{release_uri}}/output/colocalisation'
 
   variant_partition:
     params:

--- a/src/orchestration/dags/config/unified_pipeline.yaml
+++ b/src/orchestration/dags/config/unified_pipeline.yaml
@@ -192,12 +192,10 @@ steps:
     depends_on:
       - gentropy_study
 
-  gentropy_colocalisation_coloc:
+  gentropy_colocalisation_colocpip_and_ecaviar:
     depends_on:
       - gentropy_credible_set
-  gentropy_colocalisation_ecaviar:
-    depends_on:
-      - gentropy_credible_set
+
   gentropy_variant_partition:
     depends_on:
       - pis_evidence
@@ -214,8 +212,7 @@ steps:
 
   gentropy_l2g_feature_matrix:
     depends_on:
-      - gentropy_colocalisation_coloc
-      - gentropy_colocalisation_ecaviar
+      - gentropy_colocalisation_colocpip_and_ecaviar
       - gentropy_variant
 
   gentropy_l2g_training:


### PR DESCRIPTION
This PR updates orchestration to use the new colocPIP w/ ecaviar step parameters and changes paths for the subsequent feature matrix generation.

As a consequence, we now output one colocalisation dataframe where each studylocus pair has one row for both colocPIP h3/h4 and eCAVIAR clpp.