### PR TITLE
feat(batch): add Pydantic model layer for Google Batch API

### DIFF
--- a/src/orchestration/models/batch/__init__.py
+++ b/src/orchestration/models/batch/__init__.py
@@ -1,0 +1,15 @@
+"""Models representing Google Batch operator-config mapping."""
+
+from orchestration.models.batch.operator import (
+    BatchIndexOperatorSpec,
+    BatchIndexRow,
+    BatchJobOperatorSpec,
+    ManifestGeneratorSpec,
+)
+
+__all__ = [
+    "BatchIndexOperatorSpec",
+    "BatchIndexRow",
+    "BatchJobOperatorSpec",
+    "ManifestGeneratorSpec",
+]

--- a/src/orchestration/models/batch/environment.py
+++ b/src/orchestration/models/batch/environment.py
@@ -110,6 +110,8 @@ class EnvironmentRegistrySpec(BaseModel):
         >>> len(partitions[0].environments)
         3
         """
+        if self.empty:
+            return []
         effective_max_task_count = min(max_task_count, len(self))
         return [
             EnvironmentRegistrySpec(environments=self.environments[i : i + effective_max_task_count])

--- a/src/orchestration/models/batch/environment.py
+++ b/src/orchestration/models/batch/environment.py
@@ -1,0 +1,126 @@
+"""Environment variable specifications for Google Batch tasks."""
+
+from __future__ import annotations
+
+from google.cloud import batch_v1
+from pydantic import BaseModel
+
+
+class EnvironmentSpec(BaseModel):
+    """Environment variable(s) specification for a single task.
+
+    Attributes:
+        variables (dict[str, str]): Dictionary of environment variable(s) for the task.
+    """
+
+    variables: dict[str, str]
+    """Dictionary of environment variable(s) for the task."""
+
+    def build(self) -> batch_v1.Environment:
+        """Build an Environment object from the environment variable specifications.
+
+        Returns:
+            batch_v1.Environment: An Environment object with the specified environment variables.
+
+        Example:
+        ---
+        >>> spec = EnvironmentSpec(variables={"FOO": "bar", "BAZ": "qux"})
+        >>> env = spec.build()
+        >>> isinstance(env, batch_v1.Environment)
+        True
+        >>> env.variables == {"FOO": "bar", "BAZ": "qux"}
+        True
+        """
+        return batch_v1.Environment(variables=self.variables)
+
+
+class EnvironmentRegistrySpec(BaseModel):
+    """Registry of environments.
+
+    Attributes:
+        environments (list[EnvironmentSpec]): List of environment variable(s). Each element of the list is
+            an EnvironmentSpec object representing a single environment (all variable(s) for a single task).
+            Size of the list will be equal to the number of tasks running.
+    """
+
+    environments: list[EnvironmentSpec]
+    """List of environment variable(s). Each element of the list is
+        an EnvironmentSpec object representing a single environment (all variable(s) for a single task).
+        Size of the list will be equal to the number of tasks running.
+    """
+
+    def build(self) -> list[batch_v1.Environment]:
+        """Build a list of Environment objects from the environment variable specifications.
+
+        Returns:
+            list[batch_v1.Environment]: The list of Environment objects with a single set of environment variables each.
+
+        Example:
+        ---
+        >>> registry = EnvironmentRegistrySpec(environments=[
+        ...     EnvironmentSpec(variables={"TASK_INDEX": "0"}),
+        ...     EnvironmentSpec(variables={"TASK_INDEX": "1"}),
+        ... ])
+        >>> envs = registry.build()
+        >>> len(envs)
+        2
+        >>> all(isinstance(e, batch_v1.Environment) for e in envs)
+        True
+        >>> envs[0].variables
+        {'TASK_INDEX': '0'}
+        >>> envs[1].variables
+        {'TASK_INDEX': '1'}
+        """
+        return [env.build() for env in self.environments]
+
+    def __len__(self) -> int:
+        """Return the number of environments in the registry."""
+        return len(self.environments)
+
+    def __getitem__(self, idx: int) -> EnvironmentSpec:
+        """Get the environment specification at the specified index."""
+        return self.environments[idx]
+
+    def partition(self, max_task_count: int) -> list[EnvironmentRegistrySpec]:
+        """Partition the environment registry into batches of a specified maximum size.
+
+        Args:
+            max_task_count (int): The maximum number of tasks (environments) in each partition.
+
+        Returns:
+            list[EnvironmentRegistrySpec]: A list of EnvironmentRegistrySpec objects, each containing a partition of the environments.
+
+        Example:
+        ---
+        >>> registry = EnvironmentRegistrySpec(environments=[
+        ...     EnvironmentSpec(variables={"TASK_INDEX": "0"}),
+        ...     EnvironmentSpec(variables={"TASK_INDEX": "1"}),
+        ...     EnvironmentSpec(variables={"TASK_INDEX": "2"}),
+        ... ])
+        >>> partitions = registry.partition(max_task_count=2)
+        >>> len(partitions)
+        2
+        >>> len(partitions[0].environments)
+        2
+        >>> len(partitions[1].environments)
+        1
+        >>> partitions = registry.partition(max_task_count=10)
+        >>> len(partitions)
+        1
+        >>> len(partitions[0].environments)
+        3
+        """
+        effective_max_task_count = min(max_task_count, len(self))
+        return [
+            EnvironmentRegistrySpec(environments=self.environments[i : i + effective_max_task_count])
+            for i in range(0, len(self.environments), effective_max_task_count)
+        ]
+
+    @property
+    def empty(self) -> bool:
+        """Check if the environment registry is empty."""
+        return len(self.environments) == 0
+
+    def __repr__(self) -> str:
+        """Get environment registry string representation."""
+        return f"EnvironmentRegistrySpec(n={len(self.environments)} environments)"

--- a/src/orchestration/models/batch/instance.py
+++ b/src/orchestration/models/batch/instance.py
@@ -1,0 +1,215 @@
+"""Instance specification for Google Batch tasks."""
+
+from __future__ import annotations
+
+from functools import cached_property
+from typing import Annotated, ClassVar, Literal
+
+from google.cloud import batch_v1
+from pydantic import BaseModel, StringConstraints, model_validator
+
+from orchestration.utils.common import GCP_REGION
+from orchestration.utils.labels import Labels
+
+
+class InstanceSpec(BaseModel):
+    """Machine instance specification for Google Batch tasks.
+
+    This class maps to the :py:class:`google.cloud.batch_v1.AllocationPolicy.InstancePolicy` class used in Google Batch job definitions.
+
+    Attributes:
+        machine_type: Type of machine to be used for the batch task. Must be n*-[standard|highmem|highcpu]-* (e.g., n1-standard-4, n2-highmem-8, etc.).
+        provisioning_model: Provisioning model for the batch task. Must be one of `STANDARD`, `SPOT`, or `PREEMPTIBLE`. The default value is `SPOT`.
+    """
+
+    machine_type: Annotated[str, StringConstraints(pattern=r"^n\d-(standard|highmem|highcpu)-\d+$")] = "n1-standard-4"
+    """Type of machine to be used for the batch task. Must be n*-[standard|highmem|highcpu]-* (e.g., n1-standard-4, n2-highmem-8, etc.)."""
+
+    provisioning_model: Literal["STANDARD", "SPOT", "PREEMPTIBLE"] = "SPOT"
+    """Provisioning model for the batch task. Must be one of `STANDARD`, `SPOT`, or `PREEMPTIBLE`. The default value is `SPOT`."""
+
+    def build(self) -> batch_v1.AllocationPolicy.InstancePolicy:
+        """Build a `google.cloud.batch_v1.AllocationPolicy.InstancePolicy` object from the instance specification.
+
+        Returns:
+            batch_v1.AllocationPolicy.InstancePolicy: The built InstancePolicy object.
+
+        Example:
+        ---
+        >>> spec = InstanceSpec()
+        >>> policy = spec.build()
+        >>> isinstance(policy, batch_v1.AllocationPolicy.InstancePolicy)
+        True
+        >>> policy.machine_type
+        'n1-standard-4'
+        >>> policy.provisioning_model == batch_v1.AllocationPolicy.ProvisioningModel.SPOT
+        True
+        >>> InstanceSpec(machine_type="n2-highmem-8", provisioning_model="STANDARD").build().machine_type
+        'n2-highmem-8'
+        """
+        return batch_v1.AllocationPolicy.InstancePolicy(
+            machine_type=self.machine_type,
+            provisioning_model=batch_v1.AllocationPolicy.ProvisioningModel[self.provisioning_model],
+        )
+
+
+class InstanceResourceSpec(BaseModel):
+    """Resource specification for a single instance.
+
+    Attributes:
+        cpu_milli: CPU resources in milli-CPUs. 1000 = 1 full CPU, 2000 = 2 CPUs, etc.
+        memory_mib: Memory in MiB (mebibytes). 4096 MiB = 4 GiB.
+        boot_disk_mib: Boot disk size in MiB (mebibytes). 102400 MiB = 100 GiB.
+
+    Note:
+        Google Batch expects MiB (base-2), not MB (base-10):
+
+        | Unit | Base    | Calculation | Bytes     |
+        |------|---------|-------------|-----------|
+        | MiB  | Binary  | 2^20        | 1,048,576 |
+        | MB   | Decimal | 10^6        | 1,000,000 |
+    """
+
+    cpu_milli: int
+    """Size of CPU resources in milli-CPUs. For example, 1000 = 1 full CPU, 2000 = 2 CPUs, etc."""
+
+    memory_mib: int
+    """Size of memory in MiB (mebibytes). For example, 4096 MiB = 4 GiB."""
+
+    boot_disk_mib: int
+    """Size of boot disk in MiB (mebibytes). For example, 102400 MiB = 100 GiB."""
+
+    def build(self) -> batch_v1.ComputeResource:
+        """Build a `google.cloud.batch_v1.ComputeResource` object from the instance resource specification.
+
+        Returns:
+            batch_v1.ComputeResource: The built ComputeResource object.
+
+        Example:
+        ---
+        >>> spec = InstanceResourceSpec(cpu_milli=2000, memory_mib=4096, boot_disk_mib=102400)
+        >>> cr = spec.build()
+        >>> isinstance(cr, batch_v1.ComputeResource)
+        True
+        >>> cr.cpu_milli
+        2000
+        >>> cr.memory_mib
+        4096
+        >>> cr.boot_disk_mib
+        102400
+        """
+        return batch_v1.ComputeResource(
+            cpu_milli=self.cpu_milli,
+            memory_mib=self.memory_mib,
+            boot_disk_mib=self.boot_disk_mib,
+        )
+
+
+class AllocationSpec(BaseModel):
+    """Allocation specification for Google Batch tasks."""
+
+    DEFAULT_REGION: ClassVar[str] = f"regions/{GCP_REGION}"
+
+    instance: InstanceSpec
+    """Instance specification for the batch task."""
+
+    service_account_email: str | None = None
+    """Service account email to be used for the batch task."""
+
+    service_account_scopes: list[str] | None = None
+    """Service account scopes to be used for the batch task."""
+
+    region: Annotated[str | None, StringConstraints(pattern=r"^regions/[a-z0-9-]+$")] = None
+    """Region specification for the batch task. In format regions/<region>."""
+
+    zones: list[Annotated[str, StringConstraints(pattern=r"^zones/[a-z0-9-]+$")]] | None = None
+    """Zone specification for the batch task. In format [zones/<zone>]. Can be multiple zones."""
+
+    labels: dict[str, str] | None = None
+    """Labels to be applied to each instance in the task group."""
+
+    @model_validator(mode="after")
+    def validate_region_or_zone(self) -> AllocationSpec:
+        """Validate that either region or zones are specified, but not both.
+
+        Args:
+            allocation_spec (AllocationSpec): The allocation specification to validate.
+
+        Returns:
+            AllocationSpec: The validated allocation specification.
+
+        Raises:
+            ValueError: If both region and zones are specified, or if neither is specified.
+
+        Example:
+        ---
+        >>> AllocationSpec(instance=InstanceSpec()).region
+        'regions/europe-west1'
+        >>> AllocationSpec(instance=InstanceSpec(), zones=["zones/europe-west1-b"]).region is None
+        True
+        >>> AllocationSpec(instance=InstanceSpec(), region="regions/europe-west1", zones=["zones/europe-west1-b"])  # doctest: +ELLIPSIS
+        Traceback (most recent call last):
+            ...
+        pydantic_core._pydantic_core.ValidationError: ...
+        """
+        if self.region and self.zones:
+            raise ValueError("Either `region` or `zones` can be specified, but not both.")
+        if self.zones:
+            return self
+        # By default set the region to the default region if neither region nor zones are specified
+        self.region = self.DEFAULT_REGION
+        return self
+
+    @cached_property
+    def service_account(self) -> batch_v1.ServiceAccount:
+        """Get the service account for the batch task based on the specified email and scopes.
+
+        Returns:
+            batch_v1.ServiceAccount: The service account for the batch task.
+        """
+        return batch_v1.ServiceAccount(
+            email=self.service_account_email,
+            scopes=self.service_account_scopes or [],
+        )
+
+    @cached_property
+    def location(self) -> batch_v1.AllocationPolicy.LocationPolicy:
+        """Get the location policy for the batch task based on the specified region or zones.
+
+        Returns:
+            batch_v1.AllocationPolicy.LocationPolicy: The location policy for the batch task.
+        """
+        return batch_v1.AllocationPolicy.LocationPolicy(
+            allowed_locations=[self.region] if self.region else self.zones
+        )
+
+    def build(self) -> batch_v1.AllocationPolicy:
+        """Build a `google.cloud.batch_v1.AllocationPolicy` object from the allocation specification.
+
+        Returns:
+            batch_v1.AllocationPolicy: The built AllocationPolicy object.
+
+        Example:
+        ---
+        >>> alloc = AllocationSpec(instance=InstanceSpec(), labels={"team": "test"})
+        >>> ap = alloc.build()
+        >>> isinstance(ap, batch_v1.AllocationPolicy)
+        True
+        >>> list(ap.location.allowed_locations)
+        ['regions/europe-west1']
+        >>> ap.instances[0].policy.machine_type
+        'n1-standard-4'
+        >>> alloc_zones = AllocationSpec(instance=InstanceSpec(), zones=["zones/europe-west1-b"], labels={"team": "test"})
+        >>> list(alloc_zones.build().location.allowed_locations)
+        ['zones/europe-west1-b']
+        """
+        ap = {
+            "instances": [batch_v1.AllocationPolicy.InstancePolicyOrTemplate(policy=self.instance.build())],
+            "labels": self.labels or dict(Labels()),
+        }
+        if self.location:
+            ap["location"] = self.location
+        if self.service_account_email:
+            ap["service_account"] = self.service_account
+
+        return batch_v1.AllocationPolicy(**ap)

--- a/src/orchestration/models/batch/job.py
+++ b/src/orchestration/models/batch/job.py
@@ -1,0 +1,78 @@
+"""Job specification for batch orchestration."""
+
+from __future__ import annotations
+
+from google.cloud import batch_v1
+from pydantic import BaseModel
+
+from orchestration.models.batch.environment import EnvironmentRegistrySpec
+from orchestration.models.batch.instance import AllocationSpec
+from orchestration.models.batch.logs import LogsSpec
+from orchestration.models.batch.task_group import TaskGroupSpec
+from orchestration.utils.labels import Labels
+
+
+class JobSpec(BaseModel):
+    task_group: TaskGroupSpec
+    """Specification for the task groups to be executed in the batch job."""
+
+    allocation: AllocationSpec
+    """Specification for the allocation of resources for the batch job."""
+
+    logs: LogsSpec
+    """Specification for the logging configuration of the batch job."""
+
+    labels: dict[str, str] | None = None
+    """Labels to be applied to the batch job."""
+
+    def build(
+        self, task_environments: EnvironmentRegistrySpec | None = None, labels: dict[str, str] | None = None
+    ) -> batch_v1.Job:
+        """Build a `google.cloud.batch_v1.Job` object from the job specification.
+
+        Args:
+            task_environments: Optional environment registry to forward to the task group.
+                Pass the partitioned ``EnvironmentRegistrySpec`` from a ``BatchIndexRow`` so
+                that each submitted job receives its own slice of tasks.
+
+            labels: Optional labels to override the labels defined in the JobSpec.
+                This can be used to inject dynamic labels at runtime, for example by an Airflow operator.
+
+        Returns:
+            batch_v1.Job: The built Job object.
+
+        Example:
+        ---
+        >>> from orchestration.models.batch.environment import EnvironmentSpec, EnvironmentRegistrySpec
+        >>> from orchestration.models.batch.instance import AllocationSpec, InstanceSpec, InstanceResourceSpec
+        >>> from orchestration.models.batch.runnable import RunnableSpec
+        >>> from orchestration.models.batch.task import TaskConfiguration
+        >>> from orchestration.models.batch.task_group import TaskGroupSpec
+        >>> from orchestration.models.batch.logs import LogsSpec
+        >>> irs = InstanceResourceSpec(cpu_milli=1000, memory_mib=2048, boot_disk_mib=51200)
+        >>> rs = RunnableSpec(image_uri="gcr.io/p/img:latest", inline_commands=["echo", "hi"])
+        >>> tc = TaskConfiguration(instance_resource_spec=irs, runnable_spec=rs)
+        >>> envs = EnvironmentRegistrySpec(environments=[EnvironmentSpec(variables={"TASK_INDEX": "0"})])
+        >>> tg = TaskGroupSpec(parallelism=1, task_config=tc, task_environments=envs)
+        >>> alloc = AllocationSpec(instance=InstanceSpec(), labels={"team": "test"})
+        >>> spec = JobSpec(task_group=tg, allocation=alloc, logs=LogsSpec(), labels={"team": "test"})
+        >>> job = spec.build()
+        >>> isinstance(job, batch_v1.Job)
+        True
+        >>> len(job.task_groups)
+        1
+        >>> job.allocation_policy.instances[0].policy.machine_type
+        'n1-standard-4'
+        >>> job.logs_policy.destination == batch_v1.LogsPolicy.Destination.CLOUD_LOGGING
+        True
+        >>> dict(job.labels)
+        {'team': 'test'}
+        """
+        j = {
+            "task_groups": [self.task_group.build(task_environments=task_environments)],
+            "allocation_policy": self.allocation.build(),
+            "logs_policy": self.logs.build(),
+            "labels": labels or self.labels or dict(Labels()),
+        }
+
+        return batch_v1.Job(**j)

--- a/src/orchestration/models/batch/logs.py
+++ b/src/orchestration/models/batch/logs.py
@@ -1,0 +1,28 @@
+from google.cloud import batch_v1
+from pydantic import BaseModel
+
+
+class LogsSpec(BaseModel):
+    """Cloud logging specification."""
+
+    def build(self) -> batch_v1.LogsPolicy:
+        """Build a `google.cloud.batch_v1.LogsPolicy` object from the logs specification.
+
+        Returns:
+            batch_v1.LogsPolicy: The built LogsPolicy object.
+
+
+        Example:
+        ---
+        >>> lp = LogsSpec().build()
+        >>> lp.destination == batch_v1.LogsPolicy.Destination.CLOUD_LOGGING
+        True
+        >>> lp.cloud_logging_option.use_generic_task_monitored_resource
+        False
+        """
+        return batch_v1.LogsPolicy(
+            destination=batch_v1.LogsPolicy.Destination.CLOUD_LOGGING,
+            cloud_logging_option=batch_v1.LogsPolicy.CloudLoggingOption(
+                use_generic_task_monitored_resource=False,
+            ),
+        )

--- a/src/orchestration/models/batch/operator.py
+++ b/src/orchestration/models/batch/operator.py
@@ -24,7 +24,6 @@ class ManifestGeneratorSpec(BaseModel):
     """Parameter specification for specific BatchManifest generator.
 
     Attributes:
