### PR TITLE
feat: add pis_encode and gentropy_enhancer_to_gene steps

### DIFF
--- a/src/orchestration/dags/config/gentropy.yaml
+++ b/src/orchestration/dags/config/gentropy.yaml
@@ -251,7 +251,7 @@ steps:
         - AMBIGUOUS_INTERVAL_TYPE
 
       # INPUTS
-      step.target_index_path: gs://open-targets-pipeline-runs/szsz/25.12-ppp-testrun-3/output/target  #'{{release_uri}}/output/target'
+      step.target_index_path: gs://open-targets-pipeline-runs/szsz/25.12-ppp-testrun-3/output/target #'{{release_uri}}/output/target'
       step.biosample_index_path: gs://open-targets-pipeline-runs/szsz/25.12-ppp-testrun-3/output/biosample #'{{release_uri}}/output/biosample'
       step.biosample_mapping_path: '{{release_uri}}/input/encode/rE2G/biosample_mapping.csv'
       step.chromosome_contig_index_path: '{{release_uri}}/input/chromosome/chromosome.parquet'

--- a/src/orchestration/dags/config/gentropy.yaml
+++ b/src/orchestration/dags/config/gentropy.yaml
@@ -231,3 +231,31 @@ steps:
       step.study_index_path: '{{release_uri}}/output/study'
       # OUTPUTS
       step.evidence_output_path: '{{release_uri}}/intermediate/evidence/l2g_evidence'
+
+  enhancer_to_gene:
+    params:
+      step: interval_e2g
+      step.session.write_mode: overwrite
+      step.session.output_partitions: 30
+      step.min_valid_score: 0.6
+      step.max_valid_score: 1.0
+      step.invalid_qc_reasons:
+        - UNRESOLVED_TARGET
+        - UNKNOWN_BIOSAMPLE
+        - SCORE_OUTSIDE_BOUNDS
+        - UNKNOWN_INTERVAL_TYPE
+        - AMBIGUOUS_SCORE
+        - UNKNOWN_PROJECT_ID
+        - INVALID_CHROMOSOME
+        - INVALID_RANGE
+        - AMBIGUOUS_INTERVAL_TYPE
+
+      # INPUTS
+      step.target_index_path: gs://open-targets-pipeline-runs/szsz/25.12-ppp-testrun-3/output/target  #'{{release_uri}}/output/target'
+      step.biosample_index_path: gs://open-targets-pipeline-runs/szsz/25.12-ppp-testrun-3/output/biosample #'{{release_uri}}/output/biosample'
+      step.biosample_mapping_path: '{{release_uri}}/input/encode/rE2G/biosample_mapping.csv'
+      step.chromosome_contig_index_path: '{{release_uri}}/input/chromosome/chromosome.parquet'
+      step.interval_source: '{{release_uri}}/input/encode/rE2G/datasets/*.bed.gz'
+      # OUTPUTS
+      step.valid_output_path: '{{release_uri}}/output/enhancer_to_gene'
+      step.invalid_output_path: '{{release_uri}}/excluded/enhancer_to_gene'

--- a/src/orchestration/dags/config/pis.yaml
+++ b/src/orchestration/dags/config/pis.yaml
@@ -609,7 +609,7 @@ steps:
       destination: input/encode/rE2G/biosample_mapping.csv
 
     - name: copy encode rE2G manifest
-    # NOTE: excluded samples from query have divergent schemas that do not conform to expected rE2G format
+      # NOTE: excluded samples from query have divergent schemas that do not conform to expected rE2G format
       source: https://www.encodeproject.org/report.tsv?type=File&searchTerm=encode-re2g+thresholded&output_type=thresholded+element+gene+links&status=released&limit=all&accession!=ENCFF094BVF&accession!=ENCFF269DKY
       destination: input/encode/rE2G/download_manifest.tsv
 
@@ -619,7 +619,7 @@ steps:
       manifest: input/encode/rE2G/download_manifest.tsv
       columns:
         accession: 'Accession'
-        url_stem:  'Download URL'
+        url_stem: 'Download URL'
       expand: # COPY task template
         name: copy encode rE2G ${accession}
         source: https://www.encodeproject.org${url_stem}
@@ -940,4 +940,3 @@ steps:
       source: https://raw.githubusercontent.com/opentargets/target_engine/main/src/data_flow/phenotypeScores/20230825_mousePheScores.csv
       destination: input/target_engine/mouse_pheno_scores.csv
   ##################################################################################################
-

--- a/src/orchestration/dags/config/pis.yaml
+++ b/src/orchestration/dags/config/pis.yaml
@@ -610,7 +610,7 @@ steps:
 
     - name: copy encode rE2G manifest
       # NOTE: excluded samples from query have divergent schemas that do not conform to expected rE2G format
