### PR TITLE
replace etl_search_ebi with pts_search_ebi

### DIFF
--- a/src/orchestration/dags/config/etl.conf
+++ b/src/orchestration/dags/config/etl.conf
@@ -38,37 +38,6 @@ steps: {
     }
   }
 
-  search_ebi: {
-    input: {
-      disease: {
-        format: "parquet"
-        path: ${common.path}"/output/disease"
-      }
-      target: {
-        format: ${common.output_format}
-        path: ${common.output_path}"/output/target"
-      }
-      evidence: {
-        format: ${common.output_format}
-        path: ${common.path}"/output/evidence_gwas_credible_sets"
-      }
-      association: {
-        format: ${common.output_format}
-        path: ${common.path}"/output/association_overall_direct"
-      }
-    }
-    output: {
-      associations: {
-        format: ${common.output_format}
-        path: ${common.output_path}"/view/search_ebi_associations"
-      }
-      evidence: {
-        format: ${common.output_format}
-        path: ${common.output_path}"/view/search_ebi_evidence"
-      }
-    }
-  }
-
   literature: {
     input: {
       processing_epmcids: {

--- a/src/orchestration/dags/config/pts.yaml
+++ b/src/orchestration/dags/config/pts.yaml
@@ -1727,3 +1727,20 @@ steps:
         drugs: view/search_drug
         variants: view/search_variant
         studies: view/search_study
+
+  ##################################################################################################
+
+  #: SEARCH EBI STEP :##############################################################################
+  search_ebi:
+    - name: pyspark search_ebi
+      pyspark: search_ebi
+      source:
+        disease: output/disease
+        target: output/target
+        association: output/association_overall_direct
+        evidence: output/evidence_gwas_credible_sets
+      destination:
+        associations: view/search_ebi_associations
+        evidence: view/search_ebi_evidence
+      properties:
+        spark.driver.memory: 8g

--- a/src/orchestration/dags/config/unified_pipeline.yaml
+++ b/src/orchestration/dags/config/unified_pipeline.yaml
@@ -442,7 +442,8 @@ steps:
       - pts_drug_molecule
       - pts_target
       - pts_disease
-  etl_search_ebi:
+
+  pts_search_ebi:
     depends_on:
       - pts_association
 


### PR DESCRIPTION
## Summary
- Replaces `etl_search_ebi` with `pts_search_ebi` in `unified_pipeline.yaml`
- Removes `search_ebi` block from `etl.conf`

## Test plan
- [ ] Verify `pts_search_ebi` step appears in DAG with correct dependency on `pts_association`

Part of opentargets/issues#4347