-        runnable (RunnableSpec): Runnable specification for the BatchManifest generator.
         generator_options (dict[str, str] | None): Keyword arguments for the manifest generator.
 
     """
@@ -38,7 +37,7 @@ class BatchIndexOperatorSpec(BaseModel):
 
     Attributes:
         pointer (str): Pointer to correct BatchManifest generator.
-        max_task_count (int): Maximum number of tasks per batch job. If the total number
+        max_task_count (int): Maximum number of tasks per batch job.
 
     """
 

--- a/src/orchestration/models/batch/operator.py
+++ b/src/orchestration/models/batch/operator.py
@@ -1,0 +1,69 @@
+"""Models representing Google Batch operator-config mapping."""
+
+from pydantic import BaseModel
+
+from orchestration.models.batch.environment import EnvironmentRegistrySpec
+from orchestration.models.batch.job import JobSpec
+
+
+class BatchIndexRow(BaseModel):
+    """Representation of a single row in the batch index. Each row corresponds to a single batch job.
+
+    a Pydantic model representing a single batch job, carrying a
+    zero-based index and the `EnvironmentRegistrySpec` (one environment per task)
+    for that job.
+    """
+
+    idx: int
+    """Index of the batch job. This can be used to create unique identifiers for batch jobs and their tasks."""
+    environments: EnvironmentRegistrySpec
+    """Environment specification for the batch job. This will be used to create the Environment object for each task."""
+
+
+class ManifestGeneratorSpec(BaseModel):
+    """Parameter specification for specific BatchManifest generator.
+
+    Attributes:
+        runnable (RunnableSpec): Runnable specification for the BatchManifest generator.
+        generator_options (dict[str, str] | None): Keyword arguments for the manifest generator.
+
+    """
+
+    generator_options: dict[str, str]
+    """Keyword arguments for the manifest generator."""
+
+
+class BatchIndexOperatorSpec(BaseModel):
+    """Batch index specification.
+
+    Attributes:
+        pointer (str): Pointer to correct BatchManifest generator.
+        max_task_count (int): Maximum number of tasks per batch job. If the total number
+
+    """
+
+    pointer: str
+    """Pointer to correct BatchManifest generator."""
+
+    max_task_count: int
+    """Maximum number of tasks per batch job.
+        If the total number of tasks exceeds this limit, the
+        batch index will be partitioned into multiple batch jobs.
+
+        Each batch job will have at most `max_task_count` tasks,
+        except for the last one which may have fewer.
+    """
+
+    generator_specs: ManifestGeneratorSpec
+    """Generator specification for the BatchManifest generator."""
+
+
+class BatchJobOperatorSpec(BaseModel):
+    """Batch job specification.
+
+    Attributes:
+        batch_index_spec (BatchIndexSpec): Specification for the batch index.
+    """
+
+    job: JobSpec
+    """Specification for the batch job."""