-      source: https://www.encodeproject.org/report.tsv?type=File&searchTerm=encode-re2g+thresholded&output_type=thresholded+element+gene+links&status=released&limit=all&accession!=ENCFF094BVF&accession!=ENCFF269DKY
+      source: https://www.encodeproject.org/report.tsv?type=File&searchTerm=encode-re2g+thresholded&output_type=thresholded+element+gene+links&status=released&limit=all&accession!=ENCFF094BVF&accession!=ENCFF269DKY # yamllint disable-line rule:line-length
       destination: input/encode/rE2G/download_manifest.tsv
 
     - name: crawl_encode rE2G manifest

--- a/src/orchestration/dags/config/pis.yaml
+++ b/src/orchestration/dags/config/pis.yaml
@@ -598,14 +598,32 @@ steps:
       destination: input/interaction/string-interactions.txt.gz
   ##################################################################################################
 
-  #: ENHANCER TO GENE STEP
-  enhancer_to_gene:
-    - name: explode_glob rE2G interval
-      glob: gs://interval_data/datasets/ENCODE-rE2G/processed_E2G_2509_filtered.parquet/*.parquet
-      do:
-        - name: copy rE2G interval ${match_stem}
-          source: ${match_prefix}/${match_path}${match_stem}.${match_ext}
-          destination: output/enhancer_to_gene/${uuid}.parquet
+  #: ENCODE STEP :##################################################################################
+  encode:
+    - name: copy chromosome contigs
+      source: gs://vep_cache_data/vep/cache/contig.parquet
+      destination: input/chromosome/chromosome.parquet
+
+    - name: copy encode rE2G biosample mapping
+      source: https://raw.githubusercontent.com/opentargets/curation/refs/tags/${ot_curation}/genetics/E2G_biosample_mapping.csv
+      destination: input/encode/rE2G/biosample_mapping.csv
+
+    - name: copy encode rE2G manifest
+    # NOTE: excluded samples from query have divergent schemas that do not conform to expected rE2G format
+      source: https://www.encodeproject.org/report.tsv?type=File&searchTerm=encode-re2g+thresholded&output_type=thresholded+element+gene+links&status=released&limit=all&accession!=ENCFF094BVF&accession!=ENCFF269DKY
+      destination: input/encode/rE2G/download_manifest.tsv
+
+    - name: crawl_encode rE2G manifest
+      requires:
+        - copy encode rE2G manifest
+      manifest: input/encode/rE2G/download_manifest.tsv
+      columns:
+        accession: 'Accession'
+        url_stem:  'Download URL'
+      expand: # COPY task template
+        name: copy encode rE2G ${accession}
+        source: https://www.encodeproject.org${url_stem}
+        destination: input/encode/rE2G/datasets/${accession}.bed.gz
   ##################################################################################################
 
   #: L2G STEP :#####################################################################################
@@ -922,3 +940,4 @@ steps:
       source: https://raw.githubusercontent.com/opentargets/target_engine/main/src/data_flow/phenotypeScores/20230825_mousePheScores.csv
       destination: input/target_engine/mouse_pheno_scores.csv
   ##################################################################################################
+

--- a/src/orchestration/dags/config/unified_pipeline.yaml
+++ b/src/orchestration/dags/config/unified_pipeline.yaml
@@ -1,21 +1,21 @@
 ---
-release_name: '25.12-ppp'
+release_name: '26.01-interval-qc-2'
 
 # If `is_dev` is true:
 #   * the bucket used for the run will be `opentargets-pipeline-runs`
 #   * the prefix inside the bucket will be `run_name`
 #         which defaults to a timestamp if not provided.
 is_dev: true
-run_name: 'szsz/25.12-ppp-testrun-3'
+run_name: 'szsz/testrun-interval-qc-2'
 
 # Whether this will be a partner preview platform release (PPP)
 is_ppp: true
 
 # Versions for software and data
-pis_version: '25.12.0'
+pis_version: '26.1.0-dev.1'
 pts_version: '25.12.1'
 etl_version: '25.12.1'
-gentropy_version: '3.2.0-rc.1'
+gentropy_version: '3.2.0-dev.6'
 vep_version: 'release_115.2'
 chembl_version: '36'
 efo_version: '3.83.0'
@@ -49,6 +49,7 @@ gnomad_version: '4.1'
 #
 steps:
   # PIS STEPS
+  pis_encode:
   pis_biosample:
   pis_disease:
   pis_drug:
@@ -436,6 +437,11 @@ steps:
   gentropy_biosample:
     depends_on:
       - pis_biosample
+  gentropy_enhancer_to_gene:
+    depends_on:
+      - pis_encode
+      - etl_target
+      - gentropy_biosample
   gentropy_study:
     depends_on:
       - pts_target
@@ -465,7 +471,7 @@ steps:
     depends_on:
       - gentropy_colocalisation
       - gentropy_variant
