### PR TITLE
feat(openfda): remove etl_openfda, merge into pts_openfda

### DIFF
--- a/src/orchestration/dags/config/clusters.yaml
+++ b/src/orchestration/dags/config/clusters.yaml
@@ -118,6 +118,21 @@ clusters:
       - 'gs://genetics_etl_python_playground/initialisation/install_dependencies_on_cluster.sh'
     idle_delete_ttl: 1800
 
+  pts_openfda:
+    image_version: '2.2'
+    num_masters: 1
+    num_workers: 2
+    autoscaling_policy: otg-etl-25-secondary
+    worker_machine_type: n1-standard-8
+    master_disk_size: 512
+    worker_disk_size: 128
+    idle_delete_ttl: 3600
+    internal_ip_only: false
+    metadata:
+      PTS_REF: 'v{{pts_version}}'
+    init_actions_uris:
+      - 'gs://opentargets-pipelines/up/pts/install_dependencies_on_cluster.sh'
+
   pts_association:
     image_version: '2.2'
     num_masters: 1

--- a/src/orchestration/dags/config/etl.conf
+++ b/src/orchestration/dags/config/etl.conf
@@ -113,66 +113,6 @@ steps: {
     }
   }
 
-  openfda: {
-    input: {
-      chembl_drugs: {
-        format: ${common.output_format}
-        path: ${common.path}"/output/drug_molecule"
-      }
-      blacklisted_events: {
-        format: "csv"
-        path: ${common.path}"/input/openfda/blacklisted_events.txt"
-        options: [
-          { k: "sep",                      v: "\\t" }
-          { k: "ignoreLeadingWhiteSpace",  v: true  }
-          { k: "ignoreTrailingWhiteSpace", v: true  }
-        ]
-      }
-      fda_data: {
-        format: ${common.output_format}
-        path: ${common.path}"/intermediate/openfda/*"
-      }
-      meddra_preferred_terms: {
-        format: "csv"
-        path: "gs://open-targets-data-releases-private/meddra/meddra23.1/MedAscii/pt.asc"
-      }
-      meddra_low_level_terms: {
-        format: "csv"
-        path: "gs://open-targets-data-releases-private/meddra/meddra23.1/MedAscii/llt.asc"
-      }
-    }
-    output: {
-      fda_unfiltered: {
-        format: ${common.output_format}
-        path: ${common.output_path}"/intermediate/openfda_adverse_drug_reactions"
-      }
-      fda_results: {
-        format: ${common.output_format}
-        path: ${common.output_path}"/output/openfda_significant_adverse_drug_reactions"
-      }
-      sampling: {
-        format: ${common.output_format}
-        path: ${common.output_path}"/intermediate/openfda_sample"
-      }
-    }
-    meddra_preferred_terms_cols: [
-      "pt_code"
-      "pt_name"
-    ]
-    meddra_low_level_terms_cols: [
-      "llt_code"
-      "llt_name"
-    ]
-    montecarlo: {
-      permutations: 100
-      percentile: 0.95
-    }
-    sampling: {
-      size: 0.1
-      enabled: false
-    }
-  }
-
   search_ebi: {
     input: {
       disease: {

--- a/src/orchestration/dags/config/unified_pipeline.yaml
+++ b/src/orchestration/dags/config/unified_pipeline.yaml
@@ -127,6 +127,7 @@ steps:
   pts_openfda:
     depends_on:
       - pis_openfda
+      - pts_drug_molecule
   pts_so:
     depends_on:
       - pis_so
@@ -427,10 +428,7 @@ steps:
     depends_on:
       - pis_interaction
       - pts_target
-  etl_openfda:
-    depends_on:
-      - pts_openfda
-      - pts_drug_molecule
+
   etl_literature:
     num_partitions: 1000
     depends_on:


### PR DESCRIPTION
## Summary

- Removes `etl_openfda` step from `unified_pipeline.yaml`
- Removes `openfda:` block from `etl.conf`
- Adds `pts_drug_molecule` dependency to `pts_openfda`

Part of opentargets/issues#4347