### PR TITLE
chore: migrate etl_search_facet → pts_search_facet

### DIFF
--- a/src/orchestration/dags/config/etl.conf
+++ b/src/orchestration/dags/config/etl.conf
@@ -85,47 +85,6 @@ steps: {
     }
   }
 
-  search_facet: {
-    input: {
-      diseases: {
-        format: "parquet"
-        path: ${common.path}"/output/disease"
-      }
-      targets: {
-        format: ${common.output_format}
-        path: ${common.output_path}"/output/target"
-      }
-      go: ${steps.go.output.go}
-    }
-    output: {
-      targets: {
-        format: ${common.output_format}
-        path: ${common.output_path}"/view/search_facet_target"
-      }
-      diseases: {
-        format: ${common.output_format}
-        path: ${common.output_path}"/view/search_facet_disease"
-      }
-    }
-    categories: {
-      disease_name: "Disease"
-      therapeutic_area: "Therapeutic Area"
-      sm: "Tractability Small Molecule"
-      ab: "Tractability Antibody"
-      pr: "Tractability PROTAC"
-      oc: "Tractability Other Modalities"
-      target_id: "Target ID"
-      approved_symbol: "Approved Symbol"
-      approved_name: "Approved Name"
-      subcellular_location: "Subcellular Location"
-      target_class: "ChEMBL Target Class"
-      pathways: "Reactome"
-      go_f: "GO:MF"
-      go_p: "GO:BP"
-      go_c: "GO:CC"
-    }
-  }
-
   go: {
     input: {
       go: {

--- a/src/orchestration/dags/config/pts.yaml
+++ b/src/orchestration/dags/config/pts.yaml
@@ -1644,6 +1644,19 @@ steps:
         spark.driver.memory: 12g
   ##################################################################################################
 
+  #: SEARCH FACET STEP :###########################################################################
+  search_facet:
+    - name: pyspark search_facet
+      pyspark: search_facet
+      source:
+        diseases: output/disease
+        targets: output/target
+        go: output/go
+      destination:
+        targets: view/search_facet_target
+        diseases: view/search_facet_disease
+  ##################################################################################################
+
   #: RELEASE METRICS STEP :##########################################################################
   release_metrics:
     - name: transform release_metrics

--- a/src/orchestration/dags/config/unified_pipeline.yaml
+++ b/src/orchestration/dags/config/unified_pipeline.yaml
@@ -404,7 +404,6 @@ steps:
   # pts_release_metrics:
   #   depends_on:
   #     - pts_association
-  # ETL STEPS
   pts_otar:
     ppp_only: true
     depends_on:
@@ -418,11 +417,12 @@ steps:
       - pts_target_safety
       - pts_target_gene_essentiality
       - pts_disease
-  etl_search_facet:
+  pts_search_facet:
     depends_on:
       - pts_disease
       - pts_go
       - pts_target
+  # ETL STEPS
   etl_interaction:
     depends_on:
       - pis_interaction


### PR DESCRIPTION
## Summary

- Replaces `etl_search_facet` with `pts_search_facet` in `unified_pipeline.yaml` (depends_on: pts_disease, pts_go, pts_target)
- Adds `search_facet:` step block to `pts.yaml`
- Removes `search_facet` block from `etl.conf`

## References

https://github.com/opentargets/issues/issues/4347

## Test plan

- [x] `unified_pipeline.yaml` updated: `etl_search_facet` removed, `pts_search_facet` added with correct dependencies
- [x] `pts.yaml` has new `search_facet` step block
- [x] `etl.conf` no longer contains `search_facet` block