### PR TITLE
perf(pts_association): upgrade to n2d-highmem-16 with tuned executor config

### DIFF
--- a/src/orchestration/dags/config/clusters.yaml
+++ b/src/orchestration/dags/config/clusters.yaml
@@ -122,17 +122,17 @@ clusters:
     image_version: '2.2'
     num_masters: 1
     num_workers: 2
-    worker_machine_type: n2d-standard-16
+    worker_machine_type: n2d-highmem-16
     master_disk_size: 128
     worker_disk_size: 128
     idle_delete_ttl: 3600
     internal_ip_only: false
     metadata:
       PTS_REF: 'v{{pts_version}}'
-      # Each n1-standard-16 worker has ~60 GB RAM and 16 cores.
-      # Reserving 1 core and ~4 GB for YARN/OS overhead leaves ~56 GB and 15 cores per worker.
-      # With 5 cores per executor, that's 3 executors per worker node × 2 workers = 6 max,
-      # but keeping it at 4 initial executors (2 per node) with ~18 GB each leaves comfortable headroom and avoids excessive GC pressure.
+      # Each n2d-highmem-16 worker has ~128 GB RAM and 16 cores.
+      # With 34 GB memory + 2 GB overhead = 36 GB per executor container,
+      # 3 executors fit per worker (3 × 36 GB = 108 GB), giving 6 executors × 5 cores = 30 Spark cores.
+      # This eliminates memory spill (previously ~1 TB per run) and yields ~20% wall-time improvement.
     properties:
       # ── Driver Configuration ──
       'spark:spark.driver.memory': '18g'
@@ -140,17 +140,15 @@ clusters:
       'spark:spark.driver.cores': '5'
 
       # ── Executor Configuration ──
-      'spark:spark.executor.instances': '4'
+      'spark:spark.executor.instances': '6'
       'spark:spark.executor.cores': '5'
-      'spark:spark.executor.memory': '18g'
+      'spark:spark.executor.memory': '34g'
       'spark:spark.executor.memoryOverhead': '2g'
 
       # ── Parallelism & Partitions ──
-      'spark:spark.default.parallelism': '40'
-      # The probable output sizes range between 600MiB to 2GiB so partition should be around max 100 MiB
-      # including the overhead of multiple compressed files.
-      # FIXME: This is a temporary setting to reduce the partition number for the association step.
-      'spark:spark.sql.shuffle.partitions': '25'
+      'spark:spark.default.parallelism': '60'
+      # 60 partitions = 2 full waves of 30 Spark cores with no idle tail.
+      'spark:spark.sql.shuffle.partitions': '60'
 
       # ── Dynamic Allocation ──
       'spark:spark.dynamicAllocation.enabled': 'true'


### PR DESCRIPTION
## Summary

- Upgrades `pts_association` worker machine type from `n2d-standard-16` to `n2d-highmem-16` (64 GB → 128 GB RAM per worker)
- Fits 3 executors per worker (up from 2) with 34 GB memory each, eliminating ~1 TB of memory spill per run
- Increases `spark.sql.shuffle.partitions` from 25 to 60, aligning with 30 total Spark cores (2 full waves, no idle tail)

## Context

Ref: opentargets/issues#4375

Benchmarking on the `26.03-ppp.1` dataset showed the previous configuration was severely memory-bound. With `n2d-standard-16`, each executor had only ~2.2 GB of execution memory per task, causing ~1 TB of spill to disk per run. The `n2d-highmem-16` machines allow 3 executors per worker at 34 GB each, raising per-task execution memory to ~4.1 GB and eliminating spill entirely.

## Results

| Metric | Before | After |
|---|---|---|
| Worker machine | n2d-standard-16 (64 GB) | n2d-highmem-16 (128 GB) |
| Executors | 4 × 18 GB | 6 × 34 GB |
| Shuffle partitions | 25 | 60 |
| Memory spill | ~1 TB | 0 bytes |
| Wall time | ~45m | ~35m (~20% faster) |

## Test plan

- [x] Benchmarked against `gs://open-targets-pipeline-runs/sz/26.03-ppp.1` inputs
- [x] Output written to `gs://ot-team/dsuveges/association_optimalisation` and verified complete
- [x] Zero task failures across all runs