### PR TITLE
chore(etl): move reactome from output to intermediate

### DIFF
--- a/src/orchestration/dags/config/etl.conf
+++ b/src/orchestration/dags/config/etl.conf
@@ -46,7 +46,7 @@ steps: {
     output: {
       reactome: {
         format: ${common.output_format}
-        path: ${common.output_path}"/output/reactome"
+        path: ${common.output_path}"/intermediate/reactome"
       }
     }
   }
@@ -317,7 +317,7 @@ steps: {
       }
       reactome_etl: {
         format: "parquet"
-        path: ${common.path}"/output/reactome/part*"
+        path: ${common.path}"/intermediate/reactome/part*"
       }
       reactome_pathways: {
         format: "csv"


### PR DESCRIPTION
## Summary

- Moves the reactome step output path from `output/reactome` to `intermediate/reactome`
- Updates the target step's `reactome_etl` input path accordingly

Resolves https://github.com/opentargets/issues/issues/4297