### PR TITLE
PTS drug processing steps and remove ETL drug steps

### DIFF
--- a/src/orchestration/dags/config/etl.conf
+++ b/src/orchestration/dags/config/etl.conf
@@ -51,22 +51,6 @@ steps: {
     }
   }
 
-  pharmacogenomics: {
-    input: {
-      pgx: {
-        format: "parquet"
-        path: ${common.path}"/intermediate/pharmacogenetics.parquet"
-      }
-      drug: ${steps.drug.output.drug}
-    }
-    output: {
-      pgx: {
-        format: ${common.output_format}
-        path: ${common.output_path}"/output/pharmacogenomics"
-      }
-    }
-  }
-
   expression: {
     input: {
       rna: {
@@ -386,89 +370,6 @@ steps: {
     ]
   }
 
-  drug: {
-    input: {
-      chemical_probes: {
-        format: "parquet"
-        path: ${common.path}"/intermediate/chemical_probes_evidence.parquet"
-      }
-      chembl_indication: {
-        format: "json"
-        path: ${common.path}"/input/drug/chembl_drug_indication.jsonl"
-      }
-      chembl_molecule: {
-        format: "json"
-        path: ${common.path}"/input/drug/chembl_molecule.jsonl"
-      }
-      chembl_mechanism: {
-        format: "json"
-        path: ${common.path}"/input/drug/chembl_mechanism.jsonl"
-      }
-      chembl_target: {
-        format: "json"
-        path: ${common.path}"/input/drug/chembl_target.jsonl"
-      }
-      chembl_warning: {
-        format: "json"
-        path: ${common.path}"/input/drug/chembl_drug_warning.jsonl"
-      }
-      disease_etl: {
-        format: "parquet"
-        path: ${common.path}"/output/disease"
-      }
-      target_etl: ${steps.target.output.target}
-      drugbank_to_chembl: {
-        format: "csv"
-        path: ${common.path}/input/drug/drugbank.csv.gz
-        options: [
-          { k: "sep",    v: "\\t" }
-          { k: "header", v: true  }
-        ]
-      }
-    }
-    drug_extensions: []
-    output: {
-      drug: {
-        format: ${common.output_format}
-        path: ${common.output_path}"/output/drug_molecule"
-      }
-      mechanism_of_action: {
-        format: ${common.output_format}
-        path: ${common.output_path}"/output/drug_mechanism_of_action"
-      }
-      indications: {
-        format: ${common.output_format}
-        path: ${common.output_path}"/output/drug_indication"
-      }
-      warnings: {
-        format: ${common.output_format}
-        path: ${common.output_path}"/output/drug_warning"
-      }
-    }
-  }
-
-  known_drug: {
-    input: {
-      evidences: {
-        format: ${common.output_format}
-        path: ${common.path}"/output/evidence_chembl"
-      }
-      diseases: {
-        format: "parquet"
-        path: ${common.path}"/output/disease"
-      }
-      targets: ${steps.target.output.target}
-      drug: ${steps.drug.output.drug}
-      mechanism: ${steps.drug.output.mechanism_of_action}
-    }
-    output: {
-      known_drugs: {
-        format: ${common.output_format}
-        path: ${common.output_path}"/output/known_drug"
-      }
-    }
-  }
-
   search_facet: {
     input: {
       diseases: {
@@ -595,13 +496,22 @@ steps: {
   search: {
     input: {
       association: ${steps.association.output.indirect_by_overall}
-      drug: ${steps.drug.output.drug}
+      drug: {
+        format: ${common.output_format}
+        path: ${common.path}"/output/drug_molecule"
+      }
       evidence: {
         format: ${common.output_format}
         path: ${common.path}"/output/evidence_*"
       }
-      indication: ${steps.drug.output.indications}
-      mechanism: ${steps.drug.output.mechanism_of_action}
+      indication: {
+        format: ${common.output_format}
+        path: ${common.path}"/output/drug_indication"
+      }
+      mechanism: {
+        format: ${common.output_format}
+        path: ${common.path}"/output/drug_mechanism_of_action"
+      }
       target: ${steps.target.output.target}
       credible_sets: {
         format: "parquet"
@@ -654,7 +564,10 @@ steps: {
 
   openfda: {
     input: {
-      chembl_drugs: ${steps.drug.output.drug}
+      chembl_drugs: {
+        format: ${common.output_format}
+        path: ${common.path}"/output/drug_molecule"
+      }
       blacklisted_events: {
         format: "csv"
         path: ${common.path}"/input/openfda/blacklisted_events.txt"
@@ -686,21 +599,9 @@ steps: {
         format: ${common.output_format}
         path: ${common.output_path}"/output/openfda_significant_adverse_drug_reactions"
       }
-      fda_targets_unfiltered: {
-        format: ${common.output_format}
-        path: ${common.output_path}"/intermediate/openfda_adverse_target_reactions"
-      }
-      fda_targets_results: {
-        format: ${common.output_format}
-        path: ${common.output_path}"/output/openfda_significant_adverse_target_reactions"
-      }
       sampling: {
         format: ${common.output_format}
         path: ${common.output_path}"/intermediate/openfda_sample"
-      }
-      sampling_targets: {
-        format: ${common.output_format}
-        path: ${common.output_path}"/intermediate/openfda_sample_targets"
       }
     }
     meddra_preferred_terms_cols: [
@@ -794,7 +695,10 @@ steps: {
         path: ${common.path}"/output/disease"
       }
       processing_targets: ${steps.target.output.target}
-      processing_drugs: ${steps.drug.output.drug}
+      processing_drugs: {
+        format: ${common.output_format}
+        path: ${common.path}"/output/drug_molecule"
+      }
       processing_abstracts: {
         format: "json"
         path: "gs://otar025-epmc/ml02/abstract/**/*.jsonl"
@@ -934,45 +838,6 @@ steps: {
         max_iter: 3
         min_count: 1
         step_size: 0.02
-      }
-    }
-  }
-
-  target_engine: {
-    input: {
-      targets: ${steps.target.output.target}
-      molecule: ${steps.drug.output.drug}
-      mechanism_of_action: ${steps.drug.output.mechanism_of_action}
-      mouse_phenotypes: {
-        format: "parquet"
-        path: ${common.path}"/output/mouse_phenotype"
-      }
-      hpa_data: {
-        format: "json"
-        path: ${common.path}"/input/target_engine/proteinatlas.json.gz"
-      }
-      uniprot_slterms: {
-        format: "csv"
-        path: ${common.path}"/input/target_engine/uniprot_locations.tsv.gz"
-        options: [
-          { k: "sep",    v: "\t" }
-          { k: "header", v: true }
-        ]
-      }
-      mouse_pheno_scores: {
-        format: "csv"
-        path: ${common.path}"/input/target_engine/mouse_pheno_scores.csv"
-        options: [
-          { k: "sep",         v: ","  }
-          { k: "header",      v: true }
-          { k: "inferSchema", v: true }
-        ]
-      }
-    }
-    output: {
-      target_engine: {
-        format: ${common.output_format}
-        path: ${common.output_path}"/output/target_prioritisation"
       }
     }
   }

--- a/src/orchestration/dags/config/pis.yaml
+++ b/src/orchestration/dags/config/pis.yaml
@@ -244,25 +244,6 @@ steps:
       destination: input/evidence/cancerbiomarkers/diseases.jsonl
   ##################################################################################################
 
-  #: EVIDENCE_CHEMBL STEP :#########################################################################
-  evidence_chembl:
-    - name: find_latest chembl
-      source: gs://otar008-chembl
-      scratchpad_key: 'latest_chembl'
-    - name: copy chembl
-      requires:
-        - find_latest chembl
-      source: ${latest_chembl}
-      destination: input/evidence/chembl/chembl.json.gz
-
-    - name: find_latest stop_reasons
-      source: gs://otar000-evidence_input/ChEMBL/data_files
-      scratchpad_key: 'latest_chembl_stop_reasons'
-    - name: copy chembl stop reasons
-      requires:
-        - find_latest stop_reasons
-      source: ${latest_chembl_stop_reasons}
-      destination: input/evidence/chembl/stop_reasons.json
   ##################################################################################################
 
   #: EVIDENCE_CLINGEN STEP :########################################################################

--- a/src/orchestration/dags/config/pts.yaml
+++ b/src/orchestration/dags/config/pts.yaml
@@ -427,6 +427,36 @@ steps:
       destination: output/drug_molecule
   ##################################################################################################
 
+  #: CLINICAL_REPORT STEP :#######################################################################
+  clinical_report:
+    - name: transform clinical_report
+      source:
+        chembl_molecule: intermediate/chembl_molecule
+        disease: output/disease
+      destination:
+        output: output/clinical_report
+        excluded: excluded/clinical_report
+      transformer: clinical_report
+  ##################################################################################################
+
+  #: CLINICAL_INDICATION STEP :####################################################################
+  clinical_indication:
+    - name: transform clinical_indication
+      source: output/clinical_report
+      destination: output/clinical_indication
+      transformer: clinical_indication
+  ##################################################################################################
+
+  #: CLINICAL_TARGET STEP :#######################################################################
+  clinical_target:
+    - name: transform clinical_target
+      source:
+        clinical_report: output/clinical_report
+        drug_mechanism_of_action: output/drug_mechanism_of_action
+      destination: output/clinical_target
+      transformer: clinical_target
+  ##################################################################################################
+
   #: TARGET_PRIORITISATION STEP :###################################################################
   target_prioritisation:
     - name: pyspark target_prioritisation

--- a/src/orchestration/dags/config/pts.yaml
+++ b/src/orchestration/dags/config/pts.yaml
@@ -22,9 +22,9 @@ steps:
       requires:
         - transform disease_efo
       source:
-        - output/disease/disease.parquet
-        - input/disease/phenotype.hpoa
-        - input/disease/mondo.json
+        disease_path: output/disease/disease.parquet
+        phenotype_path: input/disease/phenotype.hpoa
+        mondo_path: input/disease/mondo.json
       destination: output/disease_phenotype/disease_phenotype.parquet
       transformer: disease_phenotype
   ##################################################################################################

--- a/src/orchestration/dags/config/pts.yaml
+++ b/src/orchestration/dags/config/pts.yaml
@@ -247,9 +247,9 @@ steps:
     - name: pyspark chembl
       pyspark: chembl
       source:
-        chembl_evidence: input/evidence/chembl/chembl.json.gz
         stop_reasons: input/evidence/chembl/stop_reasons.json
-        drug_indications: input/drug/chembl_drug_indication.jsonl
+        clinical_report: output/clinical_report
+        drug_mechanism_of_action: output/drug_mechanism_of_action
       destination: intermediate/evidence/chembl.parquet
   ##################################################################################################
 
@@ -422,7 +422,7 @@ steps:
         chemical_probes: intermediate/chemical_probes_evidence.parquet
         mechanism_of_action: output/drug_mechanism_of_action
         drug_warning: output/drug_warning
-        indication: input/drug/chembl_drug_indication.jsonl
+        clinical_report: output/clinical_report
         disease: output/disease
       destination: output/drug_molecule
   ##################################################################################################

--- a/src/orchestration/dags/config/pts.yaml
+++ b/src/orchestration/dags/config/pts.yaml
@@ -74,6 +74,7 @@ steps:
       source:
         probes_excel: input/target/chemicalprobes/probes.xlsx
         drugs_csv: input/target/chemicalprobes/probes_links.csv
+        chembl_molecule: intermediate/chembl_molecule
       destination: intermediate/chemical_probes_evidence.parquet
   ##################################################################################################
 
@@ -168,7 +169,7 @@ steps:
         brennan: input/target/safety/secondary_pharmacology.json
         toxcast: input/target/safety/toxcast.tsv
         aopwiki: input/target/safety/aopwiki.json
-        pharmacogenetics: intermediate/pharmacogenetics.parquet
+        pharmacogenetics: output/pharmacogenomics
       destination: intermediate/target/safety.parquet
 
   #: TARGET_GENE_ESSENTIALITY STEP :#### - part of target, pyspark tasks must run standalone for now
@@ -196,11 +197,16 @@ steps:
         clinpgx: input/pharmacogenetics/clinpgx_annotation.json.gz
         phenotypes: input/pharmacogenetics/phenotypes.json
         ontoma_disease_label_lut: intermediate/ontoma/disease_label_lookup_table.parquet
+        chembl_molecule: intermediate/chembl_molecule
+        drug_mechanism_of_action: output/drug_mechanism_of_action
       destination:
-        associations: intermediate/pharmacogenetics.parquet
+        associations: output/pharmacogenomics
         phenotypes: intermediate/pharmacogenetics/phenotypes.json
       settings:
         openai_token_filename: /var/run/secrets/openai_token
+      properties:
+        "spark.jars.packages": "com.johnsnowlabs.nlp:spark-nlp_2.12:6.1.3"
+
   ##################################################################################################
 
   #: EVIDENCE_PROJECT_SCORE STEP :##################################################################
@@ -378,6 +384,66 @@ steps:
         disease_id_lut: intermediate/ontoma/disease_id_lookup_table.parquet
   ##################################################################################################
 
+  #: DRUG_WARNING STEP :############################################################################
+  drug_warning:
+    - name: pyspark drug_warning
+      pyspark: drug_warning
+      source: input/drug/chembl_drug_warning.jsonl
+      destination: output/drug_warning
+  ##################################################################################################
+
+  #: DRUG_MECHANISM_OF_ACTION STEP :###############################################################
+  drug_mechanism_of_action:
+    - name: pyspark drug_mechanism_of_action
+      pyspark: drug_mechanism_of_action
+      source:
+        chembl_mechanism: input/drug/chembl_mechanism.jsonl
+        chembl_target: input/drug/chembl_target.jsonl
+        target: output/target
+      destination: output/drug_mechanism_of_action
+  ##################################################################################################
+
+  #: CHEMBL_MOLECULE STEP :#########################################################################
+  chembl_molecule:
+    - name: pyspark chembl_molecule
+      pyspark: chembl_molecule
+      source:
+        chembl_molecule: input/drug/chembl_molecule.jsonl
+        drugbank: input/drug/drugbank.csv.gz
+      destination: intermediate/chembl_molecule
+  ##################################################################################################
+
+  #: DRUG_MOLECULE STEP :##########################################################################
+  drug_molecule:
+    - name: pyspark drug_molecule
+      pyspark: drug_molecule
+      source:
+        molecule: intermediate/chembl_molecule
+        chemical_probes: intermediate/chemical_probes_evidence.parquet
+        mechanism_of_action: output/drug_mechanism_of_action
+        drug_warning: output/drug_warning
+        indication: input/drug/chembl_drug_indication.jsonl
+        disease: output/disease
+      destination: output/drug_molecule
+  ##################################################################################################
+
+  #: TARGET_PRIORITISATION STEP :###################################################################
+  target_prioritisation:
+    - name: pyspark target_prioritisation
+      pyspark: target_prioritisation
+      source:
+        targets: output/target
+        mouse_phenotypes: output/mouse_phenotype
+        molecule: output/drug_molecule
+        mechanism_of_action: output/drug_mechanism_of_action
+        hpa_data: input/target_engine/proteinatlas.json.gz
+        uniprot_slterms: input/target_engine/uniprot_locations.tsv.gz
+        mouse_pheno_scores: input/target_engine/mouse_pheno_scores.csv
+      destination: output/target_prioritisation
+      properties:
+        spark.driver.memory: 16g
+  ##################################################################################################
+
   #: TIMESERIES STEP :##############################################################################
   timeseries:
     - name: pyspark timeseries
@@ -386,10 +452,10 @@ steps:
         evidence: output/evidence_*
         disease: output/disease
       destination:
-        overall_direct: output/timeseries_overall_direct
-        overall_indirect: output/timeseries_overall_indirect
-        by_datasource_direct: output/timeseries_by_datasource_direct
-        by_datasource_indirect: output/timeseries_by_datasource_indirect
+        overall_direct: view/timeseries_overall_direct
+        overall_indirect: view/timeseries_overall_indirect
+        by_datasource_direct: view/timeseries_by_datasource_direct
+        by_datasource_indirect: view/timeseries_by_datasource_indirect
       settings:
         novelty_scale: 2 # 2 for long tailed slow decays
         novelty_shift: 3 # 3 for long tailed slow decays
@@ -472,7 +538,7 @@ steps:
       settings:
         evidence_format: json
         datasource_id: expression_atlas
-        score_expression: 'array_min(array(1.0, pvalue_linear_score(resourceScore) * (abs(log2FoldChangeValue) / 10) * (log2FoldChangePercentileRank / 100)))'
+        score_expression: "array_min(array(1.0, pvalue_linear_score(resourceScore) * (abs(log2FoldChangeValue) / 10) * (log2FoldChangePercentileRank / 100)))"
         unique_fields:
           - targetId
           - targetFromSourceId

--- a/src/orchestration/dags/config/pts.yaml
+++ b/src/orchestration/dags/config/pts.yaml
@@ -421,7 +421,6 @@ steps:
         molecule: intermediate/chembl_molecule
         chemical_probes: intermediate/chemical_probes_evidence.parquet
         mechanism_of_action: output/drug_mechanism_of_action
-        drug_warning: output/drug_warning
         clinical_report: output/clinical_report
         disease: output/disease
       destination: output/drug_molecule
@@ -433,6 +432,7 @@ steps:
       source:
         chembl_molecule: intermediate/chembl_molecule
         disease: output/disease
+        drug_warning: output/drug_warning
       destination:
         output: output/clinical_report
         excluded: excluded/clinical_report

--- a/src/orchestration/dags/config/pts.yaml
+++ b/src/orchestration/dags/config/pts.yaml
@@ -242,15 +242,14 @@ steps:
         finngen_release: R12
   ##################################################################################################
 
-  #: EVIDENCE_CHEMBl STEP :#########################################################################
-  evidence_chembl:
-    - name: pyspark chembl
-      pyspark: chembl
+  #: EVIDENCE_CLINICAL_PRECEDENCE STEP :############################################################
+  evidence_clinical_precedence:
+    - name: pyspark clinical_precedence
+      pyspark: clinical_precedence
       source:
-        stop_reasons: input/evidence/chembl/stop_reasons.json
         clinical_report: output/clinical_report
         drug_mechanism_of_action: output/drug_mechanism_of_action
-      destination: intermediate/evidence/chembl.parquet
+      destination: intermediate/evidence/clinical_precedence.parquet
   ##################################################################################################
 
   #: EVIDENCE_CANCER_BIOMARKERS STEP :################################################################
@@ -900,62 +899,64 @@ steps:
           - drugFromSource
           - drugResponse
 
-  evidence_postprocess_chembl:
+  evidence_postprocess_clinical_precedence:
     - name: pyspark evidence_postprocess
       pyspark: evidence_postprocess
       source:
-        evidence_path: intermediate/evidence/chembl.parquet
+        evidence_path: intermediate/evidence/clinical_precedence.parquet
         target_path: output/target
         disease_path: output/disease
         publication_date_lut: input/literature/literature_export
-        mechanism_of_action: output/drug_mechanism_of_action
       destination:
-        failed_evidence: excluded/evidence/chembl
-        evidence: output/evidence_chembl
+        failed_evidence: excluded/evidence/clinical_precedence
+        evidence: output/evidence_clinical_precedence
       settings:
         evidence_format: parquet
-        datasource_id: chembl
+        datasource_id: clinical_precedence
         score_expression: |
           element_at(
             map(
-              cast(0.5 as double),
-              0.05,
-              cast(1.0 as double),
-              0.1,
-              cast(2.0 as double),
-              0.2,
-              cast(3.0 as double),
-              0.7,
-              cast(4.0 as double),
-              1.0
+              'APPROVED', 1.0,
+              'PHASE_4', 1.0,
+              'WITHDRAWN', 1.0,
+              'PREAPPROVAL', 0.8,
+              'PHASE_3', 0.7,
+              'PHASE_2_3', 0.5,
+              'PHASE_2', 0.2,
+              'PHASE_1_2', 0.15,
+              'PHASE_1', 0.1,
+              'EARLY_PHASE_1', 0.05,
+              'IND', 0.05,
+              'PRECLINICAL', 0.01,
+              'UNKNOWN', 0.01
             ),
-            clinicalPhase
+            clinicalStage
           ) *
           case
-          when studyStopReasonCategories is null then
+          when trialStopReasonCategories is null then
             double(1.0)
           else
             array_min(
               transform(
-                studyStopReasonCategories,
+                trialStopReasonCategories,
                 x -> element_at(
                   map(
-                    'Another study', double(1.0),
-                    'Business or administrative', double(1.0),
-                    'COVID-19', double(1.0),
-                    'Ethical reason', double(1.0),
-                    'Insufficient data', double(1.0),
-                    'Insufficient enrollment', double(1.0),
-                    'Interim analysis', double(1.0),
-                    'Invalid reason', double(1.0),
-                    'Logistics or resources', double(1.0),
-                    'Met endpoint', double(1.0),
+                    'Another_Study', double(1.0),
+                    'Business_Administrative', double(1.0),
+                    'Covid19', double(1.0),
+                    'Ethical_Reason', double(1.0),
+                    'Insufficient_Data', double(1.0),
+                    'Insufficient_Enrollment', double(1.0),
+                    'Interim_Analysis', double(1.0),
+                    'Invalid_Reason', double(1.0),
+                    'Logistics_Resources', double(1.0),
+                    'Endpoint_Met', double(1.0),
                     'Negative', double(0.5),
-                    'No context', double(1.0),
+                    'No_Context', double(1.0),
                     'Regulatory', double(1.0),
-                    'Safety or side effects', double(0.5),
-                    'Study design', double(1.0),
-                    'Study staff moved', double(1.0),
+                    'Safety_Sideeffects', double(0.5),
+                    'Study_Design', double(1.0),
+                    'Study_Staff_Moved', double(1.0),
                     'Success', double(1.0),
                     'Uncategorised', double(1.0)
                   ),
@@ -970,9 +971,7 @@ steps:
           - diseaseId
           - datasourceId
           - drugId
-          - urls
         direction_on_trait_expression: CASE WHEN diseaseId IS NOT NULL THEN 'protect' END
-        direction_on_target_expression: moaType
 
   evidence_postprocess_reactome:
     - name: pyspark evidence_postprocess

--- a/src/orchestration/dags/config/unified_pipeline.yaml
+++ b/src/orchestration/dags/config/unified_pipeline.yaml
@@ -143,7 +143,6 @@ steps:
   pts_drug_molecule:
     depends_on:
       - pts_drug_mechanism_of_action
-      - pts_drug_warning
       - pts_chemical_probes
       - pts_clinical_report
   # Clinical Steps
@@ -151,6 +150,7 @@ steps:
     depends_on:
       - pts_chembl_molecule
       - pts_disease
+      - pts_drug_warning
   pts_clinical_indication:
     depends_on:
       - pts_clinical_report

--- a/src/orchestration/dags/config/unified_pipeline.yaml
+++ b/src/orchestration/dags/config/unified_pipeline.yaml
@@ -148,6 +148,18 @@ steps:
       - pts_drug_warning
       - pts_chemical_probes
       - pts_disease
+  # Clinical Steps
+  pts_clinical_report:
+    depends_on:
+      - pts_chembl_molecule
+      - pts_disease
+  pts_clinical_indication:
+    depends_on:
+      - pts_clinical_report
+  pts_clinical_target:
+    depends_on:
+      - pts_clinical_report
+      - pts_drug_mechanism_of_action
   pts_target_prioritisation:
     depends_on:
       - pis_target_engine

--- a/src/orchestration/dags/config/unified_pipeline.yaml
+++ b/src/orchestration/dags/config/unified_pipeline.yaml
@@ -103,6 +103,7 @@ steps:
   pts_chemical_probes:
     depends_on:
       - pis_target
+      - pts_chembl_molecule
   pts_coding_variant:
     depends_on:
       - gentropy_variant
@@ -126,7 +127,33 @@ steps:
   pts_pharmacogenetics:
     depends_on:
       - pis_pharmacogenetics
+      - pts_chembl_molecule
+      - pts_drug_mechanism_of_action
       - pts_ontoma
+  # Drug Processing Steps
+  pts_drug_warning:
+    depends_on:
+      - pis_drug
+  pts_chembl_molecule:
+    depends_on:
+      - pis_drug
+  pts_drug_mechanism_of_action:
+    depends_on:
+      - pis_drug
+      - pts_target
+  pts_drug_molecule:
+    depends_on:
+      - pts_chembl_molecule
+      - pts_drug_mechanism_of_action
+      - pts_drug_warning
+      - pts_chemical_probes
+      - pts_disease
+  pts_target_prioritisation:
+    depends_on:
+      - pis_target_engine
+      - pts_mouse_phenotype
+      - pts_drug_molecule
+      - pts_drug_mechanism_of_action
   # Evidence not processed by PTS
   pts_evidence_postprocess_europepmc:
     depends_on:
@@ -205,12 +232,12 @@ steps:
   pts_evidence_postprocess_chembl:
     depends_on:
       - pts_evidence_chembl
-      - etl_drug
+      - pts_drug_mechanism_of_action
       - pts_disease
   pts_evidence_cancer_biomarkers:
     depends_on:
       - pis_evidence_cancer_biomarkers
-      - etl_drug
+      - pts_drug_molecule
   pts_evidence_postprocess_cancer_biomarkers:
     depends_on:
       - pts_evidence_cancer_biomarkers
@@ -334,12 +361,6 @@ steps:
       - etl_reactome
       - pts_target_safety
       - pts_target_gene_essentiality
-  etl_drug:
-    num_partitions: 1
-    depends_on:
-      - pis_drug
-      - pts_disease
-      - etl_target
   etl_search_facet:
     depends_on:
       - pts_disease
@@ -352,22 +373,12 @@ steps:
   etl_openfda:
     depends_on:
       - pts_openfda
-      - etl_drug
+      - pts_drug_molecule
   etl_literature:
     num_partitions: 1000
     depends_on:
       - pis_literature
-      - etl_drug
-  etl_pharmacogenomics:
-    num_partitions: 1
-    depends_on:
-      - pts_pharmacogenetics
-      - etl_drug
-  etl_target_engine:
-    depends_on:
-      - pis_target_engine
-      - etl_drug
-      - pts_mouse_phenotype
+      - pts_drug_molecule
   etl_association:
     depends_on:
       - pts_evidence_postprocess_impc
@@ -420,10 +431,6 @@ steps:
       - pts_evidence_postprocess_ot_crispr
       - pts_evidence_postprocess_encore
       - pts_evidence_postprocess_validation_lab
-  etl_known_drug:
-    num_partitions: 2
-    depends_on:
-      - pts_evidence_postprocess_chembl
   etl_search:
     depends_on:
       - etl_association
@@ -451,7 +458,7 @@ steps:
       - gentropy_credible_set
   gentropy_variant_partition:
     depends_on:
-      - etl_pharmacogenomics
+      - pts_pharmacogenetics
       - gentropy_credible_set
       - pis_evidence_uniprot_variants
       - pis_evidence_eva

--- a/src/orchestration/dags/config/unified_pipeline.yaml
+++ b/src/orchestration/dags/config/unified_pipeline.yaml
@@ -244,7 +244,6 @@ steps:
     depends_on:
       - pts_evidence_chembl
       - pts_drug_mechanism_of_action
-      - pts_disease
   pts_evidence_cancer_biomarkers:
     depends_on:
       - pis_evidence_cancer_biomarkers

--- a/src/orchestration/dags/config/unified_pipeline.yaml
+++ b/src/orchestration/dags/config/unified_pipeline.yaml
@@ -56,7 +56,7 @@ steps:
   pis_ontoma:
   pis_evidence_expression_atlas:
   pis_evidence_cancer_biomarkers:
-  pis_evidence_chembl:
+  # pis_evidence_chembl removed: clinical_precedence reads from clinical_report + drug_moa
   pis_evidence_clingen:
   pis_evidence_cosmic:
   pis_evidence_project_score:
@@ -234,14 +234,13 @@ steps:
       - pts_evidence_gene_burden
       - etl_target
       - pts_disease
-  pts_evidence_chembl:
+  pts_evidence_clinical_precedence:
     depends_on:
-      - pis_evidence_chembl
       - pts_clinical_report
       - pts_drug_mechanism_of_action
-  pts_evidence_postprocess_chembl:
+  pts_evidence_postprocess_clinical_precedence:
     depends_on:
-      - pts_evidence_chembl
+      - pts_evidence_clinical_precedence
   pts_evidence_cancer_biomarkers:
     depends_on:
       - pis_evidence_cancer_biomarkers
@@ -324,7 +323,7 @@ steps:
       - pts_evidence_postprocess_gwas_credible_sets
       - pts_evidence_postprocess_expression_atlas
       - pts_evidence_postprocess_cancer_biomarkers
-      - pts_evidence_postprocess_chembl
+      - pts_evidence_postprocess_clinical_precedence
       - pts_evidence_postprocess_clingen
       - pts_evidence_postprocess_cosmic
       - pts_evidence_postprocess_project_score
@@ -394,7 +393,7 @@ steps:
       - pts_evidence_postprocess_gwas_credible_sets
       - pts_evidence_postprocess_expression_atlas
       - pts_evidence_postprocess_cancer_biomarkers
-      - pts_evidence_postprocess_chembl
+      - pts_evidence_postprocess_clinical_precedence
       - pts_evidence_postprocess_clingen
       - pts_evidence_postprocess_cosmic
       - pts_evidence_postprocess_project_score
@@ -420,7 +419,7 @@ steps:
       - pts_evidence_postprocess_gwas_credible_sets
       - pts_evidence_postprocess_expression_atlas
       - pts_evidence_postprocess_cancer_biomarkers
-      - pts_evidence_postprocess_chembl
+      - pts_evidence_postprocess_clinical_precedence
       - pts_evidence_postprocess_clingen
       - pts_evidence_postprocess_cosmic
       - pts_evidence_postprocess_project_score

--- a/src/orchestration/dags/config/unified_pipeline.yaml
+++ b/src/orchestration/dags/config/unified_pipeline.yaml
@@ -242,7 +242,6 @@ steps:
   pts_evidence_postprocess_chembl:
     depends_on:
       - pts_evidence_chembl
-      - pts_drug_mechanism_of_action
   pts_evidence_cancer_biomarkers:
     depends_on:
       - pis_evidence_cancer_biomarkers

--- a/src/orchestration/dags/config/unified_pipeline.yaml
+++ b/src/orchestration/dags/config/unified_pipeline.yaml
@@ -143,11 +143,10 @@ steps:
       - pts_target
   pts_drug_molecule:
     depends_on:
-      - pts_chembl_molecule
       - pts_drug_mechanism_of_action
       - pts_drug_warning
       - pts_chemical_probes
-      - pts_disease
+      - pts_clinical_report
   # Clinical Steps
   pts_clinical_report:
     depends_on:
@@ -240,7 +239,8 @@ steps:
   pts_evidence_chembl:
     depends_on:
       - pis_evidence_chembl
-      - pis_drug
+      - pts_clinical_report
+      - pts_drug_mechanism_of_action
   pts_evidence_postprocess_chembl:
     depends_on:
       - pts_evidence_chembl

--- a/src/orchestration/dags/config/unified_pipeline.yaml
+++ b/src/orchestration/dags/config/unified_pipeline.yaml
@@ -163,7 +163,6 @@ steps:
       - pis_target_engine
       - pts_mouse_phenotype
       - pts_drug_molecule
-      - pts_drug_mechanism_of_action
   # Evidence not processed by PTS
   pts_evidence_postprocess_europepmc:
     depends_on:

--- a/src/orchestration/dags/config/unified_pipeline.yaml
+++ b/src/orchestration/dags/config/unified_pipeline.yaml
@@ -119,7 +119,6 @@ steps:
       - pis_target
   pts_target_safety:
     depends_on:
-      - pis_target
       - pts_pharmacogenetics
   pts_target_gene_essentiality:
     depends_on:


### PR DESCRIPTION
- Add new PTS steps: pts_drug_warning, pts_chembl_molecule, pts_drug_mechanism_of_action, pts_drug_molecule, pts_target_prioritisation
- Remove ETL steps: etl_drug, etl_pharmacogenomics, etl_known_drug, etl_target_engine
- Update dependencies to use new PTS drug steps instead of removed ETL steps

Related to [#4247](https://github.com/opentargets/issues/issues/4247)