### PR TITLE
feat: expose gencode version to up config

### DIFF
--- a/src/orchestration/dags/config/pis.yaml
+++ b/src/orchestration/dags/config/pis.yaml
@@ -565,7 +565,7 @@ steps:
       destination: input/target/ensembl/homo_sapiens.json
 
     - name: copy gencode
-      source: https://ftp.ebi.ac.uk/pub/databases/gencode/Gencode_human/latest/gencode.v${gencode_version}.annotation.gff3.gz
+      source: https://ftp.ebi.ac.uk/pub/databases/gencode/Gencode_human/latest_release/gencode.v${gencode_version}.annotation.gff3.gz
       destination: input/target/gencode/gencode.gff3.gz
 
     - name: find_latest gene essentiality

--- a/src/orchestration/dags/config/pis.yaml
+++ b/src/orchestration/dags/config/pis.yaml
@@ -565,7 +565,7 @@ steps:
       destination: input/target/ensembl/homo_sapiens.json
 
     - name: copy gencode
-      source: https://ftp.ebi.ac.uk/pub/databases/gencode/Gencode_human/release_40/gencode.v40.annotation.gff3.gz
+      source: https://ftp.ebi.ac.uk/pub/databases/gencode/Gencode_human/latest/gencode.v${gencode_version}.annotation.gff3.gz
       destination: input/target/gencode/gencode.gff3.gz
 
     - name: find_latest gene essentiality

--- a/src/orchestration/dags/config/unified_pipeline.py
+++ b/src/orchestration/dags/config/unified_pipeline.py
@@ -60,6 +60,7 @@ class UnifiedPipelineConfig:
                 "chembl_version": up.get("chembl_version"),
                 "efo_version": up.get("efo_version"),
                 "ensembl_version": up.get("ensembl_version"),
+                "gencode_version": up.get("gencode_version"),
             },
         )
         """The internal configuration for PIS steps."""

--- a/src/orchestration/dags/config/unified_pipeline.yaml
+++ b/src/orchestration/dags/config/unified_pipeline.yaml
@@ -21,6 +21,7 @@ vep_version: 'release_115.2'
 chembl_version: '35'
 efo_version: '3.83.0'
 ensembl_version: '115'
+gencode_version: '49'
 
 # Dependency graph
 # ----------------


### PR DESCRIPTION
# Context

We need to remember to update GENCODE release during every pipeline release. 
To esnure it I have exposed `gencode_version` into top level config.