### PR TITLE
feat(pts): wire aact_extraction_batch_results into chembl_molecule (via pis_drug)

### DIFF
--- a/src/orchestration/dags/config/pis.yaml
+++ b/src/orchestration/dags/config/pis.yaml
@@ -135,27 +135,12 @@ steps:
 
   #: CLINICAL_REPORT STEP :########################################################################
   clinical_report:
-    # aact_extraction_batch_results is split out and downloaded in the drug step
-    # (it feeds chembl_molecule), so the clinical_report glob is scoped to the
-    # remaining inputs: top-level files + the aact/ and chembl/ subtrees.
-    - name: explode_glob clinical_report files
-      glob: gs://ot-team/irene/clinical_mining/2026-05-27/input/clinical_report/*
+    - name: explode_glob clinical_report
+      glob: gs://ot-team/irene/clinical_mining/2026-05-27/input/clinical_report/**/*
       do:
         - name: copy clinical_report ${match_stem} ${uuid}
           source: ${uri}
-          destination: input/clinical_report/${match_stem}.${match_ext}
-    - name: explode_glob clinical_report aact
-      glob: gs://ot-team/irene/clinical_mining/2026-05-27/input/clinical_report/aact/**/*
-      do:
-        - name: copy clinical_report aact ${match_stem} ${uuid}
-          source: ${uri}
-          destination: input/clinical_report/aact/${match_path}/${match_stem}.${match_ext}
-    - name: explode_glob clinical_report chembl
-      glob: gs://ot-team/irene/clinical_mining/2026-05-27/input/clinical_report/chembl/**/*
-      do:
-        - name: copy clinical_report chembl ${match_stem} ${uuid}
-          source: ${uri}
-          destination: input/clinical_report/chembl/${match_path}/${match_stem}.${match_ext}
+          destination: input/clinical_report/${match_path}/${match_stem}.${match_ext}
   ##################################################################################################
 
   #: DISEASE STEP :#################################################################################
@@ -188,11 +173,11 @@ steps:
       source: https://ftp.ebi.ac.uk/pub/databases/chembl/UniChem/data/wholeSourceMapping/src_id1/src1src2.txt.gz
       destination: input/drug/drugbank.csv.gz
 
-    # AACT clinical-trial batch extraction — consumed by chembl_molecule (and
-    # clinical_report). Downloaded here in the drug step so chembl_molecule's
-    # existing pis_drug dependency covers it; destination path is unchanged.
+    # AACT clinical-trial batch extraction — a standalone source consumed by
+    # chembl_molecule (and clinical_report). Downloaded in the drug step so
+    # chembl_molecule's existing pis_drug dependency covers it.
     - name: explode_glob aact extraction batch results
-      glob: gs://ot-team/irene/clinical_mining/2026-05-27/input/clinical_report/aact_extraction_batch_results/**/*
+      glob: gs://ot-team/irene/clinical_mining/aact_extraction_batch_result/output/**/*
       do:
         - name: copy aact ${match_stem} ${uuid}
           source: ${uri}

--- a/src/orchestration/dags/config/pis.yaml
+++ b/src/orchestration/dags/config/pis.yaml
@@ -176,12 +176,9 @@ steps:
     # AACT clinical-trial batch extraction — a standalone source consumed by
     # chembl_molecule (and clinical_report). Downloaded in the drug step so
     # chembl_molecule's existing pis_drug dependency covers it.
-    - name: explode_glob aact extraction batch results
-      glob: gs://ot-team/irene/clinical_mining/aact_extraction_batch_result/output/**/*
-      do:
-        - name: copy aact ${match_stem} ${uuid}
-          source: ${uri}
-          destination: input/clinical_report/aact_extraction_batch_results/${match_path}/${match_stem}.${match_ext}
+    - name: copy_many aact extraction batch results
+      sources: gs://ot-team/irene/clinical_mining/aact_extraction_batch_result/output/*
+      destination: input/clinical_report/aact_extraction_batch_results
 
     - name: elasticsearch chembl drug warning
       url: https://www.ebi.ac.uk/chembl/elk/es

--- a/src/orchestration/dags/config/pis.yaml
+++ b/src/orchestration/dags/config/pis.yaml
@@ -135,12 +135,27 @@ steps:
 
   #: CLINICAL_REPORT STEP :########################################################################
   clinical_report:
-    - name: explode_glob clinical_report
-      glob: gs://ot-team/irene/clinical_mining/2026-05-27/input/clinical_report/**/*
+    # aact_extraction_batch_results is split out and downloaded in the drug step
+    # (it feeds chembl_molecule), so the clinical_report glob is scoped to the
+    # remaining inputs: top-level files + the aact/ and chembl/ subtrees.
+    - name: explode_glob clinical_report files
+      glob: gs://ot-team/irene/clinical_mining/2026-05-27/input/clinical_report/*
       do:
         - name: copy clinical_report ${match_stem} ${uuid}
           source: ${uri}
