### PR TITLE
chore: migrate etl_target → pts_target (rename pts_target → pts_pre_target)

### DIFF
--- a/src/orchestration/dags/config/etl.conf
+++ b/src/orchestration/dags/config/etl.conf
@@ -27,7 +27,10 @@ steps: {
     scorethreshold: 0
     string_version: "12"
     input: {
-      targets: ${steps.target.output.target}
+      targets: {
+        format: ${common.output_format}
+        path: ${common.output_path}"/output/target"
+      }
       rnacentral: {
         format: "csv"
         path: ${common.path}"/input/interaction/rna_central_ensembl.tsv"
@@ -82,213 +85,16 @@ steps: {
     }
   }
 
-  target: {
-    input: {
-      chembl: {
-        format: "json"
-        path: ${common.path}"/input/target/chembl/chembl_target.jsonl"
-      }
-      chemical_probes: {
-        format: "parquet"
-        path: ${common.path}"/intermediate/chemical_probes_evidence.parquet"
-      }
-      diseases: {
-        format: "parquet"
-        path: ${common.path}"/output/disease"
-      }
-      ensembl: {
-        format: ${common.output_format}
-        path: ${common.path}"/intermediate/target/ensembl/homo_sapiens.parquet"
-      }
-      gene_code: {
-        format: "csv"
-        path: ${common.path}"/input/target/gencode/gencode.gff3.gz"
-        options: [
-          { k: "sep",     v: "\\t" }
-          { k: "comment", v: "#"   }
-        ]
-      }
-      genetic_constraints: {
-        format: "csv"
-        path: ${common.path}"/input/target/gnomad/gnomad_constraint_metrics.tsv"
-        options: [
-          { k: "sep",       v: "\\t" }
-          { k: "header",    v: true  }
-          { k: "nullValue", v: "NA"  }
-        ]
-      }
-      gene_ontology_human: {
-        format: "csv"
-        path: ${common.path}"/input/target/go/goa_human.gaf.gz"
-        options: [
-          { k: "sep",     v: "\\t" }
-          { k: "comment", v: "!"   }
-        ]
-      }
-      gene_ontology_rna: {
-        format: "csv"
-        path: ${common.path}"/input/target/go/goa_human_rna.gaf.gz"
-        options: [
-          { k: "sep", v: "\\t"   }
-          { k: "comment", v: "!" }
-        ]
-      }
-      gene_ontology_rna_lookup: {
-        format: "csv"
-        path: ${common.path}"/input/target/go/ensembl.tsv"
-        options: [
-          { k: "sep", v: "\\t" }
-        ]
-      }
-      gene_ontology_eco_lookup: {
-        format: "csv"
-        path: ${common.path}"/input/target/go/goa_human_eco.gpa.gz"
-        options: [
-          { k: "sep", v: "\\t"   }
-          { k: "comment", v: "!" }
-        ]
-      }
-      hallmarks: {
-        format: "csv"
-        path: ${common.path}"/input/target/hallmarks/cosmic-hallmarks.tsv.gz"
-        options: [
-          { k: "sep",    v: "\\t" }
-          { k: "header", v: true  }
-        ]
-      }
-      hgnc: {
-        format: "json"
-        path: ${common.path}"/input/target/genenames/hgnc_complete_set.json"
-      },
-      homology_dictionary: {
-        format: "csv"
-        path: ${common.path}"/input/target/homologue/species_EnsemblVertebrates.txt"
-        options: [
-          { k: "sep",    v: "\\t" }
-          { k: "header", v: true  }
-        ]
-      }
-      homology_coding_proteins: {
-        format: "csv"
-        path: ${common.path}"/input/target/homologue/homologies/*.tsv.gz"
-        options: [
-          { k: "sep",    v: "\\t" }
-          { k: "header", v: true  }
-        ]
-      }
-      homology_gene_dictionary: {
-        format: "parquet"
-        path: ${common.path}"/intermediate/target/homologue/gene_dictionary/*.parquet"
-        options: [
-          { k: "sep", v: "\\t" }
-        ]
-      }
-      hpa: {
-        format: "csv"
-        path: ${common.path}"/intermediate/target/hpa/subcellular_location.tsv.gz"
-        options: [
-          { k: "sep",    v: "\\t" }
-          { k: "header", v: true  }
-        ]
-      }
-      hpa_sl: {
-        format: "parquet"
-        path: ${common.path}"/intermediate/target/hpa/subcellular_locations_ssl.parquet"
-      }
-      ncbi: {
-        format: "csv"
-        path: ${common.path}"/input/target/ncbi/Homo_sapiens.gene_info.gz"
-        options: [
-          { k: "sep",    v: "\\t" }
-          { k: "header", v: true  }
-        ]
-      }
-      project_scores_ids: {
-        format: "parquet"
-        path: ${common.path}"/intermediate/target/project-scores/gene_identifiers_latest.parquet"
-      }
-      project_scores_essentiality_matrix: {
-        format: "parquet"
-        path: ${common.path}"/intermediate/target/project-scores/04_binaryDepScores.parquet"
-      }
-      reactome_etl: {
-        format: "parquet"
-        path: ${common.path}"/intermediate/reactome/part*"
-      }
-      reactome_pathways: {
-        format: "csv"
-        path: ${common.path}"/input/target/reactome/Ensembl2Reactome.txt"
-        options: [
-          { k: "sep", v: "\\t" }
-        ]
-      }
-      safety_evidence: {
-        format: "parquet"
-        path: ${common.path}"/intermediate/target/safety.parquet"
-      }
-      tep: {
-        format: "json"
-        path: ${common.path}"/input/target/tep/tep.json.gz"
-      },
-      tractability: {
-        format: "csv"
-        path: ${common.path}"/input/target/tractability/tractability.tsv"
-        options: [
-          { k: "sep",    v: "\\t" }
-          { k: "header", v: true  }
-        ]
-      }
-      uniprot: {
-        format: "txt"
-        path: ${common.path}"/input/target/uniprot/uniprot.txt.gz"
-      }
-      uniprot_ssl: {
-        format: "csv"
-        path: ${common.path}"/input/target/uniprot/uniprot-ssl.tsv.gz"
-        options: [
-          { k: "sep",    v: "\\t" }
-          { k: "header", v: true  }
-        ]
-      }
-      gene_essentiality: {
-        format: "parquet"
-        path: ${common.path}"/intermediate/target/gene-essentiality/essentiality.parquet"
-      }
-    }
-    output: {
-      target: {
-        format: ${common.output_format}
-        path: ${common.output_path}"/output/target"
-      }
-      gene_essentiality: {
-        format: ${common.output_format}
-        path: ${common.output_path}"/output/target_essentiality"
-      }
-    }
-    hgnc_ortholog_species: [
-      "9606-human"
-      "9598-chimpanzee"
-      "9544-macaque"
-      "10090-mouse"
-      "10116-rat"
-      "9986-rabbit"
-      "10141-guineapig"
-      "9615-dog"
-      "9823-pig"
-      "8364-frog"
-      "7955-zebrafish"
-      "7227-fly"
-      "6239-worm"
-    ]
-  }
-
   search_facet: {
     input: {
       diseases: {
         format: "parquet"
         path: ${common.path}"/output/disease"
       }
-      targets: ${steps.target.output.target}
+      targets: {
+        format: ${common.output_format}
+        path: ${common.output_path}"/output/target"
+      }
       go: ${steps.go.output.go}
     }
     output: {
@@ -357,7 +163,10 @@ steps: {
         format: ${common.output_format}
         path: ${common.path}"/output/drug_mechanism_of_action"
       }
-      target: ${steps.target.output.target}
+      target: {
+        format: ${common.output_format}
+        path: ${common.output_path}"/output/target"
+      }
       credible_sets: {
         format: "parquet"
         path: ${common.path}"/output/credible_set"
@@ -473,7 +282,10 @@ steps: {
         format: "parquet"
         path: ${common.path}"/output/disease"
       }
-      target: ${steps.target.output.target}
+      target: {
+        format: ${common.output_format}
+        path: ${common.output_path}"/output/target"
+      }
       evidence: {
         format: ${common.output_format}
         path: ${common.path}"/output/evidence_gwas_credible_sets"
@@ -509,7 +321,10 @@ steps: {
         format: "parquet"
         path: ${common.path}"/output/disease"
       }
-      processing_targets: ${steps.target.output.target}
+      processing_targets: {
+        format: ${common.output_format}
+        path: ${common.output_path}"/output/target"
+      }
       processing_drugs: {
         format: ${common.output_format}
         path: ${common.path}"/output/drug_molecule"

--- a/src/orchestration/dags/config/pts.yaml
+++ b/src/orchestration/dags/config/pts.yaml
@@ -158,8 +158,8 @@ steps:
       transformer: so
   ##################################################################################################
 
-  #: TARGET STEP :##################################################################################
-  target:
+  #: PRE_TARGET STEP :##############################################################################
+  pre_target:
     - name: unzip subcellular location
       source: input/target/hpa/subcellular_location.tsv.zip
       destination: intermediate/target/hpa/subcellular_location.tsv
@@ -206,6 +206,48 @@ steps:
           source: ${uri}
           destination: intermediate/target/homologue/gene_dictionary/${match_path}/${match_stem}.parquet
           transformer: homology
+
+    - name: transform uniprot
+      transformer: uniprot
+      source: input/target/uniprot/uniprot.txt.gz
+      destination: intermediate/target/uniprot/uniprot.parquet
+  ##################################################################################################
+
+  #: TARGET STEP (pyspark) :#######################################################################
+  target:
+    - name: pyspark target
+      pyspark: target
+      source:
+        diseases: output/disease
+        ensembl: intermediate/target/ensembl/homo_sapiens.parquet
+        gene_code: input/target/gencode/gencode.gff3.gz
+        genetic_constraints: input/target/gnomad/gnomad_constraint_metrics.tsv
+        gene_ontology_human: input/target/go/goa_human.gaf.gz
+        gene_ontology_rna: input/target/go/goa_human_rna.gaf.gz
+        gene_ontology_rna_lookup: input/target/go/ensembl.tsv
+        gene_ontology_eco_lookup: input/target/go/goa_human_eco.gpa.gz
+        hallmarks: input/target/hallmarks/cosmic-hallmarks.tsv.gz
+        hgnc: input/target/genenames/hgnc_complete_set.json
+        homology_dictionary: input/target/homologue/species_EnsemblVertebrates.txt
+        homology_coding_proteins: input/target/homologue/homologies/*.tsv.gz
+        homology_gene_dictionary: intermediate/target/homologue/gene_dictionary/*.parquet
+        hpa: intermediate/target/hpa/subcellular_location.tsv.gz
+        hpa_sl: intermediate/target/hpa/subcellular_locations_ssl.parquet
+        ncbi: input/target/ncbi/Homo_sapiens.gene_info.gz
+        project_scores_ids: intermediate/target/project-scores/gene_identifiers_latest.parquet
+        project_scores_essentiality_matrix: intermediate/target/project-scores/04_binaryDepScores.parquet
+        reactome_etl: output/reactome
+        reactome_pathways: input/target/reactome/Ensembl2Reactome.txt
+        safety_evidence: intermediate/target/safety.parquet
+        tep: input/target/tep/tep.json.gz
+        tractability: input/target/tractability/tractability.tsv
+        uniprot: intermediate/target/uniprot/uniprot.parquet
+        chembl: input/target/chembl/chembl_target.jsonl
+        chemical_probes: intermediate/chemical_probes_evidence.parquet
+        gene_essentiality: intermediate/target/gene-essentiality/essentiality.parquet
+      destination:
+        target: output/target
+        gene_essentiality: output/target_essentiality
   ##################################################################################################
 
   #: TARGET_SAFETY STEP :############### - part of target, pyspark tasks must run standalone for now

--- a/src/orchestration/dags/config/unified_pipeline.yaml
+++ b/src/orchestration/dags/config/unified_pipeline.yaml
@@ -113,7 +113,7 @@ steps:
       - pis_expression
   pts_mouse_phenotype:
     depends_on:
-      - etl_target
+      - pts_target
       - pis_impc
   pts_chemical_probes:
     depends_on:
@@ -130,7 +130,7 @@ steps:
   pts_so:
     depends_on:
       - pis_so
-  pts_target:
+  pts_pre_target:
     depends_on:
       - pis_target
   pts_target_safety:
@@ -150,69 +150,69 @@ steps:
     depends_on:
       - etl_literature
       - pis_literature
-      - etl_target
+      - pts_target
       - pts_disease
   pts_evidence_postprocess_gwas_credible_sets:
     depends_on:
       - gentropy_l2g_evidence
       - pis_literature
       - pts_disease
-      - etl_target
+      - pts_target
       - pis_literature
   pts_evidence_postprocess_expression_atlas:
     depends_on:
       - pis_evidence_expression_atlas
-      - etl_target
+      - pts_target
       - pts_disease
       - pis_literature
   pts_evidence_postprocess_cosmic:
     depends_on:
       - pis_evidence_cosmic
-      - etl_target
+      - pts_target
       - pts_disease
       - pis_literature
   pts_evidence_postprocess_clinvar:
     depends_on:
       - pis_evidence_eva
-      - etl_target
+      - pts_target
       - pts_disease
       - pis_literature
   pts_evidence_postprocess_clinvar_somatic:
     depends_on:
       - pis_evidence_eva
-      - etl_target
+      - pts_target
       - pts_disease
       - pis_literature
   pts_evidence_postprocess_reactome:
     depends_on:
       - pis_evidence_reactome
-      - etl_target
+      - pts_target
       - pts_disease
       - pis_literature
   pts_evidence_postprocess_uniprot_literature:
     depends_on:
       - pis_evidence_uniprot_literature
-      - etl_target
+      - pts_target
       - pts_disease
       - pis_literature
   pts_evidence_postprocess_uniprot_variants:
     depends_on:
       - pis_evidence_uniprot_variants
-      - etl_target
+      - pts_target
       - pts_disease
       - pis_literature
   pts_evidence_postprocess_encore:
     ppp_only: true
     depends_on:
       - pis_evidence_ppp # TODO: split
-      - etl_target
+      - pts_target
       - pts_disease
       - pis_literature
   pts_evidence_postprocess_validation_lab:
     ppp_only: true
     depends_on:
       - pis_evidence_ppp # TODO: split
-      - etl_target
+      - pts_target
       - pts_disease
   # Evidence processed by PTS
   pts_evidence_project_score:
@@ -222,7 +222,7 @@ steps:
   pts_evidence_postprocess_project_score:
     depends_on:
       - pts_evidence_project_score
-      - etl_target
+      - pts_target
       - pts_disease
   pts_evidence_gene_burden:
     depends_on:
@@ -231,7 +231,7 @@ steps:
   pts_evidence_postprocess_gene_burden:
     depends_on:
       - pts_evidence_gene_burden
-      - etl_target
+      - pts_target
       - pts_disease
       - pis_literature
   pts_evidence_clinical_precedence:
@@ -250,7 +250,7 @@ steps:
       - pts_evidence_cancer_biomarkers
       - pts_disease
       - pis_literature
-      - etl_target
+      - pts_target
   pts_evidence_orphanet:
     depends_on:
       - pis_evidence_orphanet
@@ -258,7 +258,7 @@ steps:
   pts_evidence_postprocess_orphanet:
     depends_on:
       - pts_evidence_orphanet
-      - etl_target
+      - pts_target
       - pts_disease
       - pis_literature
   pts_evidence_clingen:
@@ -268,7 +268,7 @@ steps:
   pts_evidence_postprocess_clingen:
     depends_on:
       - pts_evidence_clingen
-      - etl_target
+      - pts_target
       - pts_disease
       - pis_literature
   pts_evidence_impc:
@@ -279,7 +279,7 @@ steps:
     num_partitions: 100
     depends_on:
       - pts_evidence_impc
-      - etl_target
+      - pts_target
       - pts_disease
       - pis_literature
   pts_evidence_panel_app:
@@ -289,7 +289,7 @@ steps:
   pts_evidence_postprocess_panel_app:
     depends_on:
       - pts_evidence_panel_app
-      - etl_target
+      - pts_target
       - pis_literature
       - pts_disease
   pts_evidence_crispr_screens:
@@ -298,7 +298,7 @@ steps:
   pts_evidence_postprocess_crispr_screens:
     depends_on:
       - pts_evidence_crispr_screens
-      - etl_target
+      - pts_target
       - pts_disease
       - pis_literature
   pts_evidence_gene2phenotype:
@@ -308,7 +308,7 @@ steps:
   pts_evidence_postprocess_gene2phenotype:
     depends_on:
       - pts_evidence_gene2phenotype
-      - etl_target
+      - pts_target
       - pts_disease
       - pis_literature
   pts_evidence_intogen:
@@ -317,7 +317,7 @@ steps:
   pts_evidence_postprocess_intogen:
     depends_on:
       - pts_evidence_intogen
-      - etl_target
+      - pts_target
       - pts_disease
       - pis_literature
   pts_evidence_ot_crispr:
@@ -328,7 +328,7 @@ steps:
     ppp_only: true
     depends_on:
       - pts_evidence_ot_crispr
-      - etl_target
+      - pts_target
       - pts_disease
       - pis_literature
 
@@ -342,7 +342,7 @@ steps:
   pts_drug_mechanism_of_action:
     depends_on:
       - pis_drug
-      - pts_target
+      - pts_pre_target
   pts_drug_molecule:
     depends_on:
       - pts_chemical_probes
@@ -410,23 +410,23 @@ steps:
     depends_on:
       - pis_otar
       - pts_disease
-  etl_target:
+  pts_target:
     num_partitions: 10
     depends_on:
-      - pts_disease
-      - pts_target
+      - pts_pre_target
       - pts_reactome
       - pts_target_safety
       - pts_target_gene_essentiality
+      - pts_disease
   etl_search_facet:
     depends_on:
       - pts_disease
       - pts_go
-      - etl_target
+      - pts_target
   etl_interaction:
     depends_on:
       - pis_interaction
-      - etl_target
+      - pts_target
   etl_openfda:
     depends_on:
       - pts_openfda
@@ -452,15 +452,14 @@ steps:
   gentropy_enhancer_to_gene:
     depends_on:
       - pis_encode
-      - etl_target
+      - pts_target
       - gentropy_biosample
   gentropy_study:
     depends_on:
       - pis_gwas
       - pis_molqtl
-      - pts_target
+      - pts_pre_target
       - pts_disease
-      - etl_target
       - gentropy_biosample
     depends_on_ppp:
       - pis_gwas_ppp


### PR DESCRIPTION
## Summary

- Rename `pts_target:` step definition → `pts_pre_target:` in `unified_pipeline.yaml` (preprocessing step)
- Remove `etl_target:` block from `unified_pipeline.yaml`
- Add `pts_target:` block with correct dependencies (pts_pre_target, pts_reactome, pts_target_safety, pts_target_gene_essentiality, pts_disease)
- Replace all 26 occurrences of `- etl_target` with `- pts_target` in `unified_pipeline.yaml`
- Update `gentropy_study` and `pts_drug_mechanism_of_action` depends_on to reference `pts_pre_target`
- Rename `target:` → `pre_target:` in `pts.yaml` and add new `target:` pyspark step
- Remove `target { ... }` block from `etl.conf`, leaving a stub with output path

## Validation

```
grep "etl_target" src/orchestration/dags/config/unified_pipeline.yaml
# Expected: empty output ✓
```

## Test plan

- [x] No `etl_target` references remain in `unified_pipeline.yaml`
- [ ] DAG validation in staging environment

Tracking issue: https://github.com/opentargets/issues/issues/4347