### PR TITLE
chore: migrate etl_interaction → pts_interaction

### DIFF
--- a/src/orchestration/dags/config/etl.conf
+++ b/src/orchestration/dags/config/etl.conf
@@ -23,68 +23,6 @@ spark_settings: {
 # ============================= STEP CONFIGURATION =============================
 steps: {
 
-  interaction: {
-    scorethreshold: 0
-    string_version: "12"
-    input: {
-      targets: {
-        format: ${common.output_format}
-        path: ${common.output_path}"/output/target"
-      }
-      rnacentral: {
-        format: "csv"
-        path: ${common.path}"/input/interaction/rna_central_ensembl.tsv"
-        options: [
-          { k: "sep",    v: "\\t" }
-          { k: "header", v: false }
-        ]
-      }
-      humanmapping: {
-        format: "csv"
-        path: ${common.path}"/input/interaction/HUMAN_9606_idmapping.dat.gz"
-        options: [
-          { k: "sep",    v: "\\t" }
-          { k: "header", v: false }
-        ]
-      }
-      ensproteins: {
-        format: "csv"
-        path: ${common.path}"/input/interaction/Homo_sapiens.GRCh38.chr.gtf.gz"
-        options: [
-          { k: "sep",     v: "\\t" }
-          { k: "header",  v: false }
-          { k: "comment", v: "#"   }
-        ]
-      }
-      intact: {
-        format: "json"
-        path: ${common.path}"/input/interaction/intact-interactors.json"
-      }
-      strings: {
-        format: "csv"
-        path: ${common.path}"/input/interaction/string-interactions.txt.gz"
-        options: [
-          { k: "sep",    v: " "  }
-          { k: "header", v: true }
-        ]
-      }
-    }
-    output: {
-      interactions: {
-        format: ${common.output_format}
-        path: ${common.path}"/output/interaction"
-      }
-      interactions_evidence: {
-        format: ${common.output_format}
-        path: ${common.path}"/output/interaction_evidence"
-      }
-      interactions_unmatched: {
-        format: ${common.output_format}
-        path: ${common.path}"/excluded/interaction"
-      }
-    }
-  }
-
   go: {
     input: {
       go: {

--- a/src/orchestration/dags/config/pts.yaml
+++ b/src/orchestration/dags/config/pts.yaml
@@ -1657,6 +1657,25 @@ steps:
         diseases: view/search_facet_disease
   ##################################################################################################
 
+  #: INTERACTION STEP :############################################################################
+  interaction:
+    - name: pyspark interaction
+      pyspark: interaction
+      source:
+        targets: output/target
+        rnacentral: input/interaction/rna_central_ensembl.tsv
+        humanmapping: input/interaction/HUMAN_9606_idmapping.dat.gz
+        ensproteins: input/interaction/Homo_sapiens.GRCh38.chr.gtf.gz
+        intact: input/interaction/intact-interactors.json
+        strings: input/interaction/string-interactions.txt.gz
+      destination:
+        interactions: output/interaction
+        interactions_evidence: output/interaction_evidence
+        interactions_unmatched: excluded/interaction
+      settings:
+        scorethreshold: 0
+  ##################################################################################################
+
   #: RELEASE METRICS STEP :##########################################################################
   release_metrics:
     - name: transform release_metrics

--- a/src/orchestration/dags/config/unified_pipeline.yaml
+++ b/src/orchestration/dags/config/unified_pipeline.yaml
@@ -422,8 +422,8 @@ steps:
       - pts_disease
       - pts_go
       - pts_target
-  # ETL STEPS
-  etl_interaction:
+
+  pts_interaction:
     depends_on:
       - pis_interaction
       - pts_target
@@ -491,7 +491,7 @@ steps:
   gentropy_l2g_training:
     depends_on:
       - pis_l2g
-      - etl_interaction
+      - pts_interaction
       - gentropy_l2g_feature_matrix
   gentropy_l2g_prediction:
     depends_on:


### PR DESCRIPTION
## Summary

- Replaces `etl_interaction` with `pts_interaction` in `unified_pipeline.yaml`
- Adds `interaction:` step block to `pts.yaml`
- Removes `interaction: { ... }` block from `etl.conf`
- Updates `gentropy_l2g_training.depends_on` to reference `pts_interaction` instead of `etl_interaction`

Related PRs:
- pts: https://github.com/opentargets/pts/pull/101
- platform-etl-backend: https://github.com/opentargets/platform-etl-backend/pull/424

Closes https://github.com/opentargets/issues/issues/4347

## Test plan

- [x] All config files parse correctly (YAML/HOCON structure verified)
- [x] No remaining `${steps.interaction...}` HOCON references in `etl.conf`
- [x] `gentropy_l2g_training` dependency updated to `pts_interaction`

🤖 Generated with [Claude Code](https://claude.com/claude-code)