### PR TITLE
fix(dag bag) tests

### DIFF
--- a/src/orchestration/dags/gwas_catalog_sumstats_susie_clumping.py
+++ b/src/orchestration/dags/gwas_catalog_sumstats_susie_clumping.py
@@ -9,9 +9,7 @@ from orchestration.utils import chain_dependencies, find_environment_vars, read_
 from orchestration.utils.common import shared_dag_args, shared_dag_kwargs
 from orchestration.utils.dataproc import generate_dataproc_task_chain, submit_gentropy_step
 
-SOURCE_CONFIG_FILE_PATH = (
-    Path(__file__).parent / Path(__file__).parent / "config" / "gwas_catalog_sumstats_susie_clumping.yaml"
-)
+SOURCE_CONFIG_FILE_PATH = Path(__file__).parent / "config" / "gwas_catalog_sumstats_susie_clumping.yaml"
 config = read_yaml_config(SOURCE_CONFIG_FILE_PATH)
 env_spec: list[EnvironmentSpec] = config["environment_specs"]
 env: Environment = config["env"]

--- a/src/orchestration/dags/unified_pipeline.py
+++ b/src/orchestration/dags/unified_pipeline.py
@@ -48,6 +48,7 @@ with DAG(
     catchup=False,
     schedule=None,
     user_defined_filters={"strhash": strhash},
+    tags=["unified_pipeline"],
     params={
         "run_label": Param(
             default=f"up-{datetime.now().strftime('%Y%m%d-%H%M')}",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,7 +6,7 @@ import pytest
 from airflow.models import DagBag
 
 
-@pytest.fixture(params=["orchestration/dags"])
+@pytest.fixture(params=["src/orchestration/dags"])
 def dag_bag(request: pytest.FixtureRequest) -> DagBag:
     """Return a DAG bag for testing."""
     return DagBag(dag_folder=request.param, include_examples=False)

--- a/tests/test_dag_validation.py
+++ b/tests/test_dag_validation.py
@@ -6,18 +6,19 @@ from airflow.models import DagBag
 def test_no_import_errors(dag_bag: DagBag) -> None:
     """Test for import errors."""
     assert not dag_bag.import_errors, f"DAG import failures. Errors: {dag_bag.import_errors}"
+    assert len(dag_bag.dags) > 0, "No DAGs found. Check the DAG folder path and ensure DAGs are defined correctly."
 
 
 def test_requires_tags(dag_bag: DagBag) -> None:
     """Tags should be defined for each DAG."""
     for dag in dag_bag.dags.values():
-        assert dag.tags
+        assert dag.tags, "DAG should have at least one tag defined."
 
 
 def test_owner_len_greater_than_five(dag_bag: DagBag) -> None:
     """Owner should be defined for each DAG and be longer than 5 characters."""
     for dag in dag_bag.dags.values():
-        assert len(dag.owner) > 5
+        assert len(dag.owner) > 5, "DAG owner should be longer than 5 characters."
 
 
 def test_desc_len_greater_than_fifteen(dag_bag: DagBag) -> None:


### PR DESCRIPTION
# Context

This PR fixes the test path to the dag_bag. Currently tests referencing dag_bag fixture does not work properly, as the path they reflect do not contain any dags.