--- a/src/orchestration/models/batch/runnable.py
+++ b/src/orchestration/models/batch/runnable.py
@@ -1,0 +1,206 @@
+"""Runnable specification for Google Batch tasks."""
+
+from __future__ import annotations
+
+import re
+from functools import cached_property
+from importlib.resources import files
+from typing import Annotated
+
+from google.cloud import batch_v1
+from pydantic import BaseModel, StringConstraints, model_validator
+
+
+class RunnableSpec(BaseModel):
+    """Runnable specification."""
+
+    image_uri: Annotated[str, StringConstraints(min_length=1)]
+    """Container image to be used for the batch task."""
+
+    entrypoint: str = "/bin/bash"
+    """Entrypoint for the batch task. Default is /bin/bash."""
+
+    inline_commands: list[str] | None = None
+    """Commands to be executed in the batch task.
+        Mutually exclusive with `script_file` field. If both are provided, a validation error will be raised.
+        If neither are provided, a validation error will be raised."""
+
+    script_file: str | None = None
+    """Name of the script file relative to `src.orchestration.assets` directory to use for task execution.
+        Mutually exclusive with `commands` field. If both are provided, a validation error will be raised.
+        If neither is provided, a validation error will be raised."""
+
+    script_variables: dict[str, str] | None = None
+    """Optional mapping of variable names to values to substitute into the script file.
+        Sentinels in the script must follow the bash variable syntax: ``${variable_name}``."""
+
+    @model_validator(mode="after")
+    def _validate_oneof_script_or_commands(self) -> RunnableSpec:
+        if not ((self.inline_commands is not None) ^ (self.script_file is not None)):
+            raise ValueError("Exactly one of 'inline_commands' or 'script_file' must be provided, not both or neither.")
+        return self
+
+    @model_validator(mode="after")
+    def _validate_script_file_exists(self) -> RunnableSpec:
+        if self.script_file:
+            from importlib.resources import files
+
+            script_path = files("orchestration.assets").joinpath(self.script_file)
+            if not script_path.is_file():
+                raise FileNotFoundError(
+                    f"Script file '{self.script_file}' not found in 'orchestration.assets' package."
+                )
+        return self
+
+    @cached_property
+    def commands(self) -> list[str]:
+        if self.inline_commands:
+            return self.inline_commands
+        elif self.script_file:
+            # Assuming that the script file is located in the `src.orchestration.assets` package
+            script_content = self._find_script_file(self.script_file)
+            if self.script_variables:
+                script_content = self._apply_template(script_content, self.script_variables)
+            script_commands = self._parse_script_file(script_content)
+            return ["-c", script_commands]
+        else:
+            raise ValueError("Either 'inline_commands' or 'script_file' must be provided to create a Runnable.")
+
+    def build(self) -> batch_v1.Runnable:
+        """Get the commands to be executed in the batch task.
+
+        The method constructs a `google.cloud.batch_v1.Runnable` of type `CONTAINER`
+        using the provided `image_uri`, `commands` or `script_file`, and `entrypoint`.
+
+
+        If `commands` are provided, they will be used directly in the `Runnable`.
+        If a `script_file` is provided instead, the method will read the script file from
+        the `src.orchestration.assets` package, parse it to extract the commands, and use those commands in the `Runnable`.
+
+
+        Returns:
+            batch_v1.Runnable: A `google.cloud.batch_v1.Runnable` object constructed from the provided specifications.
+
+        Example:
+        ---
+        >>> spec = RunnableSpec(image_uri="gcr.io/project/image:latest", inline_commands=["echo", "hello"])
+        >>> runnable = spec.build()
+        >>> isinstance(runnable, batch_v1.Runnable)
+        True
+        >>> runnable.container.image_uri
+        'gcr.io/project/image:latest'
+        >>> list(runnable.container.commands)
+        ['echo', 'hello']
+        """
+        container = batch_v1.Runnable.Container(
+            image_uri=self.image_uri,
+            entrypoint=self.entrypoint,
+            commands=self.commands,
+        )
+
+        return batch_v1.Runnable(container=container)
+
+    @classmethod
+    def _apply_template(cls, script_content: str, variables: dict[str, str]) -> str:
+        """Replace ``${key}`` sentinels in the script content with the provided values.
+
+        Example:
+        ---
+        >>> RunnableSpec._apply_template("echo ${greeting}", {"greeting": "hello"})
+        'echo hello'
+        """
+        for key, value in variables.items():
+            script_content = script_content.replace(f"${{{key}}}", value)
+        return script_content
+
+    @classmethod
+    def _find_script_file(cls, script_name: str) -> str:
+        """Find the script file in the `src.orchestration.assets` package and return its content."""
+        script_path = files("orchestration.assets").joinpath(script_name)
+        if not script_path.is_file():
+            raise FileNotFoundError(f"Script file '{script_name}' not found in 'orchestration.assets' package.")
+        return script_path.read_text()
+
+    @classmethod
+    def _parse_script_file(cls, script_content: str) -> str:
+        r"""Parse the entry script file to extract all of the commands.
+
+        This method
+        1. removes comments and empty lines,
+        2. joins lines that are continued with a backslash (\\),
+        3. splits each joined line on ``;`` to separate co-located commands,
+        4. joins all resulting commands with ``&&``.
+
+        ``||`` and ``&&`` operators within a line are never split, so guard
+        clauses of the form ``[[ check ]] || { echo error; exit 1; }`` are
+        preserved as a single logical unit and their conditional semantics
+        remain intact.
+
+        Example:
+        ---
+        >>> script = "# comment\necho hello\\\n    world\nfoo; bar"
+        >>> RunnableSpec._parse_script_file(script)
+        'echo hello world && foo && bar'
+        """
+        lines = cls._remove_comments(script_content)
+        joined_lines = cls._join_continuation_lines(lines)
+        commands = cls._split_commands(joined_lines)
+        return " && ".join(commands)
+
+    @staticmethod
+    def _remove_comments(script: str) -> list[str]:
+        r"""Remove comment lines (starting with ``#``) and empty lines from a shell script.
+
+        Example:
+        ---
+        >>> RunnableSpec._remove_comments("# comment\necho hello\n\necho world")
+        ['echo hello', 'echo world']
+        """
+        lines = []
+        for line in script.splitlines():
+            stripped = line.strip()
+            if stripped.startswith("#") or not stripped:
+                continue
+            lines.append(line)
+        return lines
+
+    @staticmethod
+    def _join_continuation_lines(lines: list[str]) -> list[str]:
+        r"""Join lines that end with a backslash continuation into a single line.
+
+        Example:
+        ---
+        >>> RunnableSpec._join_continuation_lines(["echo hello \\", "    world", "foo"])
+        ['echo hello world', 'foo']
+        """
+        joined_lines = []
+        buffer = []
+        for line in lines:
+            # Start new buffer if line ends with \, otherwise add to current buffer and join
+            if line.rstrip().endswith("\\"):
+                buffer.append(line.rstrip()[:-1].strip())
+            else:
+                buffer.append(line.strip())
+                joined_lines.append(" ".join(buffer).strip())
+                buffer = []
+        if buffer:
+            joined_lines.append(" ".join(buffer).strip())
+        return joined_lines
+
+    @staticmethod
+    def _split_commands(joined_lines: list[str]) -> list[str]:
+        """Split on ; only — preserving || and && to keep conditional logic and pipelines intact.
+
+        Example:
+        ---
+        >>> RunnableSpec._split_commands(["foo; bar && baz", "cmd1 || cmd2", "a | b"])
+        ['foo', 'bar && baz', 'cmd1 || cmd2', 'a | b']
+        """
+        commands = []
+        for line in joined_lines:
+            parts = re.split(r"\s*;\s*", line)
+            for part in parts:
+                part = part.strip()
+                if part:
+                    commands.append(part)
+        return commands

