### PR TITLE
fix: remove deprecated Project Score cross-references

### DIFF
--- a/src/orchestration/dags/config/pis.yaml
+++ b/src/orchestration/dags/config/pis.yaml
@@ -990,14 +990,6 @@ steps:
       source: https://ftp.ncbi.nlm.nih.gov/gene/DATA/GENE_INFO/Mammalia/Homo_sapiens.gene_info.gz
       destination: input/target/ncbi/Homo_sapiens.gene_info.gz
 
-    - name: copy project score gene identifier
-      source: https://cog.sanger.ac.uk/cmp/download/gene_identifiers_latest.csv.gz
-      destination: input/target/project-scores/gene_identifiers_latest.csv.gz
-
-    - name: copy project score essentiality matrix
-      source: https://cog.sanger.ac.uk/cmp/download/essentiality_matrices.zip
-      destination: input/target/project-scores/essentiality_matrices.zip
-
     - name: copy reactome ensembl2reactome
       source: https://reactome.org/download/current/Ensembl2Reactome.txt
       destination: input/target/reactome/Ensembl2Reactome.txt

--- a/src/orchestration/dags/config/pts.yaml
+++ b/src/orchestration/dags/config/pts.yaml
@@ -335,22 +335,6 @@ steps:
       destination: intermediate/target/hpa/subcellular_locations_ssl.parquet
       separator: "\t"
 
-    - name: unzip essentiality matrix
-      source: input/target/project-scores/essentiality_matrices.zip
-      inner_file: EssentialityMatrices/04_binaryDepScores.tsv
-      destination: intermediate/target/project-scores/04_binaryDepScores.tsv
-    - name: csv_to_parquet essentiality matrix
-      requires:
-        - unzip essentiality matrix
-      source: intermediate/target/project-scores/04_binaryDepScores.tsv
-      local_source: True
-      destination: intermediate/target/project-scores/04_binaryDepScores.parquet
-      separator: "\t"
-
-    - name: csv_to_parquet gene identifier
-      source: input/target/project-scores/gene_identifiers_latest.csv.gz
-      destination: intermediate/target/project-scores/gene_identifiers_latest.parquet
-
     - name: download ensembl
       source: input/target/ensembl/homo_sapiens.json
     - name: transform ensembl
@@ -395,8 +379,6 @@ steps:
         hpa: intermediate/target/hpa/subcellular_location.tsv.gz
         hpa_sl: intermediate/target/hpa/subcellular_locations_ssl.parquet
         ncbi: input/target/ncbi/Homo_sapiens.gene_info.gz
-        project_scores_ids: intermediate/target/project-scores/gene_identifiers_latest.parquet
-        project_scores_essentiality_matrix: intermediate/target/project-scores/04_binaryDepScores.parquet
         reactome_etl: output/reactome
         reactome_pathways: input/target/reactome/Ensembl2Reactome.txt
         safety_evidence: intermediate/target/safety.parquet


### PR DESCRIPTION
## Summary

Mirror the pis and pts cleanup of the deprecated Project Score resource. No new code — this just keeps the orchestration configs aligned with the upstream changes.

- `dags/config/pis.yaml` — drop the two `cog.sanger.ac.uk/cmp/download/` fetches under `input/target/project-scores/`
- `dags/config/pts.yaml` — drop the 3 pre-processing tasks (`unzip essentiality matrix`, `csv_to_parquet essentiality matrix`, `csv_to_parquet gene identifier`) and the 2 `project_scores_*` source entries on the `target` pyspark step

Out of scope (intentionally unaffected):
- `dags/config/clusters.yaml` — Project Score v2 CRISPR evidence parser (different dataset, still maintained)
- DepMap-backed `target_gene_essentiality` step

Companion PRs:
- pts: opentargets/pts#138 (removes `_build_project_scores` and matching source entries)
- pis: opentargets/pis#201 (stops fetching the deprecated files)

Refs opentargets/issues#4367

## Test plan

- [ ] Sanity-check yamlfmt locally (orchestration CI requires single-space before inline comments)
- [ ] After all three PRs merge, run an end-to-end release to confirm the target step assembles without `input/target/project-scores/` and `dbXrefs` no longer contains `source: ProjectScore` entries