-          destination: input/clinical_report/${match_path}/${match_stem}.${match_ext}
+          destination: input/clinical_report/${match_stem}.${match_ext}
+    - name: explode_glob clinical_report aact
+      glob: gs://ot-team/irene/clinical_mining/2026-05-27/input/clinical_report/aact/**/*
+      do:
+        - name: copy clinical_report aact ${match_stem} ${uuid}
+          source: ${uri}
+          destination: input/clinical_report/aact/${match_path}/${match_stem}.${match_ext}
+    - name: explode_glob clinical_report chembl
+      glob: gs://ot-team/irene/clinical_mining/2026-05-27/input/clinical_report/chembl/**/*
+      do:
+        - name: copy clinical_report chembl ${match_stem} ${uuid}
+          source: ${uri}
+          destination: input/clinical_report/chembl/${match_path}/${match_stem}.${match_ext}
   ##################################################################################################
 
   #: DISEASE STEP :#################################################################################
@@ -172,6 +187,16 @@ steps:
     - name: copy drugbank annotation
       source: https://ftp.ebi.ac.uk/pub/databases/chembl/UniChem/data/wholeSourceMapping/src_id1/src1src2.txt.gz
       destination: input/drug/drugbank.csv.gz
+
+    # AACT clinical-trial batch extraction — consumed by chembl_molecule (and
+    # clinical_report). Downloaded here in the drug step so chembl_molecule's
+    # existing pis_drug dependency covers it; destination path is unchanged.
+    - name: explode_glob aact extraction batch results
+      glob: gs://ot-team/irene/clinical_mining/2026-05-27/input/clinical_report/aact_extraction_batch_results/**/*
+      do:
+        - name: copy aact ${match_stem} ${uuid}
+          source: ${uri}
+          destination: input/clinical_report/aact_extraction_batch_results/${match_path}/${match_stem}.${match_ext}
 
     - name: elasticsearch chembl drug warning
       url: https://www.ebi.ac.uk/chembl/elk/es

--- a/src/orchestration/dags/config/pts.yaml
+++ b/src/orchestration/dags/config/pts.yaml
@@ -671,6 +671,7 @@ steps:
       source:
         chembl_molecule: input/drug/chembl_molecule.jsonl
         drugbank: input/drug/drugbank.csv.gz
+        aact_extraction_batch_results: input/clinical_report/aact_extraction_batch_results
       destination: intermediate/chembl_molecule
   #################################################################################################
 

--- a/src/orchestration/dags/config/unified_pipeline.yaml
+++ b/src/orchestration/dags/config/unified_pipeline.yaml
@@ -364,7 +364,6 @@ steps:
   pts_chembl_molecule:
     depends_on:
       - pis_drug
-      - pis_clinical_report
   pts_drug_mechanism_of_action:
     depends_on:
       - pis_drug

--- a/src/orchestration/dags/config/unified_pipeline.yaml
+++ b/src/orchestration/dags/config/unified_pipeline.yaml
@@ -364,6 +364,7 @@ steps:
   pts_chembl_molecule:
     depends_on:
       - pis_drug
+      - pis_clinical_report
   pts_drug_mechanism_of_action:
     depends_on:
       - pis_drug


### PR DESCRIPTION
## Summary

Propagates the PTS `chembl_molecule` config change (opentargets/pts#142, tracking issue opentargets/issues#4414) into orchestration, with the AACT batch downloaded in `pis_drug` so the DAG dependencies stay unchanged.

- **`pts.yaml`** — `chembl_molecule` step gains the source `aact_extraction_batch_results: input/clinical_report/aact_extraction_batch_results` (mirrors the PTS `config.yaml` change).
- **`pis.yaml`** — mirrors opentargets/pis#202: the **drug** step uses `copy_many` to copy the AACT batch from its standalone source `gs://ot-team/irene/clinical_mining/aact_extraction_batch_result/output/*` → `input/clinical_report/aact_extraction_batch_results/`. The clinical_report step is unchanged.
- **`unified_pipeline.yaml`** — no change. The AACT input is staged by `pis_drug`, which `pts_chembl_molecule` already depends on.

> Based on `2606-public-release` (PR #201), **not** `dev`.

## Test plan

- [x] `pytest tests/test_dag_validation.py` — 6 passed
- [x] Net diff is `pts.yaml` + `pis.yaml` only

## Related

- PTS: opentargets/pts#142
- PIS: opentargets/pis#202 (the matching source-of-truth change)
