### PR TITLE
chore: migrate etl_otar → pts_otar

### DIFF
--- a/src/orchestration/dags/config/etl.conf
+++ b/src/orchestration/dags/config/etl.conf
@@ -495,39 +495,6 @@ steps: {
     }
   }
 
-  otar: {
-    input: {
-      diseases: {
-        format: "parquet"
-        path: ${common.path}"/output/disease"
-      }
-      otar_meta: {
-        format: "csv"
-        path: ${common.path}"/input/otar/otar_meta.csv"
-        options: [
-          { k: "sep",         v: ","  }
-          { k: "header",      v: true }
-          { k: "inferSchema", v: true }
-        ]
-      }
-      otar_project_to_efo: {
-        format: "csv"
-        path: ${common.path}"/input/otar/otar_project_to_efo.csv"
-        options: [
-          { k: "sep",         v: ","  }
-          { k: "header",      v: true }
-          { k: "inferSchema", v: true }
-        ]
-      }
-    }
-    output: {
-      otar: {
-        format: ${common.output_format}
-        path: ${common.output_path}"/output/otar"
-      }
-    }
-  }
-
   literature: {
     input: {
       processing_epmcids: {

--- a/src/orchestration/dags/config/pts.yaml
+++ b/src/orchestration/dags/config/pts.yaml
@@ -46,6 +46,17 @@ steps:
         pathways: input/reactome/ReactomePathways.txt
         relations: input/reactome/ReactomePathwaysRelation.txt
       destination: output/reactome
+  #: OTAR STEP :####################################################################################
+
+  ##################################################################################################
+  otar:
+    - name: pyspark otar
+      pyspark: otar
+      source:
+        diseases: output/disease
+        otar_meta: input/otar/otar_meta.csv
+        otar_project_to_efo: input/otar/otar_project_to_efo.csv
+      destination: output/otar
   ##################################################################################################
 
   #: EXPRESSION STEP :##############################################################################

--- a/src/orchestration/dags/config/unified_pipeline.yaml
+++ b/src/orchestration/dags/config/unified_pipeline.yaml
@@ -408,6 +408,7 @@ steps:
   pts_otar:
     ppp_only: true
     depends_on:
+      - pis_otar
       - pts_disease
   etl_target:
     num_partitions: 10

--- a/src/orchestration/dags/config/unified_pipeline.yaml
+++ b/src/orchestration/dags/config/unified_pipeline.yaml
@@ -405,10 +405,9 @@ steps:
   #   depends_on:
   #     - pts_association
   # ETL STEPS
-  etl_otar:
+  pts_otar:
     ppp_only: true
     depends_on:
-      - pis_otar
       - pts_disease
   etl_target:
     num_partitions: 10


### PR DESCRIPTION
## Summary

- Adds `otar:` step to `pts.yaml` with PySpark task reading from `input/otar/` and writing to `output/otar`
- Replaces `etl_otar:` with `pts_otar:` in `unified_pipeline.yaml` (retains `ppp_only: true`, updates `depends_on` to `[pts_disease]`)
- Removes the `otar: { ... }` block from `etl.conf`

Closes https://github.com/opentargets/issues/issues/4347