### PR TITLE
chore: remove go step from etl.conf

### DIFF
--- a/src/orchestration/dags/config/etl.conf
+++ b/src/orchestration/dags/config/etl.conf
@@ -23,21 +23,6 @@ spark_settings: {
 # ============================= STEP CONFIGURATION =============================
 steps: {
 
-  go: {
-    input: {
-      go: {
-        format: "csv"
-        path: ${common.path}"/input/go/go.obo"
-      }
-    }
-    output: {
-      go: {
-        format: ${common.output_format}
-        path: ${common.output_path}"/output/go"
-      }
-    }
-  }
-
   literature: {
     input: {
       processing_epmcids: {

--- a/src/orchestration/dags/config/pts.yaml
+++ b/src/orchestration/dags/config/pts.yaml
@@ -91,6 +91,14 @@ steps:
       destination: output/expression
   ##################################################################################################
 
+  #: GO STEP :######################################################################################
+  go:
+    - name: transform go
+      source: input/go/go.obo
+      destination: output/go/go.parquet
+      transformer: go
+  ##################################################################################################
+
   #: MOUSE_PHENOTYPES STEP :########################################################################
   mouse_phenotype:
     - name: pyspark generate from IMPC and validate with target

--- a/src/orchestration/dags/config/unified_pipeline.yaml
+++ b/src/orchestration/dags/config/unified_pipeline.yaml
@@ -111,6 +111,9 @@ steps:
   pts_expression:
     depends_on:
       - pis_expression
+  pts_go:
+    depends_on:
+      - pis_go
   pts_mouse_phenotype:
     depends_on:
       - pts_target
@@ -394,22 +397,27 @@ steps:
       - pts_evidence_postprocess_ot_crispr
       - pts_evidence_postprocess_encore
       - pts_evidence_postprocess_validation_lab
+
   pts_association_timeseries_view:
     ppp_only: true
     depends_on:
       - pts_association
+
   pts_association_otf:
     ppp_only: false
     depends_on:
       - pts_association
+
   # pts_release_metrics:
   #   depends_on:
   #     - pts_association
+
   pts_otar:
     ppp_only: true
     depends_on:
       - pis_otar
       - pts_disease
+
   pts_target:
     num_partitions: 10
     depends_on:
@@ -418,6 +426,7 @@ steps:
       - pts_target_safety
       - pts_target_gene_essentiality
       - pts_disease
+
   pts_search_facet:
     depends_on:
       - pts_disease


### PR DESCRIPTION
Removes the go block from etl.conf. Adds pts_go config to pts.yaml. Closes opentargets/issues#4347