### PR TITLE
perf(coloc): retopologise gentropy_colocalisation cluster (non-preemptible, executor packing, drop EFM)

### DIFF
--- a/src/orchestration/dags/config/clusters.yaml
+++ b/src/orchestration/dags/config/clusters.yaml
@@ -95,35 +95,32 @@ clusters:
   gentropy_colocalisation:
     image_version: '2.2'
     zone: 'europe-west1-b'
-    autoscaling_policy: otg-efm
+    # Fixed non-preemptible primary pool (no autoscaling, no spot secondaries).
+    # Spot-worker churn was the dominant failure source at baseline (3,021
+    # ExecutorLostFailure); a fixed on-demand pool removes preemption entirely.
     num_masters: 3
-    num_workers: 20
+    num_workers: 32
     master_machine_type: n1-highmem-16
-    worker_machine_type: n1-highmem-32
+    # n2d-highmem-32 = 32 vCPU / 256 GB. Packs 8 executors/node at cores=4,
+    # 22g heap + 4g overhead each (8 x 26 = 208 GB), leaving ~48 GB for the OS
+    # and YARN -- packing that n1-highmem-32 (208 GB) cannot fit. Executor sizing
+    # itself comes from the colocalisation step's extended_spark_conf in gentropy.yaml.
+    worker_machine_type: n2d-highmem-32
     worker_disk_type: 'pd-ssd'
     worker_disk_size: 1024
-    secondary_worker_disk_size: 100
-    secondary_worker_disk_type: 'pd-standard'
     internal_ip_only: false
     metadata:
       GENTROPY_REF: 'v{{gentropy_version}}'
     properties:
-      'dataproc:efm.spark.shuffle': 'primary-worker'
-      'spark:spark.shuffle.io.numConnectionsPerPeer': '5'
-      'spark:spark.shuffle.io.maxRetries': '15'
-      'spark:spark.shuffle.io.retryWait': '30s'
-      'spark:spark.shuffle.io.serverThreads': '100'
+      # EFM and the spot-era band-aids (shuffle.io retries, extended network
+      # timeout, speculation) are gone: with no preemption there is no shuffle to
+      # reconstruct and no straggler-from-preemption to speculate around.
       'spark:spark.stage.maxConsecutiveAttempts': '10'
       'spark:spark.sql.adaptive.enabled': 'true'
-      'spark:spark.sql.shuffle.partitions': '2000'
+      'spark:spark.sql.adaptive.skewJoin.enabled': 'true'
+      'spark:spark.sql.shuffle.partitions': '4000'
       'spark:spark.sql.files.maxPartitionBytes': '268435456'
-      'spark:spark.network.timeout': '800s'
-      'spark:spark.task.maxFailures': '15'
-      'yarn:spark.shuffle.io.serverThreads': '100'
-      # Speculative execution -> https://kb.databricks.com/scala/understanding-speculative-execution
-      'spark:spark.speculation': 'true'
-      'spark:spark.speculation.multiplier': '1.5'
-      'spark:spark.speculation.quantile': '0.9'
+      'spark:spark.task.maxFailures': '10'
 
     init_actions_uris:
       - 'gs://genetics_etl_python_playground/initialisation/install_dependencies_on_cluster.sh'

--- a/src/orchestration/dags/config/clusters.yaml
+++ b/src/orchestration/dags/config/clusters.yaml
@@ -118,7 +118,11 @@ clusters:
       'spark:spark.stage.maxConsecutiveAttempts': '10'
       'spark:spark.sql.adaptive.enabled': 'true'
       'spark:spark.sql.adaptive.skewJoin.enabled': 'true'
-      'spark:spark.sql.shuffle.partitions': '4000'
+      # 8000 (not 4000): the fused agg + parquet-write stage is the residual exit-143
+      # OOM source -- 4 tasks/executor each holding multi-GB on-heap agg + off-heap
+      # fetch/write buffers occasionally overran the container. Halving per-task data
+      # (8000 parts) cut those losses ~80% (535 -> 108) at no wall-clock cost.
+      'spark:spark.sql.shuffle.partitions': '8000'
       'spark:spark.sql.files.maxPartitionBytes': '268435456'
       'spark:spark.task.maxFailures': '10'
 


### PR DESCRIPTION
Part of opentargets/issues#4415.

## Summary

Retopologises the `gentropy_colocalisation` Dataproc cluster to remove the remaining preemption-driven instability in the `colocalisation` step. At baseline this step took **4h18m** with **3,021 `ExecutorLostFailure`** (≈$500/run); the spot-worker churn was the single dominant failure source. The gentropy code-side fixes (opentargets/gentropy#1232) already brought it to ~22.5m / 539 OOM on the same-shaped cluster — this PR removes the spot churn so the step runs on a stable, fully on-demand pool.

## Changes (`clusters.yaml` → `gentropy_colocalisation`)

- **Drop autoscaling + spot secondaries** — remove `autoscaling_policy: otg-efm` and the secondary (spot) worker pool. Run a **fixed non-preemptible primary pool** instead, eliminating preemption entirely.
- **`num_workers` 20 → 32**, **`worker_machine_type` n1-highmem-32 → n2d-highmem-32** — n2d-highmem-32 is 32 vCPU / **256 GB**, which packs 8 executors/node at the colocalisation step's `extended_spark_conf` sizing (22g heap + 4g overhead × 8 = 208 GB, ~48 GB left for OS/YARN). n1-highmem-32 (208 GB) cannot fit that packing. Executor sizing itself is unchanged — it stays in `gentropy.yaml`'s step `extended_spark_conf`.
- **Drop EFM and the spot-era band-aids** — `dataproc:efm.spark.shuffle`, the `spark.shuffle.io.*` retry knobs, `yarn:spark.shuffle.io.serverThreads`, `spark.network.timeout`, and speculation. With no preemption there's no shuffle to reconstruct and no preemption-induced straggler to speculate around.
- **Tuning** — `spark.sql.shuffle.partitions` 2000 → **8000**, add `spark.sql.adaptive.skewJoin.enabled`, `spark.task.maxFailures` 15 → 10.
  - The 8000 (vs the code-PR's same-shaped 4000 benchmark) targets the *residual* OOMs that remain after the spot fix. Event-log analysis of the optimised run pinned them to the fused aggregation + parquet-write stage: 4 tasks/executor each hold multi-GB on-heap aggregation + off-heap shuffle-fetch + parquet-write buffers, occasionally overrunning the 26 GB container (zero spill, uniform across the fleet — a per-executor memory characteristic, not skew or disk). Halving per-task data with 8000 partitions cut those losses **~80% (535 → 108 `ExecutorLostFailure`) at no wall-clock cost** (a controlled A/B, partition count the only change), output unchanged.

Masters (3× n1-highmem-16), `pd-ssd` 1024 GB workers, image 2.2, `internal_ip_only: false`, the init action, `idle_delete_ttl`, and `GENTROPY_REF` metadata are all unchanged.

## Validation

- `clusters.yaml` parses; `CustomClusterConfig(**cfg).create_cluster()` instantiates cleanly with the new block (n2d-highmem-32, 32 fixed workers, empty autoscaling config, no secondary pool).

## Context

This is the orchestration half of the colocalisation performance work tracked in opentargets/issues#4415; the gentropy code half is opentargets/gentropy#1232.
