### PR TITLE
feat: sorting out ot_crispr configuration

### DIFF
--- a/src/orchestration/dags/config/pis.yaml
+++ b/src/orchestration/dags/config/pis.yaml
@@ -525,14 +525,16 @@ steps:
       source: ${latest_validation_lab}
       destination: input/evidence/validation_lab.json.gz
 
-    - name: find_latest ot_crispr
-      source: gs://otar013-ppp/ot_crispr
-      scratchpad_key: 'latest_ot_crispr'
-    - name: copy ot_crispr
-      requires:
-        - find_latest ot_crispr
-      source: ${latest_ot_crispr}
-      destination: input/evidence/ot_crispr.json.gz
+    - name: copy ot_crispr config
+      source: gs://otar013-ppp/PPP-evidence-configuration/raw_study_table.tsv
+      destination: input/evidence/ot_crispr/config.json
+
+    - name: explode_glob ot_crispr files
+      glob: 'gs://otar013-ppp/ot_crispr/input_data_filtered/**/**'
+      do:
+        - name: copy ot_crispr ${match_stem} ${uuid}
+          source: ${uri}
+          destination: input/evidence/ot_crispr/data/${match_path}${match_stem}.${match_ext}
   ##################################################################################################
 
   #: EXPRESSION STEP :##############################################################################

--- a/src/orchestration/dags/config/pis.yaml
+++ b/src/orchestration/dags/config/pis.yaml
@@ -488,6 +488,7 @@ steps:
 
   #: EVIDENCE_PPP STEP :############################################################################
   evidence_ppp:
+    # Validation lab => Get latest evidence.
     - name: find_latest validation_lab
       source: gs://otar013-ppp/validation_lab
       scratchpad_key: latest_validation_lab
@@ -497,34 +498,17 @@ steps:
       source: ${latest_validation_lab}
       destination: input/evidence/validation_lab.json.gz
 
-    - name: explode_glob encore files
-      glob: 'gs://otar013-ppp/encore/input/2024.01.11-Freeze4/**/**'
-      do:
-        - name: copy encore ${match_stem} ${uuid}
-          source: ${uri}
-          destination: input/evidence/encore/${match_path}${match_stem}.${match_ext}
-
-    - name: copy encore config
-      source: gs://otar013-ppp/PPP-evidence-configuration/encore_config.json
-      destination: input/evidence/encore/config.json
-
-    - name: copy sanger cell passport
-      source: https://cog.sanger.ac.uk/cmp/download/model_list_latest.csv.gz
-      destination: input/evidence/cell_passport.csv.gz
-
-    - name: copy ot_curation  depmap_tissue_mapping
-      source: https://raw.githubusercontent.com/opentargets/curation/${ot_curation}/mappings/biosystem/depmap_uberon_mapping.csv
-      destination: input/ot_curation/mappings/biosystem/depmap_uberon_mapping.csv
-
-    - name: find_latest validation_lab
-      source: gs://otar013-ppp/validation_lab
-      scratchpad_key: latest_validation_lab
-    - name: copy validation_lab
+    # Encore => Get latest evidence.
+    - name: find_latest encore
+      source: gs://otar013-ppp/encore
+      scratchpad_key: latest_encore
+    - name: copy encore
       requires:
-        - find_latest validation_lab
-      source: ${latest_validation_lab}
-      destination: input/evidence/validation_lab.json.gz
+        - find_latest encore
+      source: ${latest_encore}
+      destination: input/evidence/encore.json.gz
 
+    # OT_crispr => generate evience.
     - name: copy ot_crispr config
       source: gs://otar013-ppp/PPP-evidence-configuration/raw_study_table.tsv
       destination: input/evidence/ot_crispr/config.json

--- a/src/orchestration/dags/config/pts.yaml
+++ b/src/orchestration/dags/config/pts.yaml
@@ -360,7 +360,7 @@ steps:
       pyspark: ot_crispr
       source:
         study_table: input/evidence/ot_crispr/config.tsv
-        ot_crispr_data: input/evidence/ot_crispr
+        ot_crispr_data: input/evidence/ot_crispr/data
       destination: intermediate/evidence/ot_crispr.parquet
   ##################################################################################################
 


### PR DESCRIPTION
## This PR contains

- [x] OT_crispr evidence is no longer fetched from evidence bucket but generated via pts
- [x] to produce ot_crispr evidence we need to pull config and data file
- [x] Paths updated on the evidence post-process step
- [x] Deduplicated validation lab PIS configuration  
- [x] Encore is not processed, instead the latest evidence is pulled 