--- a/src/orchestration/models/batch/runnable.py
+++ b/src/orchestration/models/batch/runnable.py
@@ -43,8 +43,6 @@ class RunnableSpec(BaseModel):
     @model_validator(mode="after")
     def _validate_script_file_exists(self) -> RunnableSpec:
         if self.script_file:
-            from importlib.resources import files
-
             script_path = files("orchestration.assets").joinpath(self.script_file)
             if not script_path.is_file():
                 raise FileNotFoundError(

--- a/src/orchestration/models/batch/task.py
+++ b/src/orchestration/models/batch/task.py
@@ -67,7 +67,7 @@ class TaskConfiguration(BaseModel):
     """Maximum run duration for the task in ISO 8601 format (e.g., '3600s' for 1 hour)."""
 
     exit_codes: Sequence[int] | None = None
-    """Sequence of exit codes that should be considered as successful task completion.
+    """Sequence of exit codes that should trigger a task retry according to the lifecycle policy.
         If not provided, the default exit codes are 50001, 50002, 50003, 50004, and 50005."""
 
     shared_environment: EnvironmentSpec | None = None

--- a/src/orchestration/models/batch/task.py
+++ b/src/orchestration/models/batch/task.py
@@ -1,0 +1,129 @@
+"""Task definition for Google Batch tasks."""
+
+from __future__ import annotations
+
+import datetime
+from collections.abc import Sequence
+from typing import ClassVar
+
+from google.cloud import batch_v1
+from pydantic import BaseModel
+
+from orchestration.models.batch.environment import EnvironmentSpec
+from orchestration.models.batch.instance import InstanceResourceSpec
+from orchestration.models.batch.runnable import RunnableSpec
+from orchestration.models.batch.volume import VolumeRegistrySpec
+from orchestration.utils import time_to_seconds
+
+
+# NOTE: `TaskSpec` is already reserved by `google.cloud.batch_v1.TaskSpec`.
+class TaskConfiguration(BaseModel):
+    """Batch task specifications.
+
+    This class represents the specifications for a task to be executed in a Google Batch job.
+
+    Attributes:
+        max_retry_count (int): Maximum number of retries for the task in case of failures.
+        max_run_duration (str): Maximum run duration for the task in ISO 8601 format (e.g., "3600s" for 1 hour).
+
+    Example:
+    ---
+    >>> irs = InstanceResourceSpec(cpu_milli=2000, memory_mib=4096, boot_disk_mib=102400)
+    >>> rs = RunnableSpec(image_uri="gcr.io/my-project/my-image:latest", inline_commands=["python", "script.py"])
+    >>> task_spec = TaskConfiguration(instance_resource_spec=irs, runnable_spec=rs)
+    >>> ts = task_spec.build()
+    >>> isinstance(ts, batch_v1.TaskSpec)
+    True
+    >>> ts.compute_resource.cpu_milli
+    2000
+    >>> ts.compute_resource.memory_mib
+    4096
+    >>> ts.compute_resource.boot_disk_mib
+    102400
+    >>> ts.max_run_duration.seconds
+    3600
+    >>> ts.max_retry_count
+    0
+    >>> ts.lifecycle_policies[0].action == batch_v1.LifecyclePolicy.Action.RETRY_TASK
+    True
+    >>> list(ts.lifecycle_policies[0].action_condition.exit_codes)
+    [50001, 50002, 50003, 50004, 50005]
+    """
+
+    # See https://docs.cloud.google.com/batch/docs/troubleshooting#reserved-exit-codes
+    DEFAULT_EXIT_CODES: ClassVar[tuple[int, ...]] = (50001, 50002, 50003, 50004, 50005)
+
+    instance_resource_spec: InstanceResourceSpec
+    """Resource specifications (cpu, memory and disk) for the task."""
+
+    runnable_spec: RunnableSpec
+    """Runnable specification (script, commands and container image) for the task."""
+
+    max_retry_count: int = 0
+    """Maximum number of retries for the task in case of failures.
+        By default, it is set to 0, meaning no retries will be attempted in case of task failure."""
+
+    max_run_duration: str = "3600s"
+    """Maximum run duration for the task in ISO 8601 format (e.g., '3600s' for 1 hour)."""
+
+    exit_codes: Sequence[int] | None = None
+    """Sequence of exit codes that should be considered as successful task completion.
+        If not provided, the default exit codes are 50001, 50002, 50003, 50004, and 50005."""
+
+    shared_environment: EnvironmentSpec | None = None
+    """Optional shared environment variables to be included in the task specification.
+        This can be potentially used to include shared environment variables to all tasks in the job.
+    """
+    shared_volumes: VolumeRegistrySpec | None = None
+    """Optional shared volumes to be included in the task specification.
+        This can be potentially used to include shared volumes to all tasks in the job.
+    """
+
+    @property
+    def max_run_duration_seconds(self) -> int:
+        """Get the maximum run duration in seconds."""
+        return time_to_seconds(self.max_run_duration)
+
+    @property
+    def effective_exit_codes(self) -> list[int]:
+        """Get the effective exit codes for the task."""
+        return list(self.exit_codes) if self.exit_codes is not None else list(self.DEFAULT_EXIT_CODES)
+
+    @property
+    def lifecycle_policies(self) -> list[batch_v1.LifecyclePolicy]:
+        """Get the lifecycle policies for the task based on the effective exit codes.
+
+        Note:
+            By default the lifecycle policy is set to `google.cloud.batch_v1.LifecyclePolicy.Action.RETRY_TASK`
+            for the default exit codes (50001, 50002, 50003, 50004, and 50005).
+            This means that **if the task exits with any of these exit codes**, it will be retried up to `max_retry_count` times.
+            If `exit_codes` are provided, the lifecycle policy will be set to retry the task for those exit codes instead.
+        """
+        return [
+            batch_v1.LifecyclePolicy(
+                action=batch_v1.LifecyclePolicy.Action.RETRY_TASK,
+                action_condition=batch_v1.LifecyclePolicy.ActionCondition(exit_codes=self.effective_exit_codes),
+            )
+        ]
+
+    def build(
+        self,
+    ) -> batch_v1.TaskSpec:
+        """Build a `google.cloud.batch_v1.TaskSpec` object from specification.
+
+        Returns:
+            batch_v1.TaskSpec: A `google.cloud.batch_v1.TaskSpec` object built from the provided specifications.
+        """
+        spec = {
+            "runnables": [self.runnable_spec.build()],
+            "compute_resource": self.instance_resource_spec.build(),
+            "max_run_duration": datetime.timedelta(seconds=self.max_run_duration_seconds),
+            "max_retry_count": self.max_retry_count,
+            "lifecycle_policies": self.lifecycle_policies,
+        }
+        if self.shared_environment:
+            spec["environment"] = self.shared_environment.build()
+        if self.shared_volumes:
+            spec["volumes"] = self.shared_volumes.build()
+
+        return batch_v1.TaskSpec(**spec)

--- a/src/orchestration/models/batch/task_group.py
+++ b/src/orchestration/models/batch/task_group.py
@@ -1,0 +1,76 @@
+"""Task group definition for Google Batch tasks."""
+
+from __future__ import annotations
+
+from google.cloud import batch_v1
+from pydantic import BaseModel
+
+from orchestration.models.batch.environment import EnvironmentRegistrySpec
+from orchestration.models.batch.task import TaskConfiguration
+
+
+class TaskGroupSpec(BaseModel):
+    """Class representing a group of tasks to be executed in a Google Batch job."""
+
+    parallelism: int
+    """Number of tasks to run in parallel."""
+
+    task_count_per_node: int = 1
+    """Number of tasks to run per node at the same time.
+        By default, it is set to 1, meaning only one task will run on a node at a time."""
+
+    task_config: TaskConfiguration
+    """Specification for the tasks in the group."""
+
+    task_environments: EnvironmentRegistrySpec
+    """List of environment variable(s) for the tasks in the group.
+        Each environment variable is represented as an EnvironmentRegistrySpec object.
+        Size of the list will be equal to the number of tasks running.
+        Each task will get one element from the list and pass it to environment.
+    """
+
+    def build(self, task_environments: EnvironmentRegistrySpec | None = None) -> batch_v1.TaskGroup:
+        """Build a TaskGroup object from the TaskGroupSpec.
+
+        Args:
+            task_environments: Optional environment registry to use instead of ``self.task_environments``.
+                Callers such as ``BatchJobOperator`` supply the partitioned environments produced by
+                ``BatchIndexOperator`` here so that each submitted job gets its own task slice.
+
+        Returns:
+            batch_v1.TaskGroup: The built TaskGroup object.
+
+        Example:
+        ---
+        >>> from orchestration.models.batch.environment import EnvironmentSpec, EnvironmentRegistrySpec
+        >>> from orchestration.models.batch.instance import InstanceResourceSpec
+        >>> from orchestration.models.batch.runnable import RunnableSpec
+        >>> from orchestration.models.batch.task import TaskConfiguration
+        >>> irs = InstanceResourceSpec(cpu_milli=1000, memory_mib=2048, boot_disk_mib=51200)
+        >>> rs = RunnableSpec(image_uri="gcr.io/p/img:latest", inline_commands=["echo", "hi"])
+        >>> tc = TaskConfiguration(instance_resource_spec=irs, runnable_spec=rs)
+        >>> envs = EnvironmentRegistrySpec(environments=[
+        ...     EnvironmentSpec(variables={"TASK_INDEX": "0"}),
+        ...     EnvironmentSpec(variables={"TASK_INDEX": "1"}),
+        ... ])
+        >>> tg_spec = TaskGroupSpec(parallelism=2, task_config=tc, task_environments=envs)
+        >>> tg = tg_spec.build()
+        >>> isinstance(tg, batch_v1.TaskGroup)
+        True
+        >>> tg.parallelism
+        2
+        >>> tg.task_count_per_node
+        1
+        >>> len(tg.task_environments)
+        2
+        >>> dict(tg.task_environments[0].variables)
+        {'TASK_INDEX': '0'}
+        """
+        effective_environments = task_environments if task_environments is not None else self.task_environments
+        return batch_v1.TaskGroup(
+            parallelism=self.parallelism,
+            task_spec=self.task_config.build(),
+            task_count_per_node=self.task_count_per_node,
+            task_environments=effective_environments.build(),
+            task_count=len(effective_environments.environments),
+        )

--- a/src/orchestration/models/batch/volume.py
+++ b/src/orchestration/models/batch/volume.py
@@ -1,0 +1,93 @@
+"""Volume specifications for Google Batch tasks."""
+
+import logging
+from functools import cached_property
+from typing import Annotated
+
+from google.cloud import batch_v1
+from pydantic import BaseModel, Field
+
+from orchestration.utils.path import GCSPath
+
+logger = logging.getLogger(__name__)
+
+
+class VolumeSpec(BaseModel):
+    """Volume specification for Google Batch tasks."""
+
+    remote_uri: Annotated[str, Field(pattern=r"^gs://[a-zA-Z0-9_-]+(/[a-zA-Z0-9_.-]+)*/?$")]
+    """GCS path to be mounted."""
+    mount_point: Annotated[str, Field(pattern=r"^/mnt(/[a-zA-Z0-9_-]+)*/?$")]
+    """Local path on the google batch VM where the GCS path will be mounted."""
+    mount_options: list[str] = []
+    """Extra gcsfuse options passed to batch_v1.Volume.mount_options (e.g. ['--billing-project=my-project'])."""
+
+    @cached_property
+    def gcs_path(self) -> GCSPath:
+        """Return the GCS path.
+
+        The GCS path is derived from the remote URI by stripping the "gs://" prefix and any
+        trailing slashes.
+
+        Returns:
+            GCSPath: The GCS path.
+
+        """
+        return GCSPath(self.remote_uri.rstrip("/"))
+
+    @cached_property
+    def remote_path(self) -> str:
+        """Return the remote path.
+
+        The remote path is derived from the remote URI by stripping the "gs://" prefix and any
+        trailing slashes.
+
+        Returns:
+            str: The remote path.
+
+        Example:
+        ---
+        >>> VolumeSpec(remote_uri="gs://my-bucket/my/path", mount_point="/mnt/data/").remote_path
+        'my-bucket/my/path'
+        """
+        gcs_path = self.gcs_path
+        return f"{gcs_path.bucket}/{gcs_path.path}"
+
+
+class VolumeRegistrySpec(BaseModel):
+    """Volume registry for Google Batch tasks."""
+
+    mounting_points: list[VolumeSpec]
+    """List of volume specifications for Google Batch tasks."""
+
+    def build(self) -> list[batch_v1.Volume]:
+        """Set up the mounting points for the container.
+
+        Returns:
+            list[batch_v1.Volume]: The volumes.
+
+        Example:
+        ---
+        >>> reg = VolumeRegistrySpec(mounting_points=[
+        ...     VolumeSpec(remote_uri="gs://bucket-a/data", mount_point="/mnt/a/"),
+        ...     VolumeSpec(remote_uri="gs://bucket-b/cache", mount_point="/mnt/b/"),
+        ... ])
+        >>> vols = reg.build()
+        >>> len(vols)
+        2
+        >>> all(isinstance(v, batch_v1.Volume) for v in vols)
+        True
+        >>> vols[0].gcs.remote_path
+        'bucket-a/data'
+        >>> vols[0].mount_path
+        '/mnt/a'
+        """
+        volumes = []
+        for mount in self.mounting_points:
+            # Google Batch does not allow trailing slashes in the mount points, so we need to strip them.
+            mount_point_safe = mount.mount_point.rstrip("/")
+            gcs_object = batch_v1.GCS(remote_path=mount.remote_path)
+            gcs_volume = batch_v1.Volume(gcs=gcs_object, mount_path=mount_point_safe, mount_options=mount.mount_options)
+            logger.debug("Built volume with remote path %s and mount point %s", mount.remote_path, mount_point_safe)
+            volumes.append(gcs_volume)
+        return volumes


### PR DESCRIPTION
## Summary

- Introduces `src/orchestration/models/batch/` — a new package of Pydantic models that mirror the `google.cloud.batch_v1` protobuf object tree
- Each model exposes a `.build()` method returning the corresponding proto, replacing the hand-rolled dicts and TypedDicts used by the old operators
- All models include inline doctests; no separate test file needed

**Models added:**

| Model | Replaces |
|---|---|
| `EnvironmentSpec` / `EnvironmentRegistrySpec` | `create_task_env()` + raw `dict` lists |
| `InstanceSpec` / `InstanceResourceSpec` / `AllocationSpec` | `BatchPolicySpecs`, `BatchResourceSpecs` TypedDicts |
| `JobSpec` | `create_batch_job()` |
| `RunnableSpec` | `create_container_runnable()`, `create_task_commands()` |
| `TaskConfiguration` / `TaskGroupSpec` | `BatchTaskSpecs`, `create_task_spec()` |
| `LogsSpec` / `VolumeSpec` / `VolumeRegistrySpec` | `set_up_mounting_points()`, `GCSMountObject` |
| `BatchIndexRow` / `BatchIndexOperatorSpec` / `BatchJobOperatorSpec` | `GoogleBatchIndexSpecs`, `ManifestGeneratorSpecs` TypedDicts |

## Stack

This is **PR 1 of 3** in a stacked series:
1. **→ This PR** — Pydantic model layer (pure additive)
2. `feat/batch-generic-operators` — Generic operators + manifest generators
3. `feat/batch-dag-migration` — DAG migration + old code removal

## Test plan

- [ ] `uv run pre-commit run --all-files` passes (inline doctests run as part of the test suite)
- [ ] No existing functionality changed — pure addition

🤖 Generated with [Claude Code](https://claude.com/claude-code)