-      - pis_enhancer_to_gene
+      - gentropy_enhancer_to_gene
   gentropy_l2g_training:
     depends_on:
       - pis_l2g

--- a/src/orchestration/dags/config/unified_pipeline.yaml
+++ b/src/orchestration/dags/config/unified_pipeline.yaml
@@ -12,7 +12,7 @@ run_name: 'szsz/testrun-interval-qc-2'
 is_ppp: true
 
 # Versions for software and data
-pis_version: '26.1.0-dev.1'
+pis_version: '26.0.0-dev+3954.1'
 pts_version: '25.12.1'
 etl_version: '25.12.1'
 gentropy_version: '3.2.0-dev.6'

--- a/src/orchestration/dags/unified_pipeline.py
+++ b/src/orchestration/dags/unified_pipeline.py
@@ -418,6 +418,10 @@ with DAG(
             "gentropy_l2g_evidence": {
                 "step.evidence_output_path": gsp("gentropy_l2g_evidence", "step.evidence_output_path"),
             },
+            "gentropy_enhancer_to_gene": {
+                "step.valid_output_path": gsp("gentropy_enhancer_to_gene", "step.valid_output_path"),
+                "step.invalid_output_path": gsp("gentropy_enhancer_to_gene", "step.invalid_output_path"),
+            },
         }
 
         default_differs = [

--- a/src/orchestration/operators/dataproc.py
+++ b/src/orchestration/operators/dataproc.py
@@ -170,7 +170,19 @@ class ClusterConfig:
         Returns:
             Cluster: The Dataproc cluster.
         """
-        return ClusterGenerator(**asdict(self)).make()
+        config = ClusterGenerator(**asdict(self)).make()
+        # Ensure that the c4- machine types have the right disk config
+        # TODO: Refactor once we are sure we need the c4- machine types
+        if self.worker_machine_type.startswith("c4-"):
+            config["worker_config"]["disk_config"]["boot_disk_type"] = "hyperdisk-balanced"
+            config["worker_config"]["disk_config"]["boot_disk_provisioned_iops"] = 6_000
+            # Default is 140+ 1.5 x 500GiB
+            config["worker_config"]["disk_config"]["boot_disk_provisioned_throughput"] = 500
+        if self.master_machine_type.startswith("c4-"):
+            config["master_config"]["disk_config"]["boot_disk_type"] = "hyperdisk-balanced"
+            config["master_config"]["disk_config"]["boot_disk_provisioned_iops"] = 6_000
+            config["master_config"]["disk_config"]["boot_disk_provisioned_throughput"] = 500
+        return config
 
 
 class ClusterDefinition(NamedTuple):


### PR DESCRIPTION

# Contents

This PR adds the `pis_encode`  and  `gentropy_enhancer_to_gene` steps to the Unified Pipeline.


## Comparison for running the `gentropy_enhancer_to_gene`

Original intervals (25.12): 48,854,316                                                        
Output intervals: 48,810,405
Excluded intervals: 68,154,612

```
|[Interval has a duplicate with different score]                                                                                                          |42112   |
|[Target/gene identifier could not match to reference]                                                                                                    |129680  |
|[Biosample identifier was not found in the reference, Target/gene identifier could not match to reference]                                               |1798    |
|[Biosample identifier was not found in the reference, Interval has a duplicate with different score, Score was above or below specified thresholds]      |672     |
|[Score was above or below specified thresholds, Target/gene identifier could not match to reference]                                                     |234456  |
|[Biosample identifier was not found in the reference, Score was above or below specified thresholds, Target/gene identifier could not match to reference]|3038    |
|[Biosample identifier was not found in the reference, Interval has a duplicate with different score]                                                     |712     |
|[Interval has a duplicate with different score, Score was above or below specified thresholds]                                                           |55758   |
|[Score was above or below specified thresholds]                                                                                                          |66180554|
|[Biosample identifier was not found in the reference, Score was above or below specified thresholds]                                                     |868917  |
|[Biosample identifier was not found in the reference]    
```
Validation failures were due to:
- biosample not found in biosampleIndex
- geneId not found in targetIndex
- when two same intervals have diverging scores for the same geneId, biosampleId mapping. 
- exclusion of intervals with scores below 0.6

## Execution time

- `pis_encode` -> 5min
- `gentropy_enhancer_to_gene` -> 15 min

## Architecture

The Interval ingestion logic:
- `pis_encode` 
    (1) Download the manifest via pis from ENCODE using the query url
    (2) Download the biosample mapping from ot curation repo
    (3) Download the chromosome index (used for checking the interval bounds are within expected range)
    (4) Based on manifest, download specific ENCODE bed files with the intervals
- `gentropy_enhancer_to_gene`
    (1) Parse the bed files to `Intervals` dataset and run the validation based on `target`, `biosample` and `chromosome` datasets.