### PR TITLE
feat: add heritability estimates ingestion to PIS and gentropy config

### DIFF
--- a/src/orchestration/dags/config/gentropy.yaml
+++ b/src/orchestration/dags/config/gentropy.yaml
@@ -41,6 +41,7 @@ steps:
       step.target_index_path: '{{release_uri}}/output/target'
       step.disease_index_path: '{{release_uri}}/output/disease'
       step.biosample_index_path: '{{release_uri}}/output/biosample'
+      step.heritability_input_path: '{{release_uri}}/input/heritability_estimate'
       # OUTPUTS
       step.valid_study_index_path: '{{release_uri}}/output/study'
       step.invalid_study_index_path: '{{release_uri}}/excluded/study'

--- a/src/orchestration/dags/config/pis.yaml
+++ b/src/orchestration/dags/config/pis.yaml
@@ -642,6 +642,13 @@ steps:
       destination: input/gwas/credible_set/finngen_ukb_mvp
   ##################################################################################################
 
+  #: HERITABILITY STEP :############################################################################
+  heritability:
+    - name: copy_many gwas ldsc h2 estimates
+      sources: gs://gwas_catalog_sumstats_susie/heritability_estimates/**/*.parquet
+      destination: input/heritability_estimates
+  ##################################################################################################
+
   #: L2G STEP :#####################################################################################
   l2g:
     - name: copy_many l2g gold standard


### PR DESCRIPTION
copies the patched heritability estimates from gwas inputs, adds heritability path to study index QC step.