### PR TITLE
Run PTS steps in dataproc when there are pyspark tasks

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ build-backend = "hatchling.build"
 [tool.deptry]
 known_first_party = ["orchestration"]
 pep621_dev_dependency_groups = ["test"]
-
+extend_exclude = ["src/orchestration/assets/**"]
 
 [tool.deptry.per_rule_ignores]
 DEP002 = ["psycopg2-binary", "flask-limiter"]
@@ -53,10 +53,12 @@ DEP002 = ["psycopg2-binary", "flask-limiter"]
 filterwarnings = "ignore::DeprecationWarning"
 addopts = "--doctest-modules --cache-clear"
 testpaths = ["tests", "src/orchestration"]
+
 [tool.ruff]
 target-version = 'py312'
 line-length = 120
 preview = true
+extend-exclude = ["src/orchestration/assets/**"]
 
 [tool.ruff.lint]
 select = [

--- a/src/orchestration/assets/dataproc_pts_init.sh
+++ b/src/orchestration/assets/dataproc_pts_init.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+set -x
+
+
+
+PTS_REF=$(/usr/share/google/get_metadata_value attributes/PTS_REF)
+readonly PTS_REF
+readonly REPO_URI="https://github.com/opentargets/pts"
+DATAPROC_CLUSTER_NAME=$(/usr/share/google/get_metadata_value attributes/dataproc-cluster-name)
+readonly DATAPROC_CLUSTER_NAME
+echo "export DATAPROC_CLUSTER_NAME=${DATAPROC_CLUSTER_NAME}" >> /etc/profile.d/custom_env_vars.sh
+
+function err() {
+    echo "[$(date +'%Y-%m-%dT%H:%M:%S%z')]: $*" >&2
+    exit 1
+}
+
+function run_with_retry() {
+    local -r cmd=("$@")
+    for ((i = 0; i < 3; i++)); do
+        if "${cmd[@]}"; then
+            return 0
+        fi
+        sleep 5
+    done
+    err "Failed to run command: ${cmd[*]}"
+}
+
+function install_pip() {
+    if command -v pip >/dev/null; then
+        echo "pip is already installed."
+        return 0
+    fi
+
+    if command -v easy_install >/dev/null; then
+        echo "Installing pip with easy_install..."
+        run_with_retry easy_install pip
+        return 0
+    fi
+
+    echo "Installing python-pip..."
+    run_with_retry apt update
+    run_with_retry apt install python-pip -y
+}
+
+
+function main() {
+    if [[ -z "${PTS_REF}" ]]; then
+        echo "ERROR: Must specify PTS_REF metadata key"
+        exit 1
+    fi
+    install_pip
+    pip install uv
+
+    pip uninstall -y pts
+    echo "Install package..."
+    run_with_retry uv pip install --no-break-system-packages --system "pts @ git+${REPO_URI}.git@${PTS_REF}"
+}
+
+main

--- a/src/orchestration/assets/dataproc_pts_run.py
+++ b/src/orchestration/assets/dataproc_pts_run.py
@@ -1,0 +1,12 @@
+#!/opt/conda/default/bin/python
+# -*- coding: utf-8 -*-
+import sys
+
+from pts.core import main
+
+if __name__ == "__main__":
+    if sys.argv[0].endswith("-script.pyw"):
+        sys.argv[0] = sys.argv[0][:-11]
+    elif sys.argv[0].endswith(".exe"):
+        sys.argv[0] = sys.argv[0][:-4]
+    sys.exit(main())

--- a/src/orchestration/conftest.py
+++ b/src/orchestration/conftest.py
@@ -1,0 +1,2 @@
+def pytest_ignore_collect(path, config):
+    return "orchestration/assets" in str(path)

--- a/src/orchestration/dags/config/clusters.yaml
+++ b/src/orchestration/dags/config/clusters.yaml
@@ -1,5 +1,20 @@
 ---
 clusters:
+  pts:
+    image_version: '2.3'
+    num_masters: 1
+    num_workers: 0 # single-node mode
+    master_machine_type: n1-standard-32
+    master_disk_size: 128
+    idle_delete_ttl: 3600
+    internal_ip_only: false
+    metadata:
+      PTS_REF: 'v{{pts_version}}'
+    properties:
+      'spark:spark.driver.memory': '48g'
+    init_actions_uris:
+      - 'gs://opentargets-pipelines/up/pts/install_dependencies_on_cluster.sh'
+
   etl:
     image_version: '2.2'
     num_masters: 1

--- a/src/orchestration/dags/config/etl.conf
+++ b/src/orchestration/dags/config/etl.conf
@@ -2,597 +2,623 @@
 // release_uri — used in common.path
 // data_sources_exclude — used in steps.evidence.data_sources_exclude
 
-spark_uri = null
+spark_uri: null
 
-common {
-  additional_outputs = []
-  output_format = "parquet"
-  path = "{{release_uri}}"
+common: {
+  additional_outputs: []
+  output_format: "parquet"
+  path: "{{release_uri}}"
+  output_path: ${common.path}
 }
 
-spark_settings {
-  write_mode = "overwrite" # in orchestrator we trust
+spark_settings: {
+  write_mode: "overwrite"  # in orchestrator we trust
 
-  default_spark_session_config = [
-    {k: "spark.driver.maxResultSize", v: "0"},
-    {k: "spark.debug.maxToStringFields", v: "2001"},
-    {k: "spark.sql.broadcastTimeout", v: "3000"}
+  default_spark_session_config: [
+    { k: "spark.driver.maxResultSize",    v: "0"    }
+    { k: "spark.debug.maxToStringFields", v: "2000" }
+    { k: "spark.sql.broadcastTimeout",    v: "3000" }
   ]
 }
 
 # ============================= STEP CONFIGURATION =============================
-steps {
-  reactome {
-    input {
-      pathways {
-        format = "csv"
-        path = ${common.path}"/input/reactome/ReactomePathways.txt"
-        options = [
-          {k: "sep", v: "\\t"},
-          {k: "header", v: "false"}
-          {k: "inferSchema", v: "true"}
+steps: {
+  reactome: {
+    input: {
+      pathways: {
+        format: "csv"
+        path: ${common.path}"/input/reactome/ReactomePathways.txt"
+        options: [
+          { k: "sep",         v: "\\t" }
+          { k: "header",      v: false }
+          { k: "inferSchema", v: true  }
         ]
       }
-      relations {
-        format = "csv"
-        path = ${common.path}"/input/reactome/ReactomePathwaysRelation.txt"
-        options = [
-          {k: "sep", v: "\\t"},
-          {k: "header", v: "false"}
-          {k: "inferSchema", v: "true"}
+      relations: {
+        format: "csv"
+        path: ${common.path}"/input/reactome/ReactomePathwaysRelation.txt"
+        options: [
+          { k: "sep",         v: "\\t" }
+          { k: "header",      v: false }
+          { k: "inferSchema", v: true  }
         ]
       }
     }
-    output {
-      reactome {
-        format = ${common.output_format}
-        path = ${common.path}"/output/reactome"
-      }
-    }
-  }
-
-  pharmacogenomics {
-    input {
-      pgx {
-        format = "json"
-        path = ${common.path}"/input/pharmacogenomics/pharmacogenomics.json.gz"
-      }
-      drug = ${steps.drug.output.drug}
-    }
-    output {
-      pgx {
-        format = ${common.output_format}
-        path = ${common.path}"/output/pharmacogenomics"
+    output: {
+      reactome: {
+        format: ${common.output_format}
+        path: ${common.output_path}"/output/reactome"
       }
     }
   }
 
-  expression {
-    input {
-      rna {
-        format = "csv"
-        path = ${common.path}"/input/expression/baseline_expression_counts.tsv"
-        options = [
-          {k: "sep", v: "\\t"},
-          {k: "header", v: "true"}
-          {k: "inferSchema", v: "true"}
-        ]
+  pharmacogenomics: {
+    input: {
+      pgx: {
+        format: "json"
+        path: ${common.path}"/input/pharmacogenomics/pharmacogenomics.json.gz"
       }
-      binned {
-        format = "csv"
-        path = ${common.path}"/input/expression/baseline_expression_binned.tsv"
-        options = [
-          {k: "sep", v: "\\t"},
-          {k: "header", v: "true"}
-          {k: "inferSchema", v: "true"}
-        ]
-      }
-      zscore {
-        format = "csv"
-        path = ${common.path}"/input/expression/baseline_expression_zscore_binned.tsv"
-        options = [
-          {k: "sep", v: "\\t"},
-          {k: "header", v: "true"}
-          {k: "inferSchema", v: "true"}
-        ]
-      }
-      exprhierarchy {
-        format = "csv"
-        path = ${common.path}"/input/expression/expression_hierarchy_curation.tsv"
-        options = [
-          {k: "sep", v: "\\t"},
-          {k: "header", v: "false"}
-          {k: "inferSchema", v: "true"}
-        ]
-      }
-      efomap {
-        format = "parquet"
-        path = ${common.path}"/intermediate/expression/tissue-translation-map.parquet"
-      }
-      tissues {
-        format = "csv"
-        path = ${common.path}"/intermediate/expression/normal_tissue.tsv.gz"
-        options = [
-          {k: "sep", v: "\\t"},
-          {k: "header", v: "true"}
-          {k: "inferSchema", v: "true"}
-        ]
-      }
+      drug: ${steps.drug.output.drug}
     }
-    output {
-      expression {
-        format = ${common.output_format}
-        path = ${common.path}"/output/expression"
+    output: {
+      pgx: {
+        format: ${common.output_format}
+        path: ${common.output_path}"/output/pharmacogenomics"
       }
     }
   }
 
-  interaction {
-    scorethreshold = 0
-    string_version = "12"
-    input {
-      targets = ${steps.target.output.target}
-      rnacentral {
-        format = "csv"
-        path = ${common.path}"/input/interaction/rna_central_ensembl.tsv"
-        options = [
-          {k: "sep", v: "\\t"},
-          {k: "header", v: "false"}
+  expression: {
+    input: {
+      rna: {
+        format: "csv"
+        path: ${common.path}"/input/expression/baseline_expression_counts.tsv"
+        options: [
+          { k: "sep",         v: "\\t" }
+          { k: "header",      v: true  }
+          { k: "inferSchema", v: true  }
         ]
       }
-      humanmapping {
-        format = "csv"
-        path = ${common.path}"/input/interaction/HUMAN_9606_idmapping.dat.gz"
-        options = [
-          {k: "sep", v: "\\t"},
-          {k: "header", v: "false"}
+      binned: {
+        format: "csv"
+        path: ${common.path}"/input/expression/baseline_expression_binned.tsv"
+        options: [
+          { k: "sep",         v: "\\t" }
+          { k: "header",      v: true  }
+          { k: "inferSchema", v: true  }
         ]
       }
-      ensproteins {
-        format = "csv"
-        path = ${common.path}"/input/interaction/Homo_sapiens.GRCh38.chr.gtf.gz"
-        options = [
-          {k: "sep", v: "\\t"},
-          {k: "header", v: "false"},
-          {k: "comment", v: "#"}
+      zscore: {
+        format: "csv"
+        path: ${common.path}"/input/expression/baseline_expression_zscore_binned.tsv"
+        options: [
+          { k: "sep",         v: "\\t" }
+          { k: "header",      v: true  }
+          { k: "inferSchema", v: true  }
         ]
       }
-      intact {
-        format = "json"
-        path = ${common.path}"/input/interaction/intact-interactors.json"
+      exprhierarchy: {
+        format: "csv"
+        path: ${common.path}"/input/expression/expression_hierarchy_curation.tsv"
+        options: [
+          { k: "sep",         v: "\\t" }
+          { k: "header",      v: false }
+          { k: "inferSchema", v: true  }
+        ]
       }
-      strings {
-        format = "csv"
-        path = ${common.path}"/input/interaction/string-interactions.txt.gz"
-        options = [
-          {k: "sep", v: " "},
-          {k: "header", v: "true"}
+      efomap: {
+        format: "parquet"
+        path: ${common.path}"/intermediate/expression/tissue-translation-map.parquet"
+      }
+      tissues: {
+        format: "csv"
+        path: ${common.path}"/intermediate/expression/normal_tissue.tsv.gz"
+        options: [
+          { k: "sep",         v: "\\t" }
+          { k: "header",      v: true  }
+          { k: "inferSchema", v: true  }
         ]
       }
     }
-    output {
-      interactions {
-        format = ${common.output_format}
-        path = ${common.path}"/output/interaction"
-      }
-      interactions_evidence {
-        format = ${common.output_format}
-        path = ${common.path}"/output/interaction_evidence"
-      }
-      interactions_unmatched {
-        format = ${common.output_format}
-        path = ${common.path}"/excluded/interaction"
+    output: {
+      expression: {
+        format: ${common.output_format}
+        path: ${common.output_path}"/output/expression"
       }
     }
   }
 
-  target {
-    input {
-      chembl {
-        format = "json"
-        path = ${common.path}"/input/target/chembl/chembl_target.jsonl"
-      }
-      chemical_probes {
-        format = "json"
-        path = ${common.path}"/input/target/chemicalprobes/chemicalprobes.json.gz"
-      }
-      diseases {
-        format = "parquet"
-        path = ${common.path}"/output/disease"
-      }
-      ensembl {
-        format = ${common.output_format}
-        path = ${common.path}"/intermediate/target/ensembl/homo_sapiens.parquet"
-      }
-      gene_code {
-        format = "csv"
-        path = ${common.path}"/input/target/gencode/gencode.gff3.gz"
-        options = [
-          {k: "comment", v: "#"}
-          {k: "sep", v: "\\t"}
+  interaction: {
+    scorethreshold: 0
+    string_version: "12"
+    input: {
+      targets: ${steps.target.output.target}
+      rnacentral: {
+        format: "csv"
+        path: ${common.path}"/input/interaction/rna_central_ensembl.tsv"
+        options: [
+          { k: "sep",    v: "\\t" }
+          { k: "header", v: false }
         ]
       }
-      genetic_constraints {
-        format = "csv"
-        path = ${common.path}"/input/target/gnomad/gnomad.v4.1.constraint_metrics.tsv"
-        options = [
-          {k: "sep", v: "\\t"}
-          {k: "header", v: true}
-          {k: "nullValue", v: "NA"}
+      humanmapping: {
+        format: "csv"
+        path: ${common.path}"/input/interaction/HUMAN_9606_idmapping.dat.gz"
+        options: [
+          { k: "sep",    v: "\\t" }
+          { k: "header", v: false }
         ]
       }
-      gene_ontology_human {
-        format = "csv"
-        path = ${common.path}"/input/target/go/goa_human.gaf.gz"
-        options = [
-          {k: "sep", v: "\\t"},
-          {k: "comment", v: "!"} // remove all metadata lines beginning with !
+      ensproteins: {
+        format: "csv"
+        path: ${common.path}"/input/interaction/Homo_sapiens.GRCh38.chr.gtf.gz"
+        options: [
+          { k: "sep",     v: "\\t" }
+          { k: "header",  v: false }
+          { k: "comment", v: "#"   }
         ]
       }
-      gene_ontology_rna {
-        format = "csv"
-        path = ${common.path}"/input/target/go/goa_human_rna.gaf.gz"
-        options = [
-          {k: "sep", v: "\\t"},
-          {k: "comment", v: "!"} // remove all metadata lines beginning with !
+      intact: {
+        format: "json"
+        path: ${common.path}"/input/interaction/intact-interactors.json"
+      }
+      strings: {
+        format: "csv"
+        path: ${common.path}"/input/interaction/string-interactions.txt.gz"
+        options: [
+          { k: "sep",    v: " "  }
+          { k: "header", v: true }
         ]
       }
-      gene_ontology_rna_lookup {
-        format = "csv"
-        path = ${common.path}"/input/target/go/ensembl.tsv"
-        options = [
-          {k: "sep", v: "\\t"}
+    }
+    output: {
+      interactions: {
+        format: ${common.output_format}
+        path: ${common.path}"/output/interaction"
+      }
+      interactions_evidence: {
+        format: ${common.output_format}
+        path: ${common.path}"/output/interaction_evidence"
+      }
+      interactions_unmatched: {
+        format: ${common.output_format}
+        path: ${common.path}"/excluded/interaction"
+      }
+    }
+  }
+
+  target: {
+    input: {
+      chembl: {
+        format: "json"
+        path: ${common.path}"/input/target/chembl/chembl_target.jsonl"
+      }
+      chemical_probes: {
+        format: "json"
+        path: ${common.path}"/input/target/chemicalprobes/chemicalprobes.json.gz"
+      }
+      diseases: {
+        format: "parquet"
+        path: ${common.path}"/output/disease"
+      }
+      ensembl: {
+        format: ${common.output_format}
+        path: ${common.path}"/intermediate/target/ensembl/homo_sapiens.parquet"
+      }
+      gene_code: {
+        format: "csv"
+        path: ${common.path}"/input/target/gencode/gencode.gff3.gz"
+        options: [
+          { k: "sep",     v: "\\t" }
+          { k: "comment", v: "#"   }
         ]
       }
-      gene_ontology_eco_lookup {
-        format = "csv"
-        path = ${common.path}"/input/target/go/goa_human_eco.gpa.gz"
-        options = [
-          {k: "sep", v: "\\t"}
-          {k: "comment", v: "!"}
+      genetic_constraints: {
+        format: "csv"
+        path: ${common.path}"/input/target/gnomad/gnomad.v4.1.constraint_metrics.tsv"
+        options: [
+          { k: "sep",       v: "\\t" }
+          { k: "header",    v: true  }
+          { k: "nullValue", v: "NA"  }
         ]
       }
-      hallmarks {
-        format = "csv"
-        path = ${common.path}"/input/target/hallmarks/cosmic-hallmarks.tsv.gz"
-        options = [
-          {k: "sep", v: "\\t"}
-          {k: "header", v: true}
+      gene_ontology_human: {
+        format: "csv"
+        path: ${common.path}"/input/target/go/goa_human.gaf.gz"
+        options: [
+          { k: "sep",     v: "\\t" }
+          { k: "comment", v: "!"   }
         ]
       }
-      hgnc {
-        format = "json"
-        path = ${common.path}"/input/target/genenames/hgnc_complete_set.json"
+      gene_ontology_rna: {
+        format: "csv"
+        path: ${common.path}"/input/target/go/goa_human_rna.gaf.gz"
+        options: [
+          { k: "sep", v: "\\t"   }
+          { k: "comment", v: "!" }
+        ]
+      }
+      gene_ontology_rna_lookup: {
+        format: "csv"
+        path: ${common.path}"/input/target/go/ensembl.tsv"
+        options: [
+          { k: "sep", v: "\\t" }
+        ]
+      }
+      gene_ontology_eco_lookup: {
+        format: "csv"
+        path: ${common.path}"/input/target/go/goa_human_eco.gpa.gz"
+        options: [
+          { k: "sep", v: "\\t"   }
+          { k: "comment", v: "!" }
+        ]
+      }
+      hallmarks: {
+        format: "csv"
+        path: ${common.path}"/input/target/hallmarks/cosmic-hallmarks.tsv.gz"
+        options: [
+          { k: "sep",    v: "\\t" }
+          { k: "header", v: true  }
+        ]
+      }
+      hgnc: {
+        format: "csv"
+        path: ${common.path}"/input/target/genenames/hgnc_complete_set.tsv"
+        options: [
+          { k: "sep",       v: "\\t"  }
+          { k: "header",    v: true   }
+          { k: "nullValue", v: "null" }
+        ]
       },
-      homology_dictionary {
-        format = "csv"
-        path = ${common.path}"/input/target/homologue/species_EnsemblVertebrates.txt"
-        options = [
-          {k: "sep", v: "\\t"}
-          {k: "header", v: true}
+      homology_dictionary: {
+        format: "csv"
+        path: ${common.path}"/input/target/homologue/species_EnsemblVertebrates.txt"
+        options: [
+          { k: "sep",    v: "\\t" }
+          { k: "header", v: true  }
         ]
       }
-      homology_coding_proteins {
-        format = "csv"
-        path = ${common.path}"/input/target/homologue/homologies/*.tsv.gz"
-        options = [
-          {k: "sep", v: "\\t"}
-          {k: "header", v: true}
+      homology_coding_proteins: {
+        format: "csv"
+        path: ${common.path}"/input/target/homologue/homologies/*.tsv.gz"
+        options: [
+          { k: "sep",    v: "\\t" }
+          { k: "header", v: true  }
         ]
       }
-      homology_gene_dictionary {
-        format = "parquet"
-        path = ${common.path}"/intermediate/target/homologue/gene_dictionary/*.parquet"
-        options = [
-          {k: "sep", v: "\\t"}
+      homology_gene_dictionary: {
+        format: "parquet"
+        path: ${common.path}"/intermediate/target/homologue/gene_dictionary/*.parquet"
+        options: [
+          { k: "sep", v: "\\t" }
         ]
       }
-      hpa {
-        format = "csv"
-        path = ${common.path}"/intermediate/target/hpa/subcellular_location.tsv.gz"
-        options = [
-          {k: "sep", v: "\\t"}
-          {k: "header", v: true}
+      hpa: {
+        format: "csv"
+        path: ${common.path}"/intermediate/target/hpa/subcellular_location.tsv.gz"
+        options: [
+          { k: "sep",    v: "\\t" }
+          { k: "header", v: true  }
         ]
       }
-      hpa_sl {
-        format = "parquet"
-        path = ${common.path}"/intermediate/target/hpa/subcellular_locations_ssl.parquet"
+      hpa_sl: {
+        format: "parquet"
+        path: ${common.path}"/intermediate/target/hpa/subcellular_locations_ssl.parquet"
       }
-      ncbi {
-        format = "csv"
-        path = ${common.path}"/input/target/ncbi/Homo_sapiens.gene_info.gz"
-        options = [
-          {k: "sep", v: "\\t"}
-          {k: "header", v: true}
+      ncbi: {
+        format: "csv"
+        path: ${common.path}"/input/target/ncbi/Homo_sapiens.gene_info.gz"
+        options: [
+          { k: "sep",    v: "\\t" }
+          { k: "header", v: true  }
         ]
       }
-      project_scores_ids {
-        format = "parquet"
-        path = ${common.path}"/intermediate/target/project-scores/gene_identifiers_latest.parquet"
+      project_scores_ids: {
+        format: "parquet"
+        path: ${common.path}"/intermediate/target/project-scores/gene_identifiers_latest.parquet"
       }
-      project_scores_essentiality_matrix {
-        format = "parquet"
-        path = ${common.path}"/intermediate/target/project-scores/04_binaryDepScores.parquet"
+      project_scores_essentiality_matrix: {
+        format: "parquet"
+        path: ${common.path}"/intermediate/target/project-scores/04_binaryDepScores.parquet"
       }
-      reactome_etl {
-        format = "parquet"
-        path = ${common.path}"/output/reactome/part*"
+      reactome_etl: {
+        format: "parquet"
+        path: ${common.path}"/output/reactome/part*"
       }
-      reactome_pathways {
-        format = "csv"
-        path = ${common.path}"/input/target/reactome/Ensembl2Reactome.txt"
-        options = [
-          {k: "sep", v: "\\t"}
+      reactome_pathways: {
+        format: "csv"
+        path: ${common.path}"/input/target/reactome/Ensembl2Reactome.txt"
+        options: [
+          { k: "sep", v: "\\t" }
         ]
       }
-      safety_evidence {
-        format = "json"
-        path = ${common.path}"/input/target/safety/safetyLiabilities.json.gz"
+      safety_evidence: {
+        format: "json"
+        path: ${common.path}"/input/target/safety/safetyLiabilities.json.gz"
       }
-      tep {
-        format = "json"
-        path = ${common.path}"/input/target/tep/tep.json.gz"
+      tep: {
+        format: "json"
+        path: ${common.path}"/input/target/tep/tep.json.gz"
       },
-      tractability {
-        format = "csv"
-        path = ${common.path}"/input/target/tractability/tractability.tsv"
-        options = [
-          {k: "sep", v: "\\t"}
-          {k: "header", v: true}
+      tractability: {
+        format: "csv"
+        path: ${common.path}"/input/target/tractability/tractability.tsv"
+        options: [
+          { k: "sep",    v: "\\t" }
+          { k: "header", v: true  }
         ]
       }
-      uniprot {
-        format = "txt"
-        path = ${common.path}"/input/target/uniprot/uniprot.txt.gz"
+      uniprot: {
+        format: "txt"
+        path: ${common.path}"/input/target/uniprot/uniprot.txt.gz"
       }
-      uniprot_ssl {
-        format = "csv"
-        path = ${common.path}"/input/target/uniprot/uniprot-ssl.tsv.gz"
-        options = [
-          {k: "sep", v: "\\t"}
-          {k: "header", v: true}
+      uniprot_ssl: {
+        format: "csv"
+        path: ${common.path}"/input/target/uniprot/uniprot-ssl.tsv.gz"
+        options: [
+          { k: "sep",    v: "\\t" }
+          { k: "header", v: true  }
         ]
       }
-      gene_essentiality {
-        format = "json"
-        path = ${common.path}"/input/target/gene-essentiality/essentiality.json.gz"
+      gene_essentiality: {
+        format: "json"
+        path: ${common.path}"/input/target/gene-essentiality/essentiality.json.gz"
       }
     }
-    output {
-      target {
-        format = ${common.output_format}
-        path = ${common.path}"/output/target"
+    output: {
+      target: {
+        format: ${common.output_format}
+        path: ${common.output_path}"/output/target"
       }
-      gene_essentiality {
-        format = ${common.output_format}
-        path = ${common.path}"/output/target_essentiality"
+      gene_essentiality: {
+        format: ${common.output_format}
+        path: ${common.output_path}"/output/target_essentiality"
       }
     }
-    hgnc_ortholog_species = [
-      "9606-human",
-      "9598-chimpanzee",
-      "9544-macaque",
-      "10090-mouse",
-      "10116-rat",
-      "9986-rabbit",
-      "10141-guineapig",
-      "9615-dog",
-      "9823-pig",
-      "8364-frog",
-      "7955-zebrafish",
-      "7227-fly",
-      "6239-worm",
+    hgnc_array_columns: [
+      "alias_name"
+      "ccds_id"
+      "ena"
+      "enzyme_id"
+      "gene_group"
+      "gene_group_id"
+      "lsdb"
+      "mane_select"
+      "mgd_id"
+      "omim_id"
+      "prev_name"
+      "prev_symbol"
+      "alias_symbol"
+      "pubmed_id"
+      "refseq_accession"
+      "rgd_id"
+      "rna_central_id"
+      "uniprot_ids"
+    ]
+    hgnc_ortholog_species: [
+      "9606-human"
+      "9598-chimpanzee"
+      "9544-macaque"
+      "10090-mouse"
+      "10116-rat"
+      "9986-rabbit"
+      "10141-guineapig"
+      "9615-dog"
+      "9823-pig"
+      "8364-frog"
+      "7955-zebrafish"
+      "7227-fly"
+      "6239-worm"
     ]
   }
 
-  mouse_phenotype {
-    input {
-      mouse_phenotypes {
-        format = "json"
-        path = ${common.path}"/input/mouse_phenotype/mouse_phenotypes.json.gz"
+  mouse_phenotype: {
+    input: {
+      mouse_phenotypes: {
+        format: "json"
+        path: ${common.path}"/input/mouse_phenotype/mouse_phenotypes.json.gz"
       }
-      target = ${steps.target.output.target}
+      target: ${steps.target.output.target}
     }
-    output {
-      succeeded {
-        format = ${common.output_format}
-        path = ${common.path}"/output/mouse_phenotype"
+    output: {
+      succeeded: {
+        format: ${common.output_format}
+        path: ${common.output_path}"/output/mouse_phenotype"
       }
-      failed {
-        format = ${common.output_format}
-        path = ${common.path}"/excluded/mouse_phenotype"
+      failed: {
+        format: ${common.output_format}
+        path: ${common.output_path}"/excluded/mouse_phenotype"
       }
     }
   }
 
-  drug {
-    input {
-      chemical_probes {
-        format = "json"
-        path = ${common.path}"/input/drug/chemicalprobes.json.gz"
+  drug: {
+    input: {
+      chemical_probes: {
+        format: "json"
+        path: ${common.path}"/input/drug/chemicalprobes.json.gz"
       }
-      chembl_indication {
-        format = "json"
-        path = ${common.path}"/input/drug/chembl_drug_indication.jsonl"
+      chembl_indication: {
+        format: "json"
+        path: ${common.path}"/input/drug/chembl_drug_indication.jsonl"
       }
-      chembl_molecule {
-        format = "json"
-        path = ${common.path}"/input/drug/chembl_molecule.jsonl"
+      chembl_molecule: {
+        format: "json"
+        path: ${common.path}"/input/drug/chembl_molecule.jsonl"
       }
-      chembl_mechanism {
-        format = "json"
-        path = ${common.path}"/input/drug/chembl_mechanism.jsonl"
+      chembl_mechanism: {
+        format: "json"
+        path: ${common.path}"/input/drug/chembl_mechanism.jsonl"
       }
-      chembl_target {
-        format = "json"
-        path = ${common.path}"/input/drug/chembl_target.jsonl"
+      chembl_target: {
+        format: "json"
+        path: ${common.path}"/input/drug/chembl_target.jsonl"
       }
-      chembl_warning {
-        format = "json"
-        path = ${common.path}"/input/drug/chembl_drug_warning.jsonl"
+      chembl_warning: {
+        format: "json"
+        path: ${common.path}"/input/drug/chembl_drug_warning.jsonl"
       }
-      disease_etl {
-        format = "parquet"
-        path = ${common.path}"/output/disease"
+      disease_etl: {
+        format: "parquet"
+        path: ${common.path}"/output/disease"
       }
-      target_etl = ${steps.target.output.target}
-      drugbank_to_chembl {
-        format = "csv"
-        path = ${common.path}/input/drug/drugbank.csv.gz
-        options = [
-          {k: "sep", v: "\\t"},
-          {k: "header", v: "true"}
+      target_etl: ${steps.target.output.target}
+      drugbank_to_chembl: {
+        format: "csv"
+        path: ${common.path}/input/drug/drugbank.csv.gz
+        options: [
+          { k: "sep",    v: "\\t" }
+          { k: "header", v: true  }
         ]
       }
     }
-    drug_extensions = []
-    output {
-      drug {
-        format = ${common.output_format}
-        path = ${common.path}"/output/drug_molecule"
+    drug_extensions: []
+    output: {
+      drug: {
+        format: ${common.output_format}
+        path: ${common.output_path}"/output/drug_molecule"
       }
-      mechanism_of_action {
-        format = ${common.output_format}
-        path = ${common.path}"/output/drug_mechanism_of_action"
+      mechanism_of_action: {
+        format: ${common.output_format}
+        path: ${common.output_path}"/output/drug_mechanism_of_action"
       }
-      indications {
-        format = ${common.output_format}
-        path = ${common.path}"/output/drug_indication"
+      indications: {
+        format: ${common.output_format}
+        path: ${common.output_path}"/output/drug_indication"
       }
-      warnings {
-        format = ${common.output_format}
-        path = ${common.path}"/output/drug_warning"
-      }
-    }
-  }
-
-  known_drug {
-    input {
-      evidences = ${steps.evidence.output.succeeded}
-      diseases {
-        format = "parquet"
-        path = ${common.path}"/output/disease"
-      }
-      targets = ${steps.target.output.target}
-      drug = ${steps.drug.output.drug}
-      mechanism = ${steps.drug.output.mechanism_of_action}
-    }
-    output {
-      known_drugs {
-        format = ${common.output_format}
-        path = ${common.path}"/output/known_drug"
+      warnings: {
+        format: ${common.output_format}
+        path: ${common.output_path}"/output/drug_warning"
       }
     }
   }
 
-  evidence {
-    output {
-      succeeded {
-        format = ${common.output_format}
-        path = ${common.path}"/output/evidence"
-        partition_by = ["sourceId"]
+  known_drug: {
+    input: {
+      evidences: ${steps.evidence.output.succeeded}
+      diseases: {
+        format: "parquet"
+        path: ${common.path}"/output/disease"
       }
-      failed {
-        format = ${common.output_format}
-        path = ${common.path}"/excluded/evidence"
-        partition_by = ["sourceId"]
+      targets: ${steps.target.output.target}
+      drug: ${steps.drug.output.drug}
+      mechanism: ${steps.drug.output.mechanism_of_action}
+    }
+    output: {
+      known_drugs: {
+        format: ${common.output_format}
+        path: ${common.output_path}"/output/known_drug"
       }
     }
-    input {
-      raw_input_evidences {
-        format = "json"
-        path = ${common.path}"/input/evidence/*"
+  }
+
+  evidence: {
+    output: {
+      succeeded: {
+        format: ${common.output_format}
+        path: ${common.output_path}"/output/evidence"
+        partition_by: [ "sourceId" ]
       }
-      raw_intermediate_evidences {
-        format = "json"
-        path = ${common.path}"/intermediate/evidence/*"
-      }
-      diseases {
-        format = "parquet"
-        path = ${common.path}"/output/disease"
-      }
-      targets = ${steps.target.output.target}
-      mechanism_of_action = ${steps.drug.output.mechanism_of_action}
-      literature_dating {
-        format = "json"
-        path = "gs://otar000-evidence_input/literature_export/*"
+      failed: {
+        format: ${common.output_format}
+        path: ${common.output_path}"/excluded/evidence"
+        partition_by: [ "sourceId" ]
       }
     }
-    direction_of_effect {
-      var_filter_lof = [
-        // High impact variants https://www.ensembl.org/info/genome/variation/prediction/predicted_data.html
-        "SO_0001589",  // frameshit_variant
-        "SO_0001587",  // stop_gained
-        "SO_0001574",  // splice_acceptor_variant
-        "SO_0001575",  // splice_donor_variant
-        "SO_0002012",  // start_lost
-        "SO_0001578",  // stop_lost
-        "SO_0001893",  // transcript_ablation
+    input: {
+      raw_input_evidences: {
+        format: "json"
+        path: ${common.path}"/input/evidence/*"
+      }
+      raw_intermediate_evidences: {
+        format: "json"
+        path: ${common.path}"/intermediate/evidence/*"
+      }
+      diseases: {
+        format: "parquet"
+        path: ${common.path}"/output/disease"
+      }
+      targets: ${steps.target.output.target}
+      mechanism_of_action: ${steps.drug.output.mechanism_of_action}
+      literature_dating: {
+        format: "json"
+        path: "gs://otar000-evidence_input/literature_export/*"
+      }
+    }
+    direction_of_effect: {
+      var_filter_lof: [
+        # High impact variants https://www.ensembl.org/info/genome/variation/prediction/predicted_data.html
+        "SO_0001589"  # frameshit_variant
+        "SO_0001587"  # stop_gained
+        "SO_0001574"  # splice_acceptor_variant
+        "SO_0001575"  # splice_donor_variant
+        "SO_0002012"  # start_lost
+        "SO_0001578"  # stop_lost
+        "SO_0001893"  # transcript_ablation
       ]
-      gof = ["SO_0002053"]
-      lof = ["SO_0002054"]
-      oncotsg_list = [
-        "TSG",
-        "oncogene",
-        "Oncogene",
-        "oncogene",
-        "oncogene,TSG",
-        "TSG,oncogene",
-        "fusion,oncogene",
-        "oncogene,fusion",
+      gof: [ "SO_0002053" ]
+      lof: [ "SO_0002054" ]
+      oncotsg_list: [
+        "TSG"
+        "oncogene"
+        "Oncogene"
+        "oncogene"
+        "oncogene,TSG"
+        "TSG,oncogene"
+        "fusion,oncogene"
+        "oncogene,fusion"
       ]
-      inhibitors = [
-        "RNAI INHIBITOR",
-        "NEGATIVE MODULATOR",
-        "NEGATIVE ALLOSTERIC MODULATOR",
-        "ANTAGONIST",
-        "ANTISENSE INHIBITOR",
-        "BLOCKER",
-        "INHIBITOR",
-        "DEGRADER",
-        "INVERSE AGONIST",
-        "ALLOSTERIC ANTAGONIST",
+      inhibitors: [
+        "RNAI INHIBITOR"
+        "NEGATIVE MODULATOR"
+        "NEGATIVE ALLOSTERIC MODULATOR"
+        "ANTAGONIST"
+        "ANTISENSE INHIBITOR"
+        "BLOCKER"
+        "INHIBITOR"
+        "DEGRADER"
+        "INVERSE AGONIST"
+        "ALLOSTERIC ANTAGONIST"
         "DISRUPTING AGENT"
       ]
-      activators = [
-        "PARTIAL AGONIST",
-        "ACTIVATOR",
-        "POSITIVE ALLOSTERIC MODULATOR",
-        "POSITIVE MODULATOR",
-        "AGONIST",
-        "SEQUESTERING AGENT",
+      activators: [
+        "PARTIAL AGONIST"
+        "ACTIVATOR"
+        "POSITIVE ALLOSTERIC MODULATOR"
+        "POSITIVE MODULATOR"
+        "AGONIST"
+        "SEQUESTERING AGENT"
         "STABILISER"
       ]
-      sources = [
-        "gene_burden",
-        "eva",
-        "eva_somatic",
-        "gene2phenotype",
-        "orphanet",
-        "cancer_gene_census",
-        "intogen",
-        "impc",
-        "chembl",
+      sources: [
+        "gene_burden"
+        "eva"
+        "eva_somatic"
+        "gene2phenotype"
+        "orphanet"
+        "cancer_gene_census"
+        "intogen"
+        "impc"
+        "chembl"
       ]
     }
-    unique_fields = [
-      "targetId",
-      "targetFromSourceId",
-      "diseaseId",
+    unique_fields: [
+      "targetId"
+      "targetFromSourceId"
+      "diseaseId"
       "datasourceId"
     ]
-    score_expr = "resourceScore"
-    datatype_id = "other"
+    score_expr: "resourceScore"
+    datatype_id: "other"
     # by default, exclude ppp datasources
-    data_sources_exclude = {{data_sources_exclude}}
-    data_sources = [
+    data_sources_exclude: {{data_sources_exclude}}
+    data_sources: [
       {
-        id: "chembl",
+        id: "chembl"
         unique_fields: [
-          "drugId",
+          "drugId"
           "urls.url"
-        ],
+        ]
         score_expr: """
           element_at(
             map(
@@ -643,30 +669,28 @@ steps {
             )
           end
         """
-      },
+      }
       {
-        id: "crispr_screen",
+        id: "crispr_screen"
         unique_fields: [
-          "studyId",
-          "targetFromSourceId",
+          "studyId"
+          "targetFromSourceId"
           "diseaseFromSourceMappedId"
-        ],
+        ]
         score_expr: "pvalue_linear_score(resourceScore, 0.5, 0.005, 0.0, 1.0)"
-      },
+      }
       {
-        id: "europepmc",
-        unique_fields: [
-          "literature"
-        ],
+        id: "europepmc"
+        unique_fields: [ "literature" ]
         score_expr: "array_min(array(resourceScore / 100.0, 1.0))"
-      },
+      }
       {
-        id: "eva",
-        datatype_id: "genetic_association",
+        id: "eva"
+        datatype_id: "genetic_association"
         unique_fields: [
-          "studyId",
+          "studyId"
           "variantId"
-        ],
+        ]
         score_expr: """
           coalesce(
             array_max(
@@ -717,13 +741,13 @@ steps {
             0.0
           )
         """
-      },
+      }
       {
-        id: "eva_somatic",
+        id: "eva_somatic"
         unique_fields: [
-          "studyId",
+          "studyId"
           "variantId"
-        ],
+        ]
         score_expr: """
           coalesce(
             array_max(
@@ -774,54 +798,54 @@ steps {
             0.0
           )
         """
-      },
+      }
       {
         excluded_biotypes: [
-          "IG_C_pseudogene",
-          "IG_J_pseudogene",
-          "IG_pseudogene",
-          "IG_V_pseudogene",
-          "polymorphic_pseudogene",
-          "processed_pseudogene",
-          "pseudogene",
-          "rRNA",
-          "rRNA_pseudogene",
-          "snoRNA",
-          "snRNA",
-          "transcribed_processed_pseudogene",
-          "transcribed_unitary_pseudogene",
-          "transcribed_unprocessed_pseudogene",
-          "TR_J_pseudogene",
-          "TR_V_pseudogene",
-          "unitary_pseudogene",
+          "IG_C_pseudogene"
+          "IG_J_pseudogene"
+          "IG_pseudogene"
+          "IG_V_pseudogene"
+          "polymorphic_pseudogene"
+          "processed_pseudogene"
+          "pseudogene"
+          "rRNA"
+          "rRNA_pseudogene"
+          "snoRNA"
+          "snRNA"
+          "transcribed_processed_pseudogene"
+          "transcribed_unitary_pseudogene"
+          "transcribed_unprocessed_pseudogene"
+          "TR_J_pseudogene"
+          "TR_V_pseudogene"
+          "unitary_pseudogene"
           "unprocessed_pseudogene"
-        ],
-        id: "expression_atlas",
+        ]
+        id: "expression_atlas"
         unique_fields: [
-          "contrast",
+          "contrast"
           "studyId"
-        ],
+        ]
         score_expr: "array_min(array(1.0, pvalue_linear_score_default(resourceScore) * (abs(log2FoldChangeValue) / 10) * (log2FoldChangePercentileRank / 100)))"
-      },
+      }
       {
-        id: "gene_burden",
-        datatype_id: "genetic_association",
+        id: "gene_burden"
+        datatype_id: "genetic_association"
         unique_fields: [
-          "ancestryId",
+          "ancestryId"
           "diseaseFromSource"
-          "statisticalMethod",
+          "statisticalMethod"
           "projectId"
-        ],
+        ]
         score_expr: "pvalue_linear_score(resourceScore, 1e-7, 1e-17, 0.25, 1.0)"
-      },
+      }
       {
-        id: "gene2phenotype",
-        datatype_id: "genetic_association",
+        id: "gene2phenotype"
+        datatype_id: "genetic_association"
         unique_fields: [
-          "diseaseFromSource",
-          "allelicRequirements",
+          "diseaseFromSource"
+          "allelicRequirements"
           "studyId"
-        ],
+        ]
         score_expr: """
           element_at(
             map(
@@ -834,14 +858,14 @@ steps {
             confidence
           )
         """
-      },
+      }
       {
-        id: "genomics_england",
-        datatype_id: "genetic_association",
+        id: "genomics_england"
+        datatype_id: "genetic_association"
         unique_fields: [
-          "diseaseFromSource",
+          "diseaseFromSource"
           "studyId"
-        ],
+        ]
         score_expr: """
           element_at(
             map(
@@ -851,119 +875,111 @@ steps {
             confidence
           )
         """
-      },
+      }
       {
-        id: "intogen",
-        unique_fields: [
-          "cohortShortName"
-        ],
+        id: "intogen"
+        unique_fields: [ "cohortShortName" ]
         score_expr: "pvalue_linear_score(resourceScore, 0.1, 1e-10, 0.25, 1.0)"
-      },
+      }
       {
-        id: "gwas_credible_sets",
+        id: "gwas_credible_sets"
         datatype_id: "genetic_association"
-        unique_fields: [
-          "studyLocusId",
-        ],
+        unique_fields: [ "studyLocusId" ]
         score_expr: "resourceScore"
-      },
+      }
       {
-        id: "ot_crispr",
-        datatype_id: "ot_partner",
+        id: "ot_crispr"
+        datatype_id: "ot_partner"
         unique_fields: [
-          "studyId",
-          "diseaseFromSourceMappedId",
-          "targetFromSourceId",
-          "resourceScore",
+          "studyId"
+          "diseaseFromSourceMappedId"
+          "targetFromSourceId"
+          "resourceScore"
           "statisticalTestTail"
-        ],
+        ]
         score_expr: "1.0"
-      },
+      }
       {
-        id: "encore",
-        datatype_id: "ot_partner",
+        id: "encore"
+        datatype_id: "ot_partner"
         unique_fields: [
-          "targetFromSourceId",
-          "interactingTargetFromSourceId",
-          "diseaseFromSourceMappedId",
+          "targetFromSourceId"
+          "interactingTargetFromSourceId"
+          "diseaseFromSourceMappedId"
           "cellType"
-        ],
+        ]
         score_expr: "pvalue_linear_score(geneticInteractionPValue, 1.0, 0.01, 0.0, 1.0)"
-      },
+      }
       {
-        id: "ot_crispr_validation",
+        id: "ot_crispr_validation"
         unique_fields: [
-          "targetFromSourceId",
-          "diseaseFromSourceMappedId",
-          "resourceScore",
-          "diseaseCellLines",
+          "targetFromSourceId"
+          "diseaseFromSourceMappedId"
+          "resourceScore"
+          "diseaseCellLines"
           "primaryProjectId"
-        ],
+        ]
         score_expr: "resourceScore"
-      },
+      }
       {
-        id: "orphanet",
-        datatype_id: "genetic_association",
-        unique_fields: [
-          "diseaseFromSourceId"
-        ],
-        score_expr: "element_at(map('Assessed', 1.0,'Not yet assessed', 0.5), confidence)"
-      },
+        id: "orphanet"
+        datatype_id: "genetic_association"
+        unique_fields: [ "diseaseFromSourceId" ]
+        score_expr: "element_at(map('Assessed', 1.0, 'Not yet assessed', 0.5), confidence)"
+      }
       {
-        id: "impc",
+        id: "impc"
         unique_fields: [
-          "diseaseFromSource",
-          "biologicalModelAllelicComposition",
-          "targetInModel",
+          "diseaseFromSource"
+          "biologicalModelAllelicComposition"
+          "targetInModel"
           "biologicalModelGeneticBackground"
-        ],
+        ]
         score_expr: "resourceScore / 100"
-      },
+      }
       {
-        id: "crispr",
-        score_expr: "linear_rescale(resourceScore, 41.5, 100, 0.415, 1.0)",
+        id: "crispr"
+        score_expr: "linear_rescale(resourceScore, 41.5, 100, 0.415, 1.0)"
         unique_fields: []
-      },
+      }
       {
-        id: "progeny",
+        id: "progeny"
         unique_fields: [
-          "pathways",
-          "diseaseFromSource"
-        ],
-        score_expr: "pvalue_linear_score(resourceScore, 1e-4, 1e-14, 0.5, 1.0)"
-      },
-      {
-        id: "reactome",
-        unique_fields: [
-          "variantAminoacidDescriptions",
-          "targetModulation",
-          "reactionId"
-        ],
-        score_expr: "1.0"
-      },
-      {
-        id: "slapenrich",
-        unique_fields: [
-          "pathways",
-          "diseaseFromSource"
-        ],
-        score_expr: "pvalue_linear_score(resourceScore, 1e-4, 1e-14, 0.5, 1.0)"
-      },
-      {
-        id: "sysbio",
-        unique_fields: [
-          "studyOverview",
-          "literature",
           "pathways"
-        ],
+          "diseaseFromSource"
+        ]
+        score_expr: "pvalue_linear_score(resourceScore, 1e-4, 1e-14, 0.5, 1.0)"
+      }
+      {
+        id: "reactome"
+        unique_fields: [
+          "variantAminoacidDescriptions"
+          "targetModulation"
+          "reactionId"
+        ]
+        score_expr: "1.0"
+      }
+      {
+        id: "slapenrich"
+        unique_fields: [
+          "pathways"
+          "diseaseFromSource"
+        ]
+        score_expr: "pvalue_linear_score(resourceScore, 1e-4, 1e-14, 0.5, 1.0)"
+      }
+      {
+        id: "sysbio"
+        unique_fields: [
+          "studyOverview"
+          "literature"
+          "pathways"
+        ]
         score_expr: "resourceScore"
-      },
+      }
       {
         id: "uniprot_literature"
         datatype_id: "genetic_association"
-        unique_fields: [
-          "diseaseFromSource"
-        ],
+        unique_fields: [ "diseaseFromSource" ]
         score_expr: """
           element_at(
             map(
@@ -973,15 +989,15 @@ steps {
             confidence
           )
         """
-      },
+      }
       {
         id: "uniprot_variants"
         datatype_id: "genetic_association"
         unique_fields: [
-          "diseaseFromSource",
-          "variantRsId",
+          "diseaseFromSource"
+          "variantRsId"
           "variantId"
-        ],
+        ]
         score_expr: """
           element_at(
             map(
@@ -991,15 +1007,15 @@ steps {
             confidence
           )
         """
-      },
+      }
       {
         id: "clingen"
         datatype_id: "genetic_association"
         unique_fields: [
-          "diseaseFromSource",
-          "studyId",
-          "allelicRequirements",
-        ],
+          "diseaseFromSource"
+          "studyId"
+          "allelicRequirements"
+        ]
         score_expr: """
           element_at(
             map(
@@ -1014,513 +1030,519 @@ steps {
             confidence
           )
         """
-      },
+      }
       {
         id: "cancer_biomarkers"
         unique_fields: [
-          "biomarkerName",
-          "confidence",
-          "diseaseFromSource",
-          "drugFromSource",
+          "biomarkerName"
+          "confidence"
+          "diseaseFromSource"
+          "drugFromSource"
           "drugResponse"
-        ],
+        ]
         score_expr: "1.0"
       }
     ]
   }
 
-  search_facet {
-    input {
-      diseases {
-        format = "parquet"
-        path = ${common.path}"/output/disease"
+  search_facet: {
+    input: {
+      diseases: {
+        format: "parquet"
+        path: ${common.path}"/output/disease"
       }
-      targets = ${steps.target.output.target}
-      go = ${steps.go.output.go}
+      targets: ${steps.target.output.target}
+      go: ${steps.go.output.go}
     }
-    output {
-      targets {
-        format = ${common.output_format}
-        path = ${common.path}"/view/search_facet_target"
+    output: {
+      targets: {
+        format: ${common.output_format}
+        path: ${common.output_path}"/view/search_facet_target"
       }
-      diseases {
-        format = ${common.output_format}
-        path = ${common.path}"/view/search_facet_disease"
-      }
-    }
-    categories {
-      disease_name = "Disease"
-      therapeutic_area = "Therapeutic Area"
-      sm = "Tractability Small Molecule"
-      ab = "Tractability Antibody"
-      pr = "Tractability PROTAC"
-      oc = "Tractability Other Modalities"
-      target_id = "Target ID"
-      approved_symbol = "Approved Symbol"
-      approved_name = "Approved Name"
-      subcellular_location = "Subcellular Location"
-      target_class = "ChEMBL Target Class"
-      pathways = "Reactome"
-      go_f = "GO:MF"
-      go_p = "GO:BP"
-      go_c = "GO:CC"
-    }
-  }
-
-  go {
-    input {
-      go {
-        format = "csv"
-        path = ${common.path}"/input/go/go.obo"
+      diseases: {
+        format: ${common.output_format}
+        path: ${common.output_path}"/view/search_facet_disease"
       }
     }
-    output {
-      go {
-        format = ${common.output_format}
-        path = ${common.path}"/output/go"
-      }
+    categories: {
+      disease_name: "Disease"
+      therapeutic_area: "Therapeutic Area"
+      sm: "Tractability Small Molecule"
+      ab: "Tractability Antibody"
+      pr: "Tractability PROTAC"
+      oc: "Tractability Other Modalities"
+      target_id: "Target ID"
+      approved_symbol: "Approved Symbol"
+      approved_name: "Approved Name"
+      subcellular_location: "Subcellular Location"
+      target_class: "ChEMBL Target Class"
+      pathways: "Reactome"
+      go_f: "GO:MF"
+      go_p: "GO:BP"
+      go_c: "GO:CC"
     }
   }
 
-  association {
-    output {
-      direct_by_datatype {
-        format = ${common.output_format}
-        path = ${common.path}"/output/association_by_datatype_direct"
-      }
-      direct_by_datasource {
-        format = ${common.output_format}
-        path = ${common.path}"/output/association_by_datasource_direct"
-      }
-      direct_by_overall {
-        format = ${common.output_format}
-        path = ${common.path}"/output/association_overall_direct"
-      }
-      indirect_by_datasource {
-        format = ${common.output_format}
-        path = ${common.path}"/output/association_by_datasource_indirect"
-      }
-      indirect_by_datatype {
-        format = ${common.output_format}
-        path = ${common.path}"/output/association_by_datatype_indirect"
-      }
-      indirect_by_overall {
-        format = ${common.output_format}
-        path = ${common.path}"/output/association_by_overall_indirect"
+  go: {
+    input: {
+      go: {
+        format: "csv"
+        path: ${common.path}"/input/go/go.obo"
       }
     }
-    input {
-      evidences = ${steps.evidence.output.succeeded}
-      diseases {
-        format = "parquet"
-        path = ${common.path}"/output/disease"
+    output: {
+      go: {
+        format: ${common.output_format}
+        path: ${common.output_path}"/output/go"
       }
     }
-    default_weight = 1.0
-    default_propagate = true
-    data_sources = [
-      {id: "europepmc",            weight: 0.2, data_type = "literature",        propagate = true},
-      {id: "expression_atlas",     weight: 0.2, data_type = "rna_expression",    propagate = false},
-      {id: "impc",                 weight: 0.2, data_type = "animal_model",      propagate = true},
-      {id: "progeny",              weight: 0.5, data_type = "affected_pathway",  propagate = true},
-      {id: "slapenrich",           weight: 0.5, data_type = "affected_pathway",  propagate = true},
-      {id: "sysbio",               weight: 0.5, data_type = "affected_pathway",  propagate = true},
-      {id: "cancer_biomarkers",    weight: 0.5, data_type = "affected_pathway",  propagate = true},
-      {id: "ot_crispr",            weight: 0.5, data_type = "ot_partner",        propagate = true},
-      {id: "ot_crispr_validation", weight: 0.5, data_type = "ot_validation_lab", propagate = true},
-      {id: "encore",               weight: 0.5, data_type = "ot_partner",        propagate = true},
+  }
+
+  association: {
+    input: {
+      evidences: ${steps.evidence.output.succeeded}
+      diseases: {
+        format: "parquet"
+        path: ${common.path}"/output/disease"
+      }
+    }
+    output: {
+      direct_by_datatype: {
+        format: ${common.output_format}
+        path: ${common.output_path}"/output/association_by_datatype_direct"
+      }
+      direct_by_datasource: {
+        format: ${common.output_format}
+        path: ${common.output_path}"/output/association_by_datasource_direct"
+      }
+      direct_by_overall: {
+        format: ${common.output_format}
+        path: ${common.output_path}"/output/association_overall_direct"
+      }
+      indirect_by_datasource: {
+        format: ${common.output_format}
+        path: ${common.output_path}"/output/association_by_datasource_indirect"
+      }
+      indirect_by_datatype: {
+        format: ${common.output_format}
+        path: ${common.output_path}"/output/association_by_datatype_indirect"
+      }
+      indirect_by_overall: {
+        format: ${common.output_format}
+        path: ${common.output_path}"/output/association_overall_indirect"
+      }
+    }
+    default_weight: 1.0
+    default_propagate: true
+    data_sources: [
+      { id: "europepmc",            data_type: "literature",        weight: 0.2, propagate: true  }
+      { id: "expression_atlas",     data_type: "rna_expression",    weight: 0.2, propagate: false }
+      { id: "impc",                 data_type: "animal_model",      weight: 0.2, propagate: true  }
+      { id: "progeny",              data_type: "affected_pathway",  weight: 0.5, propagate: true  }
+      { id: "slapenrich",           data_type: "affected_pathway",  weight: 0.5, propagate: true  }
+      { id: "sysbio",               data_type: "affected_pathway",  weight: 0.5, propagate: true  }
+      { id: "cancer_biomarkers",    data_type: "affected_pathway",  weight: 0.5, propagate: true  }
+      { id: "ot_crispr",            data_type: "ot_partner",        weight: 0.5, propagate: true  }
+      { id: "ot_crispr_validation", data_type: "ot_validation_lab", weight: 0.5, propagate: true  }
+      { id: "encore",               data_type: "ot_partner",        weight: 0.5, propagate: true  }
     ]
   }
 
-  association_otf {
-    input {
-      diseases {
-        format = "parquet"
-        path = ${common.path}"/output/disease"
+  association_otf: {
+    input: {
+      diseases: {
+        format: "parquet"
+        path: ${common.path}"/output/disease"
       }
-      evidences = ${steps.evidence.output.succeeded}
-      targets = ${steps.target.output.target}
+      evidences: ${steps.evidence.output.succeeded}
+      targets: ${steps.target.output.target}
     }
-    output {
-      clickhouse {
-        format = ${common.output_format}
-        path = ${common.path}"/view/association_otf"
-      }
-    }
-  }
-
-  search {
-    input {
-      evidence = ${steps.evidence.output.succeeded}
-      disease {
-        format = "parquet"
-        path = ${common.path}"/output/disease"
-      }
-      disease_hpo {
-        format = "parquet"
-        path = ${common.path}"/output/disease_phenotype"
-      }
-      hpo {
-        format = "parquet"
-        path = ${common.path}"/output/disease_hpo"
-      }
-      target = ${steps.target.output.target}
-      drug = ${steps.drug.output.drug}
-      mechanism = ${steps.drug.output.mechanism_of_action}
-      indication = ${steps.drug.output.indications}
-      association = ${steps.association.output.indirect_by_overall}
-      credible_sets {
-        format = "parquet"
-        path = ${common.path}"/output/credible_set"
-      }
-      studies {
-        format = "parquet"
-        path = ${common.path}"/output/study"
-      }
-      variants {
-        format = "parquet"
-        path = ${common.path}"/output/variant"
-      }
-    }
-    output {
-      targets {
-        format = ${common.output_format}
-        path = ${common.path}"/view/search_target"
-      }
-      diseases {
-        format = ${common.output_format}
-        path = ${common.path}"/view/search_disease"
-      }
-      drugs {
-        format = ${common.output_format}
-        path = ${common.path}"/view/search_drug"
-      }
-      variants {
-        format = ${common.output_format}
-        path = ${common.path}"/view/search_variant"
-      }
-      studies {
-        format = ${common.output_format}
-        path = ${common.path}"/view/search_study"
+    output: {
+      clickhouse: {
+        format: ${common.output_format}
+        path: ${common.output_path}"/view/association_otf"
       }
     }
   }
 
-  openfda {
-    input {
-      chembl_drugs = ${steps.drug.output.drug}
-      fda_data {
-        format = ${common.output_format}
-        path = ${common.path}"/intermediate/openfda/*"
+  search: {
+    input: {
+      association: ${steps.association.output.indirect_by_overall}
+      drug: ${steps.drug.output.drug}
+      evidence: ${steps.evidence.output.succeeded}
+      indication: ${steps.drug.output.indications}
+      mechanism: ${steps.drug.output.mechanism_of_action}
+      target: ${steps.target.output.target}
+      credible_sets: {
+        format: "parquet"
+        path: ${common.path}"/output/credible_set"
       }
-      blacklisted_events {
-        format = "csv"
-        path = ${common.path}"/input/openfda/blacklisted_events.txt"
-        options = [
-          {k: "sep", v: "\\t"},
-          {k: "ignoreLeadingWhiteSpace", v: "true"},
-          {k: "ignoreTrailingWhiteSpace", v: "true"}
+      disease: {
+        format: "parquet"
+        path: ${common.path}"/output/disease"
+      }
+      disease_hpo: {
+        format: "parquet"
+        path: ${common.path}"/output/disease_phenotype"
+      }
+      hpo: {
+        format: "parquet"
+        path: ${common.path}"/output/disease_hpo"
+      }
+      studies: {
+        format: "parquet"
+        path: ${common.path}"/output/study"
+      }
+      variants: {
+        format: "parquet"
+        path: ${common.path}"/output/variant"
+      }
+    }
+    output: {
+      diseases: {
+        format: ${common.output_format}
+        path: ${common.output_path}"/view/search_disease"
+      }
+      drugs: {
+        format: ${common.output_format}
+        path: ${common.output_path}"/view/search_drug"
+      }
+      studies: {
+        format: ${common.output_format}
+        path: ${common.output_path}"/view/search_study"
+      }
+      targets: {
+        format: ${common.output_format}
+        path: ${common.output_path}"/view/search_target"
+      }
+      variants: {
+        format: ${common.output_format}
+        path: ${common.output_path}"/view/search_variant"
+      }
+    }
+  }
+
+  openfda: {
+    input: {
+      chembl_drugs: ${steps.drug.output.drug}
+      blacklisted_events: {
+        format: "csv"
+        path: ${common.path}"/input/openfda/blacklisted_events.txt"
+        options: [
+          { k: "sep",                      v: "\\t" }
+          { k: "ignoreLeadingWhiteSpace",  v: true  }
+          { k: "ignoreTrailingWhiteSpace", v: true  }
         ]
       }
-      meddra_preferred_terms {
-        format = "csv"
-        path = "gs://open-targets-data-releases-private/meddra/meddra23.1/MedAscii/pt.asc"
+      fda_data: {
+        format: ${common.output_format}
+        path: ${common.path}"/intermediate/openfda/*"
       }
-      meddra_low_level_terms {
-        format = "csv"
-        path = "gs://open-targets-data-releases-private/meddra/meddra23.1/MedAscii/llt.asc"
+      meddra_preferred_terms: {
+        format: "csv"
+        path: "gs://open-targets-data-releases-private/meddra/meddra23.1/MedAscii/pt.asc"
+      }
+      meddra_low_level_terms: {
+        format: "csv"
+        path: "gs://open-targets-data-releases-private/meddra/meddra23.1/MedAscii/llt.asc"
       }
     }
-    meddra_preferred_terms_cols = ["pt_code", "pt_name"]
-    meddra_low_level_terms_cols = ["llt_code", "llt_name"]
-    montecarlo {
+    output: {
+      fda_unfiltered: {
+        format: ${common.output_format}
+        path: ${common.output_path}"/intermediate/openfda_adverse_drug_reactions"
+      }
+      fda_results: {
+        format: ${common.output_format}
+        path: ${common.output_path}"/output/openfda_significant_adverse_drug_reactions"
+      }
+      fda_targets_unfiltered: {
+        format: ${common.output_format}
+        path: ${common.output_path}"/intermediate/openfda_adverse_target_reactions"
+      }
+      fda_targets_results: {
+        format: ${common.output_format}
+        path: ${common.output_path}"/output/openfda_significant_adverse_target_reactions"
+      }
+      sampling: {
+        format: ${common.output_format}
+        path: ${common.output_path}"/intermediate/openfda_sample"
+      }
+      sampling_targets: {
+        format: ${common.output_format}
+        path: ${common.output_path}"/intermediate/openfda_sample_targets"
+      }
+    }
+    meddra_preferred_terms_cols: [
+      "pt_code"
+      "pt_name"
+    ]
+    meddra_low_level_terms_cols: [
+      "llt_code"
+      "llt_name"
+    ]
+    montecarlo: {
       permutations: 100
       percentile: 0.95
     }
-    sampling {
-      size = 0.1
-      enabled = false
+    sampling: {
+      size: 0.1
+      enabled: false
     }
-    output {
-      fda_unfiltered {
-        format = ${common.output_format}
-        path = ${common.path}"/intermediate/openfda_adverse_drug_reactions"
+  }
+
+  search_ebi: {
+    input: {
+      disease: {
+        format: "parquet"
+        path: ${common.path}"/output/disease"
       }
-      fda_results {
-        format = ${common.output_format}
-        path = ${common.path}"/output/openfda_significant_adverse_drug_reactions"
+      target: ${steps.target.output.target}
+      evidence: {
+        format: ${common.output_format}
+        path: ${steps.evidence.output.succeeded.path}"/sourceId=gwas_credible_sets/"
       }
-      fda_targets_unfiltered {
-        format = ${common.output_format}
-        path = ${common.path}"/intermediate/openfda_adverse_target_reactions"
+      association: ${steps.association.output.direct_by_overall}
+    }
+    output: {
+      associations: {
+        format: ${common.output_format}
+        path: ${common.output_path}"/view/search_ebi_associations"
       }
-      fda_targets_results {
-        format = ${common.output_format}
-        path = ${common.path}"/output/openfda_significant_adverse_target_reactions"
-      }
-      sampling {
-        format = ${common.output_format}
-        path = ${common.path}"/intermediate/openfda_sample"
-      }
-      sampling_targets {
-        format = ${common.output_format}
-        path = ${common.path}"/intermediate/openfda_sample_targets"
+      evidence: {
+        format: ${common.output_format}
+        path: ${common.output_path}"/view/search_ebi_evidence"
       }
     }
   }
 
-  search_ebi {
-    input {
-      disease {
-        format = "parquet"
-        path = ${common.path}"/output/disease"
+  otar: {
+    input: {
+      diseases: {
+        format: "parquet"
+        path: ${common.path}"/output/disease"
       }
-      target = ${steps.target.output.target}
-      evidence {
-        format = ${common.output_format}
-        path = ${steps.evidence.output.succeeded.path}"/sourceId=gwas_credible_sets/"
-      }
-      association = ${steps.association.output.direct_by_overall}
-    }
-    output {
-      associations {
-        format = ${common.output_format}
-        path = ${common.path}"/view/search_ebi_associations"
-      }
-      evidence {
-        format = ${common.output_format}
-        path = ${common.path}"/view/search_ebi_evidence"
-      }
-    }
-  }
-
-  otar {
-    input {
-      diseases {
-        format = "parquet"
-        path = ${common.path}"/output/disease"
-      }
-      otar_meta {
-        format = "csv"
-        path = ${common.path}"/input/otar/otar_meta.csv"
-        options = [
-          {k: "sep", v: ","},
-          {k: "header", v: "true"}
-          {k: "inferSchema", v: "true"}
+      otar_meta: {
+        format: "csv"
+        path: ${common.path}"/input/otar/otar_meta.csv"
+        options: [
+          { k: "sep",         v: ","  }
+          { k: "header",      v: true }
+          { k: "inferSchema", v: true }
         ]
       }
-      otar_project_to_efo {
-        format = "csv"
-        path = ${common.path}"/input/otar/otar_project_to_efo.csv"
-        options = [
-          {k: "sep", v: ","},
-          {k: "header", v: "true"}
-          {k: "inferSchema", v: "true"}
+      otar_project_to_efo: {
+        format: "csv"
+        path: ${common.path}"/input/otar/otar_project_to_efo.csv"
+        options: [
+          { k: "sep",         v: ","  }
+          { k: "header",      v: true }
+          { k: "inferSchema", v: true }
         ]
       }
     }
-    output {
-      otar {
-        format = ${common.output_format}
-        path = ${common.path}"/output/otar"
+    output: {
+      otar: {
+        format: ${common.output_format}
+        path: ${common.output_path}"/output/otar"
       }
     }
   }
 
-  literature {
-    common {
-      publication_section_ranks = [
-        {section: "title",    rank: 1, weight: 1.0}
-        {section: "abstract", rank: 1, weight: 0.8}
-        {section: "concl",    rank: 1, weight: 0.7}
-        {section: "results",  rank: 2, weight: 0.6}
-        {section: "discuss",  rank: 2, weight: 0.5}
-        {section: "methods",  rank: 3, weight: 0.3}
-        {section: "other",    rank: 4, weight: 0.1}
+  literature: {
+    input: {
+      processing_epmcids: {
+        format: "csv"
+        path: ${common.path}"/input/literature/PMID_PMCID_DOI.csv.gz"
+        options: [
+          { k: "header",      v: true }
+          { k: "inferSchema", v: true }
+        ]
+      }
+      processing_diseases: {
+        format: "parquet"
+        path: ${common.path}"/output/disease"
+      }
+      processing_targets: ${steps.target.output.target}
+      processing_drugs: ${steps.drug.output.drug}
+      processing_abstracts: {
+        format: "json"
+        path: "gs://otar025-epmc/ml02/abstract/**/*.jsonl"
+      }
+      processing_full_texts: {
+        format: "json"
+        path: "gs://otar025-epmc/ml02/fulltext/**/*.jsonl"
+      }
+      epmc_cooccurences: ${steps.literature.output.processing_cooccurrences}
+      embedding_matches: ${steps.literature.output.processing_matches}
+      vectors_input: ${steps.literature.output.embedding_model}
+    }
+    output: {
+      processing_cooccurrences: {
+        format: ${common.output_format}
+        path: ${common.output_path}"/intermediate/literature_cooccurrence"
+      }
+      processing_matches: {
+        format: ${common.output_format}
+        path: ${common.output_path}"/intermediate/literature_match"
+      }
+      processing_literature_index: {
+        format: ${common.output_format}
+        path: ${common.output_path}"/output/literature"
+      }
+      processing_literature_sentences: {
+        format: ${common.output_format}
+        path: ${common.output_path}"/intermediate/literature_sentence"
+      }
+      processing_failed_cooccurrences: {
+        format: ${common.output_format}
+        path: ${common.output_path}"/excluded/literature_cooccurrence"
+      }
+      processing_failed_matches: {
+        format: ${common.output_format}
+        path: ${common.output_path}"/excluded/literature_match"
+      }
+      epmc_cooccurrences: {
+        format: ${common.output_format}
+        path: ${common.output_path}"/intermediate/literature_epmc_cooccurrence"
+      }
+      epmc_output: {
+        format: "json"
+        path: ${common.output_path}"/intermediate/evidence/literature_epmc"
+        options: [
+          { k: "compression", v: "gzip" }
+        ]
+      }
+      embedding_model: {
+        format: ${common.output_format}
+        path: ${common.output_path}"/etc/model/w2v_model"
+      }
+      embedding_training_set: {
+        format: ${common.output_format}
+        path: ${common.output_path}"/intermediate/literature_training_set"
+      }
+      vectors_output: {
+        format: ${common.output_format}
+        path: ${common.output_path}"/output/literature_vector"
+      }
+    }
+    common: {
+      publication_section_ranks: [
+        { section: "title",    rank: 1, weight: 1.0 }
+        { section: "abstract", rank: 1, weight: 0.8 }
+        { section: "concl",    rank: 1, weight: 0.7 }
+        { section: "results",  rank: 2, weight: 0.6 }
+        { section: "discuss",  rank: 2, weight: 0.5 }
+        { section: "methods",  rank: 3, weight: 0.3 }
+        { section: "other",    rank: 4, weight: 0.1 }
       ]
 
-      spark_session_config = [
-        {k: "spark.sql.mapKeyDedupPolicy", v: "LAST_WIN"}
+      spark_session_config: [
+        { k: "spark.sql.mapKeyDedupPolicy", v: "LAST_WIN" }
       ]
     }
-    input {
-      processing_epmcids {
-        format = "csv"
-        path = ${common.path}"/input/literature/PMID_PMCID_DOI.csv.gz"
-        options = [
-          {k: "header", v: "true"}
-          {k: "inferSchema", v: "true"}
-        ]
-      }
-      processing_diseases {
-        format = "parquet"
-        path = ${common.path}"/output/disease"
-      }
-      processing_targets = ${steps.target.output.target}
-      processing_drugs = ${steps.drug.output.drug}
-      processing_abstracts {
-        format = "json"
-        path = "gs://otar025-epmc/ml02/abstract/**/*.jsonl"
-      }
-      processing_full_texts {
-        format = "json"
-        path = "gs://otar025-epmc/ml02/fulltext/**/*.jsonl"
-      }
-      epmc_cooccurences = ${steps.literature.output.processing_cooccurrences}
-      embedding_matches = ${steps.literature.output.processing_matches}
-      vectors_input = ${steps.literature.output.embedding_model}
+    processing: {
+      # When preparing the literature outputs we can optionally save all the
+      # entities which did not match. These are not used for anything downstream
+      # and are only useful for debugging and quality control. Setting this value
+      # to true will result in additional outputs 'failedMatches' and 'failedCoocs'
+      # being written. Note, this slows down the process significantly.
+      write_failures: false
     }
-    output {
-      processing_cooccurrences {
-        format = ${common.output_format}
-        path = ${common.path}"/intermediate/literature_cooccurrence"
+    epmc: {
+      uris: {
+        ensembl: "https://www.ensembl.org/Homo_sapiens/Gene/Summary?db=core;g="
+        chembl: "https://www.ebi.ac.uk/chembl/compound_report_card/"
+        ontologies: "https://www.ebi.ac.uk/ols/ontologies/efo/terms?short_form="
       }
-      processing_matches {
-        format = ${common.output_format}
-        path = ${common.path}"/intermediate/literature_match"
-      }
-      processing_literature_index {
-        format = ${common.output_format}
-        path = ${common.path}"/output/literature"
-      }
-      processing_literature_sentences {
-        format = ${common.output_format}
-        path = ${common.path}"/intermediate/literature_sentence"
-      }
-      processing_failed_cooccurrences {
-        format = ${common.output_format}
-        path = ${common.path}"/excluded/literature_cooccurrence"
-      }
-      processing_failed_matches {
-        format = ${common.output_format}
-        path = ${common.path}"/excluded/literature_match"
-      }
-      epmc_cooccurrences {
-        format = ${common.output_format}
-        path = ${common.path}"/intermediate/literature_epmc_cooccurrence"
-      }
-      epmc_output {
-        format = "json"
-        path = ${common.path}"/intermediate/evidence/literature_epmc"
-        options = [
-          {k: "compression", v: "gzip"},
-        ]
-      }
-      embedding_model {
-        format = ${common.output_format}
-        path = ${common.path}"/etc/model/w2v_model"
-      }
-      embedding_training_set {
-        format = ${common.output_format}
-        path = ${common.path}"/intermediate/literature_training_set"
-      }
-      vectors_output {
-        format = ${common.output_format}
-        path = ${common.path}"/output/literature_vector"
-      }
-    }
-    processing {
-      // When preparing the literature outputs we can optionally save all the
-      // entities which did not match. These are not used for anything downstream
-      // and are only useful for debugging and quality control. Setting this value
-      // to true will result in additional outputs 'failedMatches' and 'failedCoocs'
-      // being written. Note, this slows down the process significantly.
-      write_failures = false
-    }
-    epmc {
-      uris {
-        ensembl = "https://www.ensembl.org/Homo_sapiens/Gene/Summary?db=core;g="
-        chembl = "https://www.ebi.ac.uk/chembl/compound_report_card/"
-        ontologies = "https://www.ebi.ac.uk/ols/ontologies/efo/terms?short_form="
-      }
-      excluded_target_terms = [
-        "TEC",
-        "TECS",
-        "Tec",
-        "tec",
-        "'",
-        "(",
-        ")",
-        "-",
-        "-S",
-        "S",
-        "S-",
-        "SS",
-        "SSS",
-        "Ss",
-        "Ss-",
-        "s",
-        "s-",
-        "ss",
-        "U3",
-        "U6",
-        "u6",
-        "SNORA70",
-        "U2",
+      excluded_target_terms: [
+        "TEC"
+        "TECS"
+        "Tec"
+        "tec"
+        "'"
+        "("
+        ")"
+        "-"
+        "-S"
+        "S"
+        "S-"
+        "SS"
+        "SSS"
+        "Ss"
+        "Ss-"
+        "s"
+        "s-"
+        "ss"
+        "U3"
+        "U6"
+        "u6"
+        "SNORA70"
+        "U2"
         "U8"
       ]
       # The following are the relevant sections for disease/target associations as described in PMID28587637
-      sections_of_interest = [
-        "title",
-        "abstract",
-        "intro",
-        "case",
-        "figure",
-        "table",
-        "discuss",
-        "concl",
-        "results",
-        "appendix",
-        "other",
+      sections_of_interest: [
+        "title"
+        "abstract"
+        "intro"
+        "case"
+        "figure"
+        "table"
+        "discuss"
+        "concl"
+        "results"
+        "appendix"
+        "other"
       ]
-      print_metrics = true
+      print_metrics: true
     }
-    embedding {
-      model_configuration {
-        window_size = 10
-        num_partitions = 16
-        max_iter = 3
-        min_count = 1
-        step_size = 0.02
+    embedding: {
+      model_configuration: {
+        window_size: 10
+        num_partitions: 16
+        max_iter: 3
+        min_count: 1
+        step_size: 0.02
       }
     }
   }
 
-  target_engine {
-    input {
-      targets = ${steps.target.output.target}
-      molecule = ${steps.drug.output.drug}
-      mechanism_of_action = ${steps.drug.output.mechanism_of_action}
-      mouse_phenotypes {
-        format = "json"
-        path = ${common.path}"/input/mouse_phenotype/mouse_phenotypes.json.gz"
+  target_engine: {
+    input: {
+      targets: ${steps.target.output.target}
+      molecule: ${steps.drug.output.drug}
+      mechanism_of_action: ${steps.drug.output.mechanism_of_action}
+      mouse_phenotypes: {
+        format: "json"
+        path: ${common.path}"/input/mouse_phenotype/mouse_phenotypes.json.gz"
       }
-      hpa_data {
-        format = "json"
-        path = ${common.path}"/input/target_engine/proteinatlas.json.gz"
+      hpa_data: {
+        format: "json"
+        path: ${common.path}"/input/target_engine/proteinatlas.json.gz"
       }
-      uniprot_slterms {
-        format = "csv"
-        path = ${common.path}"/input/target_engine/uniprot_locations.tsv.gz"
-        options = [
-          {k: "header", v: "true"},
-          {k: "sep", v: "\t"},
+      uniprot_slterms: {
+        format: "csv"
+        path: ${common.path}"/input/target_engine/uniprot_locations.tsv.gz"
+        options: [
+          { k: "sep",    v: "\t" }
+          { k: "header", v: true }
         ]
       }
-      mouse_pheno_scores {
-        format = "csv"
-        path = ${common.path}"/input/target_engine/mouse_pheno_scores.csv"
-        options = [
-              {k: "sep", v: ","},
-              {k: "header", v: "true"}
-              {k: "inferSchema", v: "true"}
-            ]
+      mouse_pheno_scores: {
+        format: "csv"
+        path: ${common.path}"/input/target_engine/mouse_pheno_scores.csv"
+        options: [
+          { k: "sep",         v: ","  }
+          { k: "header",      v: true }
+          { k: "inferSchema", v: true }
+        ]
       }
     }
-    output {
-      target_engine {
-        path = ${common.path}"/output/target_prioritisation"
-        format = ${common.output_format}
+    output: {
+      target_engine: {
+        format: ${common.output_format}
+        path: ${common.output_path}"/output/target_prioritisation"
       }
     }
   }

--- a/src/orchestration/dags/config/pis.yaml
+++ b/src/orchestration/dags/config/pis.yaml
@@ -1,15 +1,19 @@
 ---
 work_path: /mnt/disks/work
 log_level: INFO
-pool: 16
+pool_size: 16
 
 release_uri: '{{release_uri}}'
 scratchpad:
   chembl_version: '{{chembl_version}}'
   efo_version: '{{efo_version}}'
   ensembl_version: '{{ensembl_version}}'
-  hpo_version: '2025-01-16'
-  mondo_version: '2025-02-04'
+  gencode_version: '{{gencode_version}}'
+  depmap_version: '{{depmap_version}}'
+  hpo_version: '{{hpo_version}}'
+  mondo_version: '{{mondo_version}}'
+  ot_curation: '{{ot_curation}}'
+  probes_drugs_version: '{{probes_drugs_version}}'
 
 steps:
   #: BIOSAMPLE STEP :###############################################################################
@@ -50,14 +54,9 @@ steps:
 
   #: DRUG STEP :####################################################################################
   drug:
-    - name: find_latest chemical probes
-      source: gs://otar001-core/ChemicalProbes/annotation
-      scratchpad_key: latest_chemical_probes
     - name: copy chemical probes
-      requires:
-        - find_latest chemical probes
-      source: ${latest_chemical_probes}
-      destination: input/drug/chemicalprobes.json.gz
+      source: https://www.probes-drugs.org/media/download/probes/pd_export_${probes_drugs_version}_probes_standardized.xlsx
+      destination: input/target/chemicalprobes/probes.xlsx
 
     - name: find_latest drugbank annotation
       source: gs://otar001-core/DrugBank/annotation
@@ -78,7 +77,6 @@ steps:
         - efo_id
         - max_phase_for_ind
         - indication_refs
-
     - name: elasticsearch chembl drug warning
       url: https://www.ebi.ac.uk/chembl/elk/es
       destination: input/drug/chembl_drug_warning.jsonl
@@ -97,7 +95,6 @@ steps:
         - warning_refs
         - warning_type
         - warning_year
-
     - name: elasticsearch chembl mechanism of action
       url: https://www.ebi.ac.uk/chembl/elk/es
       destination: input/drug/chembl_mechanism.jsonl
@@ -142,6 +139,14 @@ steps:
 
   #: EVIDENCE STEP :################################################################################
   evidence:
+    - name: explode ot_curation files
+      foreach:
+        - mappings/biosystem/depmap_uberon_mapping.csv
+      do:
+        - name: copy ${each}
+          source: https://raw.githubusercontent.com/opentargets/curation/${ot_curation}/${each}
+          destination: input/ot_curation/${each}
+
     - name: find_latest atlas
       source: gs://otar010-atlas
       scratchpad_key: 'latest_atlas'
@@ -151,32 +156,36 @@ steps:
       source: ${latest_atlas}
       destination: input/evidence/atlas.json.bz2
 
-    - name: find_latest cancer biomarkers
-      source: gs://otar000-evidence_input/CancerBiomarkers/json
-      scratchpad_key: 'latest_cancer_biomarkers'
-    - name: copy cancer biomarkers
-      requires:
-        - find_latest cancer biomarkers
-      source: ${latest_cancer_biomarkers}
-      destination: input/evidence/cancerbiomarkers.json.gz
+    - name: copy cancer biomarkers associations
+      source: gs://otar000-evidence_input/CancerBiomarkers/data_files/cancerbiomarkers-2018-05-01.tsv
+      destination: input/evidence/cancerbiomarkers/associations.tsv
+    - name: copy cancer biomarkers sources
+      source: gs://otar000-evidence_input/CancerBiomarkers/data_files/cancer_biomarker_source.jsonl
+      destination: input/evidence/cancerbiomarkers/sources.jsonl
+    - name: copy cancer biomarkers diseases
+      source: gs://otar000-evidence_input/CancerBiomarkers/data_files/cancer_biomarker_disease.jsonl
+      destination: input/evidence/cancerbiomarkers/diseases.jsonl
 
     - name: find_latest chembl
-      source: gs://otar000-evidence_input/ChEMBL/json
+      source: gs://otar008-chembl
       scratchpad_key: 'latest_chembl'
     - name: copy chembl
       requires:
         - find_latest chembl
       source: ${latest_chembl}
-      destination: input/evidence/chembl.json.gz
-
-    - name: find_latest clingen
-      source: gs://otar000-evidence_input/ClinGen/json
-      scratchpad_key: 'latest_clingen'
-    - name: copy clingen
+      destination: input/evidence/chembl/chembl.json.gz
+    - name: find_latest stop_reasons
+      source: gs://otar000-evidence_input/ChEMBL/data_files
+      scratchpad_key: 'latest_chembl_stop_reasons'
+    - name: copy chembl stop reasons
       requires:
-        - find_latest clingen
-      source: ${latest_clingen}
-      destination: input/evidence/clingen.json.gz
+        - find_latest stop_reasons
+      source: ${latest_chembl_stop_reasons}
+      destination: input/evidence/chembl/stop_reasons.json
+
+    - name: copy clingen
+      source: https://search.clinicalgenome.org/kb/gene-validity/download
+      destination: input/evidence/clingen.csv
 
     - name: find_latest cosmic
       source: gs://otar007-cosmic
@@ -188,23 +197,23 @@ steps:
       source: ${latest_cosmic}
       destination: input/evidence/cosmic.json.gz
 
-    - name: find_latest crispr
-      source: gs://otar000-evidence_input/CRISPR/json
-      scratchpad_key: 'latest_crispr'
-    - name: copy crispr
-      requires:
-        - find_latest crispr
-      source: ${latest_crispr}
-      destination: input/evidence/crispr.json.gz
+    - name: copy sanger cell passport
+      source: https://cog.sanger.ac.uk/cmp/download/model_list_latest.csv.gz
+      destination: input/evidence/cell_passport.csv.gz
 
-    - name: find_latest crispr_screen
-      source: gs://otar000-evidence_input/Crispr_screens/json
-      scratchpad_key: 'latest_crispr_screen'
-    - name: copy crispr_screen
-      requires:
-        - find_latest crispr_screen
-      source: ${latest_crispr_screen}
-      destination: input/evidence/crispr_screen.json.gz
+    - name: copy project_score cell types
+      source: gs://otar000-evidence_input/CRISPR/data_files/project_score_v2/cell_types.tsv
+      destination: input/evidence/project_score/cell_types.tsv
+    - name: copy project_score gene scores
+      source: gs://otar000-evidence_input/CRISPR/data_files/project_score_v2/mapped_diseases.tsv
+      destination: input/evidence/project_score/mapped_diseases.tsv
+
+    - name: crispr_brain fetch
+      destination: input/evidence/crispr_screens
+      api_url: https://crisprbrain.org/api/screens
+      client_id: 92f263647c43525d3e4f181aa7e348f26e32129c0f827321d9261cc9765c56c0
+      study_prefix_url: https://storage.googleapis.com/crisprbrain.appspot.com/api-data/
+      validate_version: 1
 
     - name: find_latest eva
       source: gs://otar012-eva/disease-target-evidence
@@ -215,41 +224,140 @@ steps:
       source: ${latest_eva}
       destination: input/evidence/eva.json.gz
 
-    - name: find_latest gene_burden
-      source: gs://otar000-evidence_input/GeneBurden/json
-      scratchpad_key: 'latest_gene_burden'
-    - name: copy gene_burden
-      requires:
-        - find_latest gene_burden
-      source: ${latest_gene_burden}
-      destination: input/evidence/gene_burden.json.gz
+    - name: copy gene_burden cvdi
+      source: https://static-content.springer.com/esm/art%3A10.1038%2Fs41588-024-01894-5/MediaObjects/41588_2024_1894_MOESM4_ESM.xlsx
+      destination: input/evidence/gene_burden/cvdi.xlsx
+    - name: explode_glob download genebass
+      glob: 'gs://otar000-evidence_input/GeneBurden/data_files/genebass_entries/*.parquet'
+      do:
+        - name: copy genebass ${match_stem}
+          source: ${uri}
+          destination: input/evidence/gene_burden/genebass/${match_stem}.${match_ext}
 
-    - name: find_latest gene2phenotype
-      source: gs://otar000-evidence_input/Gene2Phenotype/json
-      scratchpad_key: 'latest_gene2phenotype'
-    - name: copy gene2phenotype
-      requires:
-        - find_latest gene2phenotype
-      source: ${latest_gene2phenotype}
-      destination: input/evidence/gene2phenotype.json.gz
+    - name: copy gene_burden finngen
+      source: gs://finngen-public-data-r12/lof/data/finngen_R12_lof.txt.gz
+      destination: input/evidence/gene_burden/finngen/finngen.txt.gz
+    - name: copy gene_burden finngen phenos
+      source: https://r12.finngen.fi/api/phenos
+      destination: input/evidence/gene_burden/finngen/phenos
 
-    - name: find_latest genomics_england
-      source: gs://otar000-evidence_input/GenomicsEngland/json
-      scratchpad_key: 'latest_genomics_england'
-    - name: copy genomics_england
-      requires:
-        - find_latest genomics_england
-      source: ${latest_genomics_england}
-      destination: input/evidence/genomics_england.json.gz
+    - name: explode_glob AZ parquet (binary)
+      glob: gs://otar000-evidence_input/GeneBurden/data_files/azphewas-com-470k-phewas-binary/*.parquet
+      do:
+        - name: copy binary ${match_stem}.parquet
+          source: ${uri}
+          destination: input/evidence/gene_burden/astrazeneca/azphewas-com-470k-phewas-binary/${match_stem}.parquet
+    - name: explode_glob AZ parquet (quantitative)
+      glob: gs://otar000-evidence_input/GeneBurden/data_files/azphewas-com-470k-phewas-quantitative/*.parquet
+      do:
+        - name: copy quantitative ${match_stem}.parquet
+          source: ${uri}
+          destination: input/evidence/gene_burden/astrazeneca/azphewas-com-470k-phewas-quantitative/${match_stem}.parquet
+    - name: explode AZ CSVs
+      foreach:
+        - azphewas_com_genes_UK_Biobank_470k.csv
+        - azphewas_com_phenotypes_UK_Biobank_470k.csv
+      do:
+        - name: copy ${each}
+          source: gs://otar000-evidence_input/GeneBurden/data_files/${each}
+          destination: input/evidence/gene_burden/astrazeneca/${each}
 
-    - name: find_latest impc
-      source: gs://otar000-evidence_input/IMPC/json
-      scratchpad_key: 'latest_impc'
-    - name: copy impc
-      requires:
-        - find_latest impc
-      source: ${latest_impc}
-      destination: input/evidence/impc.json.gz
+    - name: copy gene2phenotype cancer
+      source: https://www.ebi.ac.uk/gene2phenotype/api/panel/Cancer/download/
+      destination: input/evidence/gene2phenotype/cancer.csv
+    - name: copy gene2phenotype cardiac
+      source: https://www.ebi.ac.uk/gene2phenotype/api/panel/Cardiac/download/
+      destination: input/evidence/gene2phenotype/cardiac.csv
+    - name: copy gene2phenotype dd
+      source: https://www.ebi.ac.uk/gene2phenotype/api/panel/DD/download/
+      destination: input/evidence/gene2phenotype/dd.csv
+    - name: copy gene2phenotype ear
+      source: https://www.ebi.ac.uk/gene2phenotype/api/panel/Ear/download/
+      destination: input/evidence/gene2phenotype/ear.csv
+    - name: copy gene2phenotype eye
+      source: https://www.ebi.ac.uk/gene2phenotype/api/panel/Eye/download/
+      destination: input/evidence/gene2phenotype/eye.csv
+    - name: copy gene2phenotype skeletal
+      source: https://www.ebi.ac.uk/gene2phenotype/api/panel/Skeletal/download/
+      destination: input/evidence/gene2phenotype/skeletal.csv
+    - name: copy gene2phenotype skin
+      source: https://www.ebi.ac.uk/gene2phenotype/api/panel/Skin/download/
+      destination: input/evidence/gene2phenotype/skin.csv
+
+    - name: copy panel_app
+      source: gs://otar000-evidence_input/GenomicsEngland/data_files/All_genes_20250525_public_v1plus_genes_all_ratings.tsv
+      destination: input/evidence/panel_app.tsv
+
+    - name: solr fetch gene_gene
+      destination: input/evidence/impc
+      url: http://www.ebi.ac.uk/mi/impc/solr/phenodigm/select
+      queries:
+        - data_type: gene_gene
+          fields:
+            - gene_id
+            - hgnc_gene_id
+    - name: solr fetch ontology_ontology
+      destination: input/evidence/impc
+      url: http://www.ebi.ac.uk/mi/impc/solr/phenodigm/select
+      queries:
+        - data_type: ontology_ontology
+          fields:
+            - mp_id
+            - hp_id
+    - name: solr fetch mouse_model
+      destination: input/evidence/impc
+      url: http://www.ebi.ac.uk/mi/impc/solr/phenodigm/select
+      queries:
+        - data_type: mouse_model
+          fields:
+            - model_id
+            - model_phenotypes
+    - name: solr fetch disease
+      destination: input/evidence/impc
+      url: http://www.ebi.ac.uk/mi/impc/solr/phenodigm/select
+      queries:
+        - data_type: disease
+          fields:
+            - disease_id
+            - disease_phenotypes
+    - name: solr fetch disease_model_summary
+      destination: input/evidence/impc
+      url: http://www.ebi.ac.uk/mi/impc/solr/phenodigm/select
+      batch_size: 100000000
+      queries:
+        - data_type: disease_model_summary
+          fields:
+            - model_id
+            - model_genetic_background
+            - model_description
+            - disease_id
+            - disease_term
+            - disease_model_avg_norm
+            - disease_model_max_norm
+            - marker_id
+    - name: solr fetch ontology
+      destination: input/evidence/impc
+      url: http://www.ebi.ac.uk/mi/impc/solr/phenodigm/select
+      queries:
+        - data_type: ontology
+          fields:
+            - ontology
+            - phenotype_id
+            - phenotype_term
+
+    - name: explode impc metadata
+      foreach:
+        - MGI_Gene_Model_Coord.rpt # Mouse gene mappings
+        - MGI_PhenoGenoMP.rpt # Mouse PubMed references
+        - mp.owl # Mammalian Phenotype ontology
+      do:
+        - name: copy ${each}
+          source: http://www.informatics.jax.org/downloads/reports/${each}
+          destination: input/evidence/impc/${each}
+
+    - name: copy gene name
+      source: https://storage.googleapis.com/public-download-files/hgnc/tsv/tsv/hgnc_complete_set.txt
+      destination: input/target/genenames/hgnc_complete_set.tsv
 
     - name: find_latest intogen
       source: gs://otar000-evidence_input/IntOgen/json
@@ -260,14 +368,9 @@ steps:
       source: ${latest_intogen}
       destination: input/evidence/intogen.json.gz
 
-    - name: find_latest orphanet
-      source: gs://otar000-evidence_input/Orphanet/json
-      scratchpad_key: 'latest_orphanet'
     - name: copy orphanet
-      requires:
-        - find_latest orphanet
-      source: ${latest_orphanet}
-      destination: input/evidence/orphanet.json.gz
+      source: http://www.orphadata.org/data/xml/en_product6.xml
+      destination: input/evidence/orphanet.xml
 
     - name: find_latest progeny
       source: gs://otar000-evidence_input/PROGENy/json
@@ -335,14 +438,30 @@ steps:
       source: ${latest_validation_lab}
       destination: input/evidence/validation_lab.json.gz
 
-    - name: find_latest encore
-      source: gs://otar013-ppp/encore
-      scratchpad_key: 'latest_encore'
-    - name: copy encore
+    - name: explode_glob encore files
+      glob: 'gs://otar013-ppp/encore/input/2024.01.11-Freeze4/**/**'
+      do:
+        - name: copy encore ${match_stem} ${uuid}
+          source: ${uri}
+          destination: input/evidence/encore/${match_path}${match_stem}.${match_ext}
+    - name: copy encore config
+      source: gs://otar013-ppp/PPP-evidence-configuration/encore_config.json
+      destination: input/evidence/encore/config.json
+    - name: copy sanger cell passport
+      source: https://cog.sanger.ac.uk/cmp/download/model_list_latest.csv.gz
+      destination: input/evidence/cell_passport.csv.gz
+    - name: copy ot_curation  depmap_tissue_mapping
+      source: https://raw.githubusercontent.com/opentargets/curation/${ot_curation}/mappings/biosystem/depmap_uberon_mapping.csv
+      destination: input/evidence/depmap_uberon_mapping.csv
+
+    - name: find_latest validation_lab
+      source: gs://otar013-ppp/validation_lab
+      scratchpad_key: latest_validation_lab
+    - name: copy validation_lab
       requires:
-        - find_latest encore
-      source: ${latest_encore}
-      destination: input/evidence/encore.json.gz
+        - find_latest validation_lab
+      source: ${latest_validation_lab}
+      destination: input/evidence/validation_lab.json.gz
 
     - name: find_latest ot_crispr
       source: gs://otar013-ppp/ot_crispr
@@ -431,24 +550,13 @@ steps:
       destination: input/interaction/string-interactions.txt.gz
   ##################################################################################################
 
-  #: INTERVAL STEP
-  interval:
-    - name: explode_glob rE2G interval
-      glob: gs://interval_data/datasets/ENCODE-rE2G/processed_E2G_2507.parquet/*.parquet
-      do:
-        - name: copy rE2G interval ${match_stem}
-          source: ${match_prefix}/${match_path}${match_stem}.${match_ext}
-          destination: output/interval/${uuid}.parquet
-
-  ##################################################################################################
-
   #: L2G STEP :#####################################################################################
   l2g:
-    # - name: copy l2g model
-    #   source: gs://ot_orchestration/benchmarks/l2g/fm0/v5.1_best_cv/locus_to_gene_model/classifier.skops
-    #   destination: etc/model/l2g_prediction/classifier.skops
+    - name: copy l2g model
+      source: gs://ot_orchestration/benchmarks/l2g/fm0/v5.1_best_cv/locus_to_gene_model/classifier.skops
+      destination: etc/model/l2g_prediction/classifier.skops
     - name: explode_glob l2g gold_standard
-      glob: gs://genetics-portal-dev-analysis/yt4/2506_release/training_set/20250625_gentropy_paper_v1.json/*.json
+      glob: gs://genetics-portal-dev-analysis/yt4/20241024_EGL_playground/training_set/patched_training_2503-testrun-1_all_string_extended_EGL_variants.json/*.json
       do:
         - name: copy l2g gold_standard ${match_stem}
           source: ${match_prefix}/${match_path}${match_stem}.${match_ext}
@@ -460,18 +568,6 @@ steps:
     - name: copy literature
       source: https://ftp.ebi.ac.uk/pub/databases/pmc/DOI/PMID_PMCID_DOI.csv.gz
       destination: input/literature/PMID_PMCID_DOI.csv.gz
-  ##################################################################################################
-
-  #: MOUSE_PHENOTYPE STEP :#######################################################################
-  mouse_phenotype:
-    - name: find_latest mouse phenotypes
-      source: gs://otar001-core/MousePhenotypes
-      scratchpad_key: latest_mouse_phenotypes
-    - name: copy mouse phenotypes
-      requires:
-        - find_latest mouse phenotypes
-      source: ${latest_mouse_phenotypes}
-      destination: input/mouse_phenotype/mouse_phenotypes.json.gz
   ##################################################################################################
 
   #: OPENFDA STEP :#################################################################################
@@ -508,16 +604,20 @@ steps:
       destination: input/otar/otar_project_to_efo.csv
   ##################################################################################################
 
-  #: PHARMACOGENOMICS STEP :########################################################################
-  pharmacogenomics:
-    - name: find_latest pharmacogenomics
-      source: gs://otar001-core/Pharmacogenetics/json
-      scratchpad_key: latest_pharmacogenomics
-    - name: copy pharmacogenomics
+  #: PHARMACOGENETICS STEP :########################################################################
+  pharmacogenetics:
+    - name: find_latest clinpgx annotation
+      source: gs://otar012-eva/pharmacogenomics/
+      scratchpad_key: latest_clinpgx_annotation
+    - name: copy clinpgx annotation
       requires:
-        - find_latest pharmacogenomics
-      source: ${latest_pharmacogenomics}
-      destination: input/pharmacogenomics/pharmacogenomics.json.gz
+        - find_latest clinpgx annotation
+      source: ${latest_clinpgx_annotation}
+      destination: input/pharmacogenetics/clinpgx_annotation.json.gz
+    - name: copy ot_curation extracted phenotypes
+      source: https://raw.githubusercontent.com/opentargets/curation/refs/tags/${ot_curation}/pharmacogenetics/pgx_phenotypes.json
+      destination: input/pharmacogenetics/phenotypes.json
+
   ##################################################################################################
 
   #: REACTOME STEP :################################################################################
@@ -551,39 +651,36 @@ steps:
         - target_type
         - pref_name
 
-    - name: find_latest chemical probe
-      source: gs://otar001-core/ChemicalProbes/annotation
-      scratchpad_key: latest_chemical_probe
     - name: copy chemical probes
-      requires:
-        - find_latest chemical probe
-      source: ${latest_chemical_probe}
-      destination: input/target/chemicalprobes/chemicalprobes.json.gz
+      source: https://www.probes-drugs.org/media/download/probes/pd_export_${probes_drugs_version}_probes_standardized.xlsx
+      destination: input/target/chemicalprobes/probes.xlsx
+
+    - name: copy chemical probes links
+      source: https://www.probes-drugs.org/media/download/id_mapping/pd_export_${probes_drugs_version}_links_standardized.csv
+      destination: input/target/chemicalprobes/probes_links.csv
 
     - name: copy ensembl
       source: https://ftp.ensembl.org/pub/release-${ensembl_version}/json/homo_sapiens/homo_sapiens.json
       destination: input/target/ensembl/homo_sapiens.json
 
     - name: copy gencode
-      source: https://ftp.ebi.ac.uk/pub/databases/gencode/Gencode_human/latest_release/gencode.v${gencode_version}.annotation.gff3.gz
+      source: https://ftp.ebi.ac.uk/pub/databases/gencode/Gencode_human/release_${gencode_version}/gencode.v${gencode_version}.annotation.gff3.gz
       destination: input/target/gencode/gencode.gff3.gz
 
-    - name: find_latest gene essentiality
-      source: gs://otar000-evidence_input/Essentiality/json
-      scratchpad_key: latest_gene_essentiality
-    - name: copy essentiality
-      requires:
-        - find_latest gene essentiality
-      source: ${latest_gene_essentiality}
-      destination: input/target/gene-essentiality/essentiality.json.gz
+    - name: explode_glob download essentiality files
+      glob: 'gs://otar000-evidence_input/Essentiality/DepMap/${depmap_version}/*.csv'
+      do:
+        - name: copy depmap ${match_stem}
+          source: ${uri}
+          destination: input/target/gene-essentiality/depmap/${match_stem}.${match_ext}
 
     - name: copy gene name
-      source: https://storage.googleapis.com/public-download-files/hgnc/json/json/hgnc_complete_set.json
-      destination: input/target/genenames/hgnc_complete_set.json
+      source: https://storage.googleapis.com/public-download-files/hgnc/tsv/tsv/hgnc_complete_set.txt
+      destination: input/target/genenames/hgnc_complete_set.tsv
 
     - name: copy gnomad
-      source: https://storage.googleapis.com/gcp-public-data--gnomad/release/4.1/constraint/gnomad.v4.1.constraint_metrics.tsv
-      destination: input/target/gnomad/gnomad.v4.1.constraint_metrics.tsv
+      source: https://storage.googleapis.com/gcp-public-data--gnomad/release/2.1.1/constraint/gnomad.v2.1.1.lof_metrics.by_gene.txt.bgz
+      destination: input/target/gnomad/gnomad.v2.1.1.lof_metrics.by_gene.txt.bgz
 
     - name: copy go annotation human eco gpa
       source: https://ftp.ebi.ac.uk/pub/databases/GO/goa/HUMAN/goa_human.gpa.gz
@@ -632,10 +729,10 @@ steps:
           destination: input/target/homologue/gene_dictionary/${each}.json
         - name: copy ${each} protein homology
           source: https://ftp.ensembl.org/pub/release-${ensembl_version}/tsv/ensembl-compara/homologies/${each}/Compara.${ensembl_version}.protein_default.homologies.tsv.gz
-          destination: input/target/homologue/homologies/protein-${each}.tsv.gz
+          destination: input/target/homologue/homologies/protein-${each}.tsv
         - name: copy ${each} ncrna homology
           source: https://ftp.ensembl.org/pub/release-${ensembl_version}/tsv/ensembl-compara/homologies/${each}/Compara.${ensembl_version}.ncrna_default.homologies.tsv.gz
-          destination: input/target/homologue/homologies/ncrna-${each}.tsv.gz
+          destination: input/target/homologue/homologies/ncrna-${each}.tsv
 
     - name: copy homology ensembl vertebrates
       source: https://ftp.ensembl.org/pub/release-${ensembl_version}/species_EnsemblVertebrates.txt
@@ -670,14 +767,31 @@ steps:
       source: https://reactome.org/download/current/Ensembl2Reactome.txt
       destination: input/target/reactome/Ensembl2Reactome.txt
 
-    - name: find_latest safety
-      source: gs://otar001-core/TargetSafety/json
-      scratchpad_key: latest_safety
-    - name: copy target safety
+    - name: explode ot_curation target safety
+      foreach:
+        - adverse_effects.tsv
+        - safety_risks.tsv
+        - secondary_pharmacology.json
+      do:
+        - name: copy ${each}
+          source: https://raw.githubusercontent.com/opentargets/curation/refs/tags/${ot_curation}/target_safety/${each}
+          destination: input/target/safety/${each}
+    - name: find_latest toxcast
+      source: gs://otar001-core/TargetSafety/data_files/toxcast
+      scratchpad_key: latest_toxcast
+    - name: copy toxcast
       requires:
-        - find_latest safety
-      source: ${latest_safety}
-      destination: input/target/safety/safetyLiabilities.json.gz
+        - find_latest toxcast
+      source: ${latest_toxcast}
+      destination: input/target/safety/toxcast.tsv
+    - name: find_latest aopwiki
+      source: gs://otar001-core/TargetSafety/data_files/aopwiki
+      scratchpad_key: latest_aopwiki
+    - name: copy aopwiki
+      requires:
+        - find_latest aopwiki
+      source: ${latest_aopwiki}
+      destination: input/target/safety/aopwiki.json
 
     - name: find_latest tep
       source: gs://otar001-core/TEPs
@@ -704,7 +818,6 @@ steps:
     - name: copy uniprot-ssl
       source: https://rest.uniprot.org/locations/stream?compressed=true&fields=id%2Cname%2Ccategory&format=tsv&query=%28%2A%29
       destination: input/target/uniprot/uniprot-ssl.tsv.gz
-
   ##################################################################################################
 
   #: TARGET_ENGINE STEP :###########################################################################

--- a/src/orchestration/dags/config/pts.yaml
+++ b/src/orchestration/dags/config/pts.yaml
@@ -1,7 +1,7 @@
 ---
 work_path: /mnt/disks/work
 log_level: INFO
-pool: 32
+pool_size: 32
 
 release_uri: '{{release_uri}}'
 scratchpad: {}
@@ -26,12 +26,6 @@ steps:
         - input/disease/mondo.json
       destination: output/disease_phenotype/disease_phenotype.parquet
       transformer: disease_phenotype
-    - name: transform disease_efo for webapp
-      requires:
-        - transform disease_efo
-      source: output/disease/disease.parquet
-      destination: webapp/disease.jsonl
-      transformer: disease_efo_webapp
 
   ##################################################################################################
 
@@ -50,6 +44,46 @@ steps:
       source: input/expression/map_with_efos.json
       destination: intermediate/expression/tissue-translation-map.parquet
       transformer: expression_tissue
+  ##################################################################################################
+
+  #: MOUSE_PHENOTYPES STEP :########################################################################
+  mouse_phenotype:
+    - name: pyspark separate into output and excluded
+      pyspark: mouse_phenotype
+      source:
+        target: output/target
+        mouse_phenotype: input/mouse_phenotype/mouse_phenotypes.json.gz
+      destination:
+        output: output/mouse_phenotype
+        excluded: excluded/mouse_phenotype
+  ##################################################################################################
+
+  #: CHEMICAL PROBES STEP :#########################################################################
+  chemical_probes:
+    - name: pyspark chemical probes
+      pyspark: chemical_probes
+      source:
+        probes_excel: input/target/chemicalprobes/probes.xlsx
+        drugs_csv: input/target/chemicalprobes/probes_links.csv
+      destination:
+        output: intermediate/chemical_probes_evidence.parquet
+  ##################################################################################################
+
+  #: CODING VARIANT STEP :##########################################################################
+  coding_variant:
+    - name: pyspark coding_variant view
+      pyspark: coding_variant
+      source:
+        variant: output/variant
+        target: output/target
+        disease: output/disease
+        evidence_eva: output/evidence/sourceId=eva
+        evidence_eva_somatic: output/evidence/sourceId=eva_somatic
+        evidence_uniprot_variant: output/evidence/sourceId=uniprot_variants
+        evidence_gwas_credible_set: output/evidence/sourceId=gwas_credible_sets
+        credible_set: output/credible_set
+        pharmacogenetics: output/pharmacogenetics
+      destination: view/coding_variant
   ##################################################################################################
 
   #: OPENFDA STEP :#################################################################################
@@ -87,6 +121,20 @@ steps:
       destination: intermediate/target/hpa/subcellular_locations_ssl.parquet
       separator: "\t"
 
+    - name: pyspark gene_essentiality
+      pyspark: gene_essentiality
+      source:
+        models: input/target/gene-essentiality/depmap/Model.csv
+        essential_genes: input/target/gene-essentiality/depmap/CRISPRInferredCommonEssentials.csv
+        gene_effects: input/target/gene-essentiality/depmap/CRISPRGeneEffect.csv
+        gene_expression: input/target/gene-essentiality/depmap/OmicsExpressionProteinCodingGenesTPMLogp1.csv
+        mutation_hotspots: input/target/gene-essentiality/depmap/OmicsSomaticMutationsMatrixHotspot.csv
+        mutation_damaging: input/target/gene-essentiality/depmap/OmicsSomaticMutationsMatrixDamaging.csv
+        depmap_tissue_mapping: input/ot_curation/mappings/biosystem/depmap_uberon_mapping.csv
+      destination: intermediate/target/gene-essentiality/essentiality.parquet
+      settings:
+        keep_only_essentials: true
+
     - name: unzip essentiality matrix
       source: input/target/project-scores/essentiality_matrices.zip
       inner_file: EssentialityMatrices/04_binaryDepScores.tsv
@@ -107,6 +155,11 @@ steps:
       destination: intermediate/target/ensembl/homo_sapiens.parquet
       transformer: ensembl
 
+    - name: transform gnomad
+      source: input/target/gnomad/gnomad.v2.1.1.lof_metrics.by_gene.txt.bgz
+      destination: intermediate/target/gnomad/gnomad_lof_by_gene.txt.gz
+      transformer: gnomad
+
     - name: explode_glob homology
       glob: input/target/homologue/gene_dictionary/*.json
       do:
@@ -114,4 +167,115 @@ steps:
           source: ${match_prefix}/${match_path}${match_stem}.${match_ext}
           destination: intermediate/target/homologue/gene_dictionary/${match_path}${match_stem}.parquet
           transformer: homology
+  ##################################################################################################
+
+  #: EVIDENCE STEP :################################################################################
+  evidence:
+    - name: pyspark project_score
+      pyspark: project_score
+      source:
+        gene_scores: input/evidence/project_score/mapped_diseases.tsv
+        cell_types: input/evidence/project_score/cell_types.tsv
+        cell_passport: input/evidence/cell_passport.csv.gz
+        cell_line_mapping: input/ot_curation/mappings/biosystem/depmap_uberon_mapping.csv
+      destination: intermediate/evidence/project_score.parquet
+
+    - name: pyspark gene_burden
+      pyspark: gene_burden
+      source:
+        az_binary: input/evidence/gene_burden/astrazeneca/azphewas-com-470k-phewas-binary
+        az_quantitative: input/evidence/gene_burden/astrazeneca/azphewas-com-470k-phewas-quantitative
+        az_genes: input/evidence/gene_burden/astrazeneca/azphewas_com_genes_UK_Biobank_470k.csv
+        az_phenotypes: input/evidence/gene_burden/astrazeneca/azphewas_com_phenotypes_UK_Biobank_470k.csv
+        finngen: input/evidence/gene_burden/finngen/finngen.txt.gz
+        finngen_phenotypes: input/evidence/gene_burden/finngen/phenos
+        genebass: input/evidence/gene_burden/genebass/**.parquet
+        cvdi: input/evidence/gene_burden/cvdi.xlsx
+        curated_studies: input/ot_curation/gene_burden/curated_evidence.tsv
+        disease_mappings: input/ot_curation/mappings/disease/manual_string.tsv
+      destination: intermediate/evidence/gene_burden.parquet
+      settings:
+        finngen_release: R12
+
+    - name: pyspark chembl
+      pyspark: chembl
+      source:
+        chembl_evidence: input/evidence/chembl/chembl.json.gz
+        stop_reasons: input/evidence/chembl/stop_reasons.json
+        drug_indications: input/drug/chembl_drug_indication.jsonl
+      destination: intermediate/evidence/chembl.parquet
+
+    - name: pyspark cancer_biomarkers
+      pyspark: cancer_biomarkers
+      source:
+        associations: input/evidence/cancerbiomarkers/associations.tsv
+        source: input/evidence/cancerbiomarkers/sources.jsonl
+        disease: input/evidence/cancerbiomarkers/diseases.jsonl
+        drugs: output/drug_molecule
+      destination: intermediate/evidence/cancer_biomarkers.parquet
+  ##################################################################################################
+
+  #: TIMESERIES STEP :########################################################################
+  timeseries:
+    - name: pyspark timeseries
+      pyspark: timeseries
+      source:
+        evidence: output/evidence
+        disease: output/disease
+      destination:
+        overall_direct: view/timeseries_overall_direct
+        overall_indirect: view/timeseries_overall_indirect
+        by_datasource_direct: view/timeseries_by_datasource_direct
+        by_datasource_indirect: view/timeseries_by_datasource_indirect
+      settings:
+        novelty_scale: 2 # 2 for long tailed slow decays
+        novelty_shift: 3 # 3 for long tailed slow decays
+        novelty_window: 10
+        datasource_weights:
+          - id: gwas_credible_sets
+            weight: 1.0
+          - id: eva
+            weight: 1.0
+          - id: gene_burden
+            weight: 1.0
+          - id: genomics_england
+            weight: 1.0
+          - id: gene2phenotype
+            weight: 1.0
+          - id: uniprot_literature
+            weight: 1.0
+          - id: uniprot_variants
+            weight: 1.0
+          - id: orphanet
+            weight: 1.0
+          - id: clingen
+            weight: 1.0
+          - id: cancer_gene_census
+            weight: 1.0
+          - id: intogen
+            weight: 1.0
+          - id: eva_somatic
+            weight: 1.0
+          - id: cancer_biomarkers
+            weight: 1.0
+          - id: chembl
+            weight: 1.0
+          - id: crispr_screen
+            weight: 1.0
+          - id: crispr
+            weight: 1.0
+          - id: slapenrich
+            weight: 0.5
+          - id: progeny
+            weight: 0.5
+          - id: reactome
+            weight: 1.0
+          - id: sysbio
+            weight: 0.5
+          - id: europepmc
+            weight: 0.2
+          - id: expression_atlas
+            weight: 0.2
+          - id: impc
+            weight: 0.2
   ##################################################################################################

--- a/src/orchestration/dags/config/unified_pipeline.py
+++ b/src/orchestration/dags/config/unified_pipeline.py
@@ -117,6 +117,7 @@ class UnifiedPipelineConfig:
         self.clusters = AppConfig.from_file(
             file_path=config_path / "clusters.yaml",
             template_context={
+                "pts_version": up.get("pts_version"),
                 "gentropy_version": up.get("gentropy_version"),
                 "requester_pays_project_id": GCP_PROJECT_PLATFORM,
             },

--- a/src/orchestration/dags/config/unified_pipeline.py
+++ b/src/orchestration/dags/config/unified_pipeline.py
@@ -61,6 +61,11 @@ class UnifiedPipelineConfig:
                 "efo_version": up.get("efo_version"),
                 "ensembl_version": up.get("ensembl_version"),
                 "gencode_version": up.get("gencode_version"),
+                "depmap_version": up.get("depmap_version"),
+                "hpo_version": up.get("hpo_version"),
+                "mondo_version": up.get("mondo_version"),
+                "ot_curation": up.get("ot_curation"),
+                "probes_drugs_version": up.get("probes_drugs_version"),
             },
         )
         """The internal configuration for PIS steps."""

--- a/src/orchestration/dags/config/unified_pipeline.yaml
+++ b/src/orchestration/dags/config/unified_pipeline.yaml
@@ -72,6 +72,9 @@ steps:
   pis_target_engine:
 
   # PTS STEPS
+  pts_chemical_probes:
+    depends_on:
+      - pis_target
   pts_disease:
     depends_on:
       - pis_disease

--- a/src/orchestration/dags/config/unified_pipeline.yaml
+++ b/src/orchestration/dags/config/unified_pipeline.yaml
@@ -1,27 +1,32 @@
 ---
-release_name: '25.09-ppp'
+release_name: '25.09'
 
 # If `is_dev` is true:
 #   * the bucket used for the run will be `open-targets-pipeline-runs`
 #   * the prefix inside the bucket will be `run_name`
 #         which defaults to a timestamp if not provided.
 is_dev: true
-run_name: 'szsz/25.09-ppp-testrun-1'
+run_name: 'jferrer/test-edp-1'
 
 # Whether this will be a partner preview platform release (PPP)
-is_ppp: true
+is_ppp: false
 
 # Versions for software and data
-pis_version: '25.2.1'
-pts_version: '25.2.1-rc.1'
+pis_version: '25.2.3.dev.18'
+pts_version: '25.3.0-dev.11'
 etl_version: '25.2.0-rc.1'
 gentropy_version: '2.4.2-rc.4'
 vep_version: 'release_115.2'
 
-chembl_version: '35'
+chembl_version: '36'
 efo_version: '3.83.0'
 ensembl_version: '115'
 gencode_version: '49'
+depmap_version: '2025Q2'
+hpo_version: '2025-01-16'
+mondo_version: '2025-02-04'
+ot_curation: '25.12'
+probes_drugs_version: '02_2025'
 
 # Dependency graph
 # ----------------
@@ -73,6 +78,9 @@ steps:
   pts_expression:
     depends_on:
       - pis_expression
+  pts_mouse_phenotype:
+    depends_on:
+      - etl_target
   pts_target:
     depends_on:
       - pis_target

--- a/src/orchestration/dags/unified_pipeline.py
+++ b/src/orchestration/dags/unified_pipeline.py
@@ -2,8 +2,9 @@
 
 from __future__ import annotations
 
+import logging
 from datetime import datetime
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 from airflow.decorators.task_group import task_group
 from airflow.models.baseoperator import chain
@@ -16,6 +17,7 @@ from airflow.utils.edgemodifier import Label
 from airflow.utils.trigger_rule import TriggerRule
 
 from orchestration.dags.config.unified_pipeline import UnifiedPipelineConfig
+from orchestration.models.pts_step import PTSDataprocStep, pts_step_from_config
 from orchestration.operators.batch.vep import VepAnnotateOperator
 from orchestration.operators.dataproc import (
     ClusterConfig,
@@ -30,7 +32,7 @@ from orchestration.operators.differs.config_differ import ConfigDiffer
 from orchestration.operators.differs.manifest_artifact_differ import ManifestArtifactDiffer
 from orchestration.operators.differs.spark_job_differ import SparkJobDiffer
 from orchestration.operators.gce import ComputeEngineRunContainerizedWorkloadSensor, DeleteInstanceOperator
-from orchestration.operators.gcs import CopyBlobOperator, UploadStringOperator
+from orchestration.operators.gcs import CopyBlobOperator, UploadFileOperator, UploadStringOperator
 from orchestration.utils import resource_name, strhash, to_hocon, to_yaml
 from orchestration.utils.common import GCP_PROJECT_PLATFORM, GCP_ZONE, shared_dag_args
 from orchestration.utils.labels import Labels
@@ -55,6 +57,7 @@ with DAG(
         ),
     },
 ) as dag:
+    logger = logging.getLogger(__name__)
     config = UnifiedPipelineConfig()
     steps: dict[str, dict[str, DAGNode]] = {}  # this is a registry of tasks, it is used to build dependencies
 
@@ -145,10 +148,13 @@ with DAG(
     # ==============================================================================================
     @task_group(group_id="pts_stage")
     def pts_stage() -> None:
+        pts_clusters = {}  # map of cluster_name to a list of step_names
         for step_name in config.steps("pts_"):
 
             @task_group(group_id=step_name)
             def pts_step(step_name: str) -> None:
+                s = pts_step_from_config(step_name, config)
+
                 config_uri = config.config_uri(step_name)
                 labels = Labels({"tool": "pts", "step": step_name}, is_ppp=config.is_ppp)
                 vm_name = resource_name(step_name)
@@ -170,36 +176,84 @@ with DAG(
                     overwrite=True,
                 )
 
-                r = ComputeEngineRunContainerizedWorkloadSensor(
-                    task_id=f"run_{step_name}",
-                    instance_name=vm_name,
-                    labels=labels,
-                    container_image=config.pts_image,
-                    container_env=config.pts_env_vars(step_name),
-                    container_scopes=config.service_account_extra_scopes,
-                    container_files={config_uri: "/config.yaml"},
-                    work_disk_size_gb=config.pts_disk_size,
-                    machine_type=config.pts_machine_type,
-                    deferrable=True,
-                )
+                chain(d, Label("differences found, run step"), u)
 
-                t = ComputeEngineDeleteInstanceOperator(
-                    task_id=f"delete_vm_{step_name}",
-                    project_id=GCP_PROJECT_PLATFORM,
-                    zone=GCP_ZONE,
-                    resource_id=vm_name,
-                )
+                if s.is_gce:
+                    r = ComputeEngineRunContainerizedWorkloadSensor(
+                        task_id=f"run_{step_name}",
+                        instance_name=vm_name,
+                        labels=labels,
+                        container_image=config.pts_image,
+                        container_env=config.pts_env_vars(step_name),
+                        container_scopes=config.service_account_extra_scopes,
+                        container_files={config_uri: "/config.yaml"},
+                        work_disk_size_gb=config.pts_disk_size,
+                        machine_type=config.pts_machine_type,
+                        deferrable=True,
+                    )
+
+                    t = ComputeEngineDeleteInstanceOperator(
+                        task_id=f"delete_vm_{step_name}",
+                        project_id=GCP_PROJECT_PLATFORM,
+                        zone=GCP_ZONE,
+                        resource_id=vm_name,
+                    )
+
+                    chain(u, Label("gce pts step"), r, t)
+
+                elif s.is_dataproc:
+                    s = cast(PTSDataprocStep, s)
+                    u2 = UploadFileOperator(
+                        task_id=f"upload_entrypoint_{step_name}",
+                        project_id=GCP_PROJECT_PLATFORM,
+                        src_path=s.dataproc_script_run_source,
+                        dst_uri=s.dataproc_script_run_uri,
+                    )
+
+                    c = CreateClusterOperator(
+                        task_id="cluster_create_pts",
+                        cluster_name=s.cluster_definition.cluster_name,
+                        cluster_config=s.cluster_definition.cluster_config,
+                        labels=labels,
+                    )
+
+                    r = SubmitJobOperator(
+                        task_id=f"run_{step_name}",
+                        cluster_name=s.cluster_definition.cluster_name,
+                        step_name=step_name,
+                        py_spark_job=s.build_job(),
+                        labels=labels,
+                    )
+
+                    cluster_name = s.cluster_definition.cluster_name
+                    steps_in_cluster = pts_clusters.get(cluster_name, [])
+                    pts_clusters[cluster_name] = [*steps_in_cluster, step_name]
+                    chain(u, Label("dataproc pts step"), u2, c, r)
 
                 e = EmptyOperator(
                     task_id=f"end_{step_name}",
                     trigger_rule=TriggerRule.NONE_FAILED_MIN_ONE_SUCCESS,
                 )
 
-                chain(d, Label("differences found, run step"), u, r, (t, e))
+                if s.is_gce:
+                    chain(t, e)
+                elif s.is_dataproc:
+                    chain(r, e)
                 chain(d, Label("no differences found, skip step"), e)
                 steps[step_name] = {"start": d, "end": e}
 
             pts_step(step_name)
+
+        # delete a cluster after its steps have run
+        for cluster_name, steps_in_cluster in pts_clusters.items():
+            x = DeleteClusterOperator(
+                task_id="cluster_delete_pts",
+                cluster_name=cluster_name,
+                trigger_rule=TriggerRule.ALL_SUCCESS,
+            )
+            for step_name in steps_in_cluster:
+                step = steps[step_name]["end"]
+                x.set_upstream(step)
 
     pts_stage()
 

--- a/src/orchestration/models/pts_step.py
+++ b/src/orchestration/models/pts_step.py
@@ -1,0 +1,133 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from google.cloud.dataproc_v1.types.jobs import PySparkJob
+
+from orchestration.dags.config.unified_pipeline import UnifiedPipelineConfig
+from orchestration.models.step import UnifiedPipelineStep
+from orchestration.operators.dataproc import PTSJobBuilder
+
+ASSET_PATH = Path(__file__).parent.parent / "assets"
+PTS_CLUSTER_NAME = "pts"
+
+
+def pts_step_from_config(
+    name: str,
+    config: UnifiedPipelineConfig,
+) -> PTSStep:
+    """Factory function to create a PTSStep from config.
+
+    Args:
+        name (str): The name of the step.
+        config (UnifiedPipelineConfig): The config object for PTS.
+
+    Returns:
+        PTSStep: The created PTSStep instance.
+    """
+    short_name = name.split("_", 1)[1]
+    step_tasks = config.pts.config.get("steps", {}).get(short_name, {})
+    if len(step_tasks) == 0:
+        raise ValueError(f"no tasks found for pts step {name}")
+
+    # if any task inside a step is a pyspark task, then this is a dataproc step
+    for task in step_tasks:
+        if task.get("name", "").startswith("pyspark"):
+            return PTSDataprocStep(name, config)
+
+    return PTSStep(name, config)
+
+
+class PTSStep(UnifiedPipelineStep):
+    """PTS step class.
+
+    The PTSStep class represents a PTS step in the Unified Pipeline orchestration
+    DAG.
+
+    This is also a stub for now, most functionality currently implemented is related
+    to dataproc steps and their infrastructure.
+    """
+
+    def __init__(
+        self,
+        name: str,
+        config: UnifiedPipelineConfig,
+    ):
+        """Initialize a PTSStep instance.
+
+        Args:
+            name (str): The name of the step.
+            config (AppConfig): The config object for PTS.
+            logger (logging.Logger, optional): Logger instance for logging. Defaults to None.
+        """
+        super().__init__(name, config)
+
+    @property
+    def is_dataproc(self) -> bool:
+        """Returns whether the step is a Dataproc step."""
+        return type(self) is PTSDataprocStep
+
+    @property
+    def is_gce(self) -> bool:
+        """Returns whether the step is a GCE step."""
+        return type(self) is PTSStep
+
+    @property
+    def config_uri(self) -> str:
+        """Returns the URI for the step config."""
+        return f"{self.config_destination_prefix}/{self.name}.yaml"
+
+
+class PTSDataprocStep(PTSStep):
+    """PTS Dataproc step class.
+
+    The PTSDataprocStep class represents a PTS step that runs on a Dataproc cluster.
+    """
+
+    def __init__(
+        self,
+        name: str,
+        config: UnifiedPipelineConfig,
+    ):
+        """Initialize a PTSDataprocStep instance.
+
+        Args:
+            name (str): The name of the step.
+            config (AppConfig): The config object for PTS.
+        """
+        super().__init__(name, config)
+        self.runs_on_cluster = True
+        self.cluster_definition = self.get_cluster_definition(name)
+        if not self.is_dataproc:
+            raise ValueError(f"step {name} is not intended to run in dataproc")
+
+    @property
+    def dataproc_script_run_source(self) -> Path:
+        """Returns the path to the Dataproc run script, if applicable."""
+        return ASSET_PATH / "dataproc_pts_run.py"
+
+    @property
+    def dataproc_script_run_uri(self) -> str:
+        """Returns the URI for the Dataproc run script, if applicable."""
+        return f"{self.bin_destination_prefix}/{self.name}_dataproc_pts_run.py"
+
+    @property
+    def dataproc_args(self) -> list[str]:
+        return ["-s", self.short_name, "-c", f"{self.name}.yaml"]
+
+    def build_job(self) -> PySparkJob:
+        """Builds the job for the step."""
+        self.logger.info(
+            f"Debug - dataproc_script_run_uri: {self.dataproc_script_run_uri}, type: {type(self.dataproc_script_run_uri)}"
+        )
+        self.logger.info(f"Debug - dataproc_args: {self.dataproc_args}, type: {type(self.dataproc_args)}")
+        self.logger.info(f"Debug - config_uri: {self.config_uri}, type: {type(self.config_uri)}")
+
+        if not self.is_dataproc:
+            raise NotImplementedError("called build_job on non-dataproc step")
+
+        return PTSJobBuilder(
+            main_python_file_uri=self.dataproc_script_run_uri,
+            args=self.dataproc_args,
+            config_uri=self.config_uri,
+        ).build()

--- a/src/orchestration/models/step.py
+++ b/src/orchestration/models/step.py
@@ -1,0 +1,98 @@
+"""Unified Pipeline step class definition."""
+
+from __future__ import annotations
+
+import logging
+from abc import abstractmethod
+from enum import StrEnum
+
+from orchestration.dags.config.unified_pipeline import ClusterDefinition, UnifiedPipelineConfig
+
+
+class UnifiedPipelineStage(StrEnum):
+    """Enum representing different stages in the unified pipeline."""
+
+    PIS = "pis"
+    PTS = "pts"
+    ETL = "etl"
+    GENTROPY = "gentropy"
+
+    @classmethod
+    def from_step_name(
+        cls,
+        step_name: str,
+    ) -> UnifiedPipelineStage:
+        """Returns the UnifiedPipelineStage corresponding to the given step name."""
+        step_prefix = step_name.split("_")[0].lower()
+        return UnifiedPipelineStage(step_prefix)
+
+
+class UnifiedPipelineStep:
+    """Unified Pipeline step class.
+
+    The Step class represents a step in an orchestration workflow.
+
+    This class is a stub for now, meant to be expanded with additional functionality
+    ported from other places in the orchestration codebase.
+
+    It is meant to be subclassed by more specific step implementations.
+    """
+
+    def __init__(
+        self,
+        name: str,
+        config: UnifiedPipelineConfig,
+    ):
+        """Initialize a Step instance.
+
+        Args:
+            name (str): The name of the step.
+            config (AppConfig): The config object for the application the step uses.
+            logger (logging.Logger, optional): Logger instance for logging. Defaults to None.
+        """
+        self.name = name
+        """The full name of the step, including stage prefix."""
+        self.short_name = name.split("_", 1)[1]
+        """The short name of the step, without stage prefix."""
+        self.config = config
+        """The UnifiedPipelineConfig."""
+        self.stage = UnifiedPipelineStage.from_step_name(name)
+        """The stage of the unified pipeline this step belongs to."""
+        self.runs_on_cluster = False
+        """Whether the step runs on a cluster."""
+        self.cluster_definition: ClusterDefinition
+        """The cluster definition for the step."""
+        self.logger = logging.getLogger(__name__)
+
+        self.logger.info(f"initializing {self.stage} step: {self.name}")
+
+    @property
+    def config_destination_prefix(self) -> str:
+        """Returns the URI prefix where the step config should be uploaded."""
+        return f"{self.config.dev_uri or self.config.release_uri}/etc/config"
+
+    @property
+    def bin_destination_prefix(self) -> str:
+        """Returns the URI prefix where the step binaries should be uploaded."""
+        return f"{self.config.dev_uri or self.config.release_uri}/etc/bin"
+
+    @property
+    @abstractmethod
+    def config_uri(self) -> str:
+        """Returns the URI for the step config."""
+
+    def get_cluster_definition(self, step_name) -> ClusterDefinition:
+        """Returns the cluster definition for the step, if applicable.
+
+        Raises:
+            ValueError: If the step does not run on a cluster.
+        """
+        if self.runs_on_cluster is False:
+            raise ValueError(f"step {step_name} does not run on a cluster.")
+
+        clusters = self.config.clusters.config.get("clusters", {})
+        sorted_cluster_names = sorted(clusters.keys(), key=len, reverse=True)
+        for cluster_name in sorted_cluster_names:
+            if step_name.startswith(cluster_name):
+                return ClusterDefinition(cluster_name, clusters[cluster_name])
+        raise ValueError(f"no cluster definition found for step {step_name}.")

--- a/src/orchestration/operators/dataproc.py
+++ b/src/orchestration/operators/dataproc.py
@@ -21,7 +21,7 @@ from google.api_core.exceptions import NotFound as GCPNotFound
 from google.cloud.dataproc_v1 import Cluster, JobReference
 from google.cloud.dataproc_v1.types.jobs import Job, JobPlacement, PySparkJob, SparkJob
 
-from orchestration.utils import convert_params_to_hydra_positional_arg, random_id
+from orchestration.utils import convert_params_to_hydra_positional_arg, random_id, resource_name
 from orchestration.utils.common import GCP_PROJECT_PLATFORM, GCP_REGION, GCP_SERVICE_ACCOUNT, GCP_ZONE
 from orchestration.utils.dataproc import ClusterGenerator
 from orchestration.utils.labels import Labels
@@ -185,6 +185,16 @@ class ClusterDefinition(NamedTuple):
     config: dict[str, Any]
     """The configuration dict for the cluster. See
         `src.orchestration.utils.dataproc.ClusterConfig`."""
+
+    @property
+    def cluster_name(self) -> str:
+        """Returns the resource name for this cluster definition."""
+        return resource_name(self.cluster_type)
+
+    @property
+    def cluster_config(self) -> ClusterConfig:
+        """Returns the ClusterConfig object for this cluster definition."""
+        return ClusterConfig(**self.config)
 
 
 class CreateClusterOperator(DataprocCreateClusterOperator):
@@ -479,4 +489,32 @@ class GentropyJobBuilder(JobBuilder):
             main_python_file_uri=self.main_python_file_uri,
             args=args,
             properties=rendered_properties,
+        )
+
+
+class PTSJobBuilder(JobBuilder):
+    """Class for building PTS dataproc jobs for PySpark PTS tasks."""
+
+    def __init__(
+        self,
+        main_python_file_uri: str,
+        args: list[str],
+        config_uri: str,
+    ) -> None:
+        self.main_python_file_uri = main_python_file_uri
+        self.args = args
+        self.config_uri = config_uri
+        self.logger = logging.getLogger(__name__)
+
+    def build(self) -> PySparkJob:
+        """Build a SparkJob that runs a Gentropy step."""
+        self.logger.info(f"params: {self.args}")
+        self.logger.info("spawning pts job")
+        self.logger.info(f"main_python_file_uri: {self.main_python_file_uri}")
+        self.logger.info(f"args: {self.args}")
+
+        return PySparkJob(
+            main_python_file_uri=self.main_python_file_uri,
+            args=self.args,
+            file_uris=[self.config_uri],
         )

--- a/src/orchestration/operators/gce.py
+++ b/src/orchestration/operators/gce.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import datetime
 import logging
+import random
 import time
 from collections.abc import Sequence
 from functools import cached_property
@@ -34,7 +35,8 @@ if TYPE_CHECKING:
     from typing import Any
 
 CONTAINER_NAME = "workload_container"
-LOGGING_REQUEST_INTERVAL = 5
+LOGGING_REQUEST_INTERVAL = 2
+LOGGING_REQUEST_MAX_INTERVAL = 180
 
 # WARNING
 # After any change in deferrable operators, you must restart the airflow triggerer
@@ -94,6 +96,10 @@ def wait_for_extended_operation(
     return result
 
 
+def _backoff(request_interval: float) -> float:
+    return min(request_interval * random.uniform(2, 2.5), LOGGING_REQUEST_MAX_INTERVAL)
+
+
 class RateLimitedLoggingClient(logging_v2.Client):
     """Client for the Google Cloud Logging service with rate limiting.
 
@@ -120,7 +126,7 @@ class RateLimitedLoggingClient(logging_v2.Client):
         while True:
             try:
                 entries = super().list_entries(*args, **kwargs)
-                self.request_interval = LOGGING_REQUEST_INTERVAL  # Reset the interval on successful requests
+                self.request_interval = _backoff(self.request_interval)
                 break
             except ResourceExhausted:
                 self.log.warning(
@@ -130,6 +136,7 @@ class RateLimitedLoggingClient(logging_v2.Client):
                 time.sleep(self.request_interval)
                 self.request_interval *= 2
 
+        self.request_interval = LOGGING_REQUEST_INTERVAL
         return entries
 
 
@@ -245,7 +252,7 @@ class CloudLoggingAsyncHook(GoogleBaseHook):
                     self.request_interval,
                 )
                 await asyncio.sleep(self.request_interval)
-                self.request_interval *= 2
+                self.request_interval = _backoff(self.request_interval)
             except RetryError as e:
                 self.log.warning(
                     "Error occurred while fetching log entries: %s, retrying after %d seconds",
@@ -253,7 +260,7 @@ class CloudLoggingAsyncHook(GoogleBaseHook):
                     self.request_interval,
                 )
                 await asyncio.sleep(self.request_interval)
-                self.request_interval *= 2
+                self.request_interval = _backoff(self.request_interval)
 
         logs = None
         try:

--- a/src/orchestration/operators/gcs.py
+++ b/src/orchestration/operators/gcs.py
@@ -27,7 +27,7 @@ class UploadFileOperator(BaseOperator):
         dst_uri: The destination URI in GCS.
     """
 
-    template_fields: Sequence[str] = ("src", "dst_uri")
+    template_fields: Sequence[str] = ("src_path", "dst_uri")
 
     def __init__(
         self,


### PR DESCRIPTION
This PR enables running PTS steps in a dataproc cluster when there are pyspark tasks in them.

It also introduces a stub of `Step` class, where we can slowly refactor config and settings that belong to a step. I only implemented what I needed for the main PR goal.

Most of the lines in additions/deletions are updating the configs for PIS/PTS/ETL, so don't be scared. :smile: 