### PR TITLE
feat: add interval features to l2g

### DIFF
--- a/src/orchestration/dags/config/gentropy.yaml
+++ b/src/orchestration/dags/config/gentropy.yaml
@@ -175,7 +175,7 @@ steps:
       step.credible_set_path: '{{release_uri}}/output/credible_set'
       step.feature_matrix_path: '{{release_uri}}/intermediate/l2g_feature_matrix'
       step.gold_standard_curation_path: '{{release_uri}}/input/l2g/gold_standard.json'
-      step.intervals_path: '{{release_uri}}/output/enhancerToGene'
+      step.intervals_path: '{{release_uri}}/output/enhancer_to_gene'
       # OUTPUTS
       step.model_path: '{{release_uri}}/etc/model/locus_to_gene_model/classifier.skops'
 

--- a/src/orchestration/dags/config/gentropy.yaml
+++ b/src/orchestration/dags/config/gentropy.yaml
@@ -158,6 +158,7 @@ steps:
       step.colocalisation_path: '{{release_uri}}/output/colocalisation'
       step.study_index_path: '{{release_uri}}/output/study'
       step.target_index_path: '{{release_uri}}/output/target'
+      step.intervals_path: '{{release_uri}}/output/enhancer_to_gene'
       # OUTPUTS
       step.feature_matrix_path: '{{release_uri}}/intermediate/l2g_feature_matrix'
 
@@ -175,7 +176,6 @@ steps:
       step.credible_set_path: '{{release_uri}}/output/credible_set'
       step.feature_matrix_path: '{{release_uri}}/intermediate/l2g_feature_matrix'
       step.gold_standard_curation_path: '{{release_uri}}/input/l2g/gold_standard.json'
-      step.intervals_path: '{{release_uri}}/output/enhancer_to_gene'
       # OUTPUTS
       step.model_path: '{{release_uri}}/etc/model/locus_to_gene_model/classifier.skops'
 

--- a/src/orchestration/dags/config/gentropy.yaml
+++ b/src/orchestration/dags/config/gentropy.yaml
@@ -175,6 +175,7 @@ steps:
       step.credible_set_path: '{{release_uri}}/output/credible_set'
       step.feature_matrix_path: '{{release_uri}}/intermediate/l2g_feature_matrix'
       step.gold_standard_curation_path: '{{release_uri}}/input/l2g/gold_standard.json'
+      step.intervals_path: '{{release_uri}}/output/enhancerToGene'
       # OUTPUTS
       step.model_path: '{{release_uri}}/etc/model/locus_to_gene_model/classifier.skops'
 

--- a/src/orchestration/dags/config/unified_pipeline.yaml
+++ b/src/orchestration/dags/config/unified_pipeline.yaml
@@ -15,7 +15,7 @@ is_ppp: true
 pis_version: '25.12.0'
 pts_version: '25.12.1'
 etl_version: '25.12.1'
-gentropy_version: '3.1.1'
+gentropy_version: '3.2.0-rc.1'
 vep_version: 'release_115.2'
 chembl_version: '36'
 efo_version: '3.83.0'
@@ -465,6 +465,7 @@ steps:
     depends_on:
       - gentropy_colocalisation
       - gentropy_variant
+      - pis_enhancer_to_gene
   gentropy_l2g_training:
     depends_on:
       - pis_l2g


### PR DESCRIPTION
# Context

For the upcoming March release we want to add enhancer2Gene fetures to L2G. This PR links the new gentropy version that brings the functionality and adds the `enhancerToGene` dataset and step to L2G feature matrix step as dependencies.


The QC of the intervals will be done in next PRs.