### PR TITLE
perf(pts_association): simplify cluster + tune partitioning

### DIFF
--- a/src/orchestration/dags/config/clusters.yaml
+++ b/src/orchestration/dags/config/clusters.yaml
@@ -137,55 +137,14 @@ clusters:
     image_version: '2.2'
     num_masters: 1
     num_workers: 2
-    worker_machine_type: n2d-standard-16
-    master_disk_size: 128
-    worker_disk_size: 128
+    autoscaling_policy: otg-etl-25-secondary
+    worker_machine_type: n2d-highmem-32
+    master_disk_size: 512
+    worker_disk_size: 256
     idle_delete_ttl: 3600
     internal_ip_only: false
     metadata:
       PTS_REF: 'v{{pts_version}}'
-      # Each n1-standard-16 worker has ~60 GB RAM and 16 cores.
-      # Reserving 1 core and ~4 GB for YARN/OS overhead leaves ~56 GB and 15 cores per worker.
-      # With 5 cores per executor, that's 3 executors per worker node × 2 workers = 6 max,
-      # but keeping it at 4 initial executors (2 per node) with ~18 GB each leaves comfortable headroom and avoids excessive GC pressure.
-    properties:
-      # ── Driver Configuration ──
-      'spark:spark.driver.memory': '18g'
-      'spark:spark.driver.memoryOverhead': '2g'
-      'spark:spark.driver.cores': '5'
-
-      # ── Executor Configuration ──
-      'spark:spark.executor.instances': '4'
-      'spark:spark.executor.cores': '5'
-      'spark:spark.executor.memory': '18g'
-      'spark:spark.executor.memoryOverhead': '2g'
-
-      # ── Parallelism & Partitions ──
-      'spark:spark.default.parallelism': '40'
-      # The probable output sizes range between 600MiB to 2GiB so partition should be around max 100 MiB
-      # including the overhead of multiple compressed files.
-      # FIXME: This is a temporary setting to reduce the partition number for the association step.
-      'spark:spark.sql.shuffle.partitions': '25'
-
-      # ── Dynamic Allocation ──
-      'spark:spark.dynamicAllocation.enabled': 'true'
-
-      # ── Memory Management ──
-      'spark:spark.memory.fraction': '0.6'
-      'spark:spark.memory.storageFraction': '0.5'
-
-      # ── Shuffle & Compression ──
-      'spark:spark.shuffle.compress': 'true'
-      'spark:spark.shuffle.spill.compress': 'true'
-      'spark:spark.io.compression.codec': 'snappy'
-
-      # ── Serialization ──
-      'spark:spark.serializer': 'org.apache.spark.serializer.KryoSerializer'
-
-      # ── Adaptive Query Execution (Spark 3.x) ──
-      'spark:spark.sql.adaptive.enabled': 'true'
-      'spark:spark.sql.adaptive.coalescePartitions.enabled': 'true'
-      'spark:spark.sql.adaptive.skewJoin.enabled': 'true'
     init_actions_uris:
       - 'gs://opentargets-pipelines/up/pts/install_dependencies_on_cluster.sh'
 

--- a/src/orchestration/dags/config/clusters.yaml
+++ b/src/orchestration/dags/config/clusters.yaml
@@ -145,6 +145,9 @@ clusters:
     internal_ip_only: false
     metadata:
       PTS_REF: 'v{{pts_version}}'
+    properties:
+      'spark:spark.sql.shuffle.partitions': '2000'
+      'spark:spark.sql.adaptive.advisoryPartitionSizeInBytes': '64MB'
     init_actions_uris:
       - 'gs://opentargets-pipelines/up/pts/install_dependencies_on_cluster.sh'
 


### PR DESCRIPTION
## Summary

Parallel solution to [opentargets/issues#4375](https://github.com/opentargets/issues/issues/4375) ([#185](https://github.com/opentargets/orchestration/pull/185) is the other in-flight proposal). The companion algorithmic refactor lives in [opentargets/pts#114](https://github.com/opentargets/pts/pull/114). This PR is just the cluster definition.

### Cluster simplification (Tier 1)
Replaces the previous 35-property block with a minimal definition that relies on Dataproc 2.2 defaults:
- 1 master + 2 primary workers, both `n2d-highmem-32`
- `otg-etl-25-secondary` autoscaling policy (existing)
- master 512 GB, worker 256 GB disks
- `idle_delete_ttl: 3600`, `internal_ip_only: false`
- No explicit Spark/YARN/dynamic-allocation tuning

### Targeted sizing overrides (Tier 2, second commit)
- `spark.sql.shuffle.partitions=2000`
- `spark.sql.adaptive.advisoryPartitionSizeInBytes=64MB`

These two properties give finer-grained tasks, which generates more YARN backlog so the autoscaler ramps more aggressively, and reduces per-task memory footprint.

## Manual benchmark on 26.03-ppp.1

| Run | Config | Wall time |
|---|---|---|
| Reference | Legacy `pts_association` (35 properties) | ~34 min |
| Run-001 | This PR Tier 1 only | 14m48s |
| **Run-003** | **This PR (Tier 1 + Tier 2 properties)** | **11m41s** |

Per-stage breakdown (Run-001 → Run-003) shows the indirect aggregations save ~1min each from the finer partitioning. Direct stages are essentially flat.

## Test plan

- [x] Cluster create succeeds with these properties (verified manually on `open-targets-eu-dev`).
- [x] PTS association job completes successfully against 26.03-ppp.1 inputs.
- [x] Output validates structurally (rows, schema, composite keys) against the 26.03-ppp.1 reference.
- [x] Companion algorithmic refactor proven deterministic across cluster topologies (Run-002 vs Run-003 = 0 mismatches across 56M rows).

## Companion PR

[opentargets/pts#114](https://github.com/opentargets/pts/pull/114) — algorithmic refactor + determinism fix in `_aggregate_associations`. Should land together with this one.