### PR TITLE
fix: re-wiring variant index generation

### DIFF
--- a/src/orchestration/dags/config/gentropy.yaml
+++ b/src/orchestration/dags/config/gentropy.yaml
@@ -99,13 +99,13 @@ steps:
       step.session.write_mode: overwrite
       # INPUTS
       step.source_paths:
-        - '{{release_uri}}/output/evidence_uniprot_variants'
-        - '{{release_uri}}/output/evidence_eva'
+        - '{{release_uri}}/input/evidence/uniprot_variants.json.gz'
+        - '{{release_uri}}/input/evidence/eva.json.gz'
         - '{{release_uri}}/output/pharmacogenomics'
         - '{{release_uri}}/output/credible_set'
       step.source_formats:
-        - parquet
-        - parquet
+        - json
+        - json
         - parquet
         - parquet
       # OUTPUTS

--- a/src/orchestration/dags/config/unified_pipeline.yaml
+++ b/src/orchestration/dags/config/unified_pipeline.yaml
@@ -408,11 +408,10 @@ steps:
       - gentropy_credible_set
   gentropy_variant_partition:
     depends_on:
-      - pts_evidence_postprocess_uniprot_variants
-      - pts_evidence_postprocess_clinvar
-      - pts_evidence_postprocess_clinvar_somatic
       - etl_pharmacogenomics
       - gentropy_credible_set
+      - pis_evidence_uniprot_variants
+      - pis_evidence_eva
   gentropy_variant_annotation:
     depends_on:
       - gentropy_variant_partition


### PR DESCRIPTION
## Context

If variant index generation picks up post-processed evidence, the already hashed variant identifiers are lost. This PR revert back to the original process, when the VEP input was generated based on the JSON evidence input.

This also means the dependencies of this step changes: EVA and Uniprot evidence processing is independent from variant index generation.