### PR TITLE
fix(hydra_parser): remove shlex in hydra cmd parser

### DIFF
--- a/src/orchestration/utils/utils.py
+++ b/src/orchestration/utils/utils.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import hashlib
 import random
 import re
-import shlex
 import string
 from pathlib import Path
 from typing import Any
@@ -201,10 +200,7 @@ def convert_params_to_hydra_positional_arg(params: dict[str, Any] | None, datapr
 
     positional_args = []
     for k, v in params.items():
-        arg = f"{k}={v}"
-        if isinstance(v, str) and v[:1] in "{[":
-            arg = shlex.quote(arg)
-        positional_args.append(arg)
+        positional_args.append(f"{k}={v}")
 
     if not dataproc:
         return positional_args

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -53,6 +53,12 @@ def test_time_to_seconds(input: str, output: int) -> None:
             True,
             id="Running with dataproc=True and yarn present does not duplicate parameter",
         ),
+        pytest.param(
+            {"step": "some_step", "step.filter": "{a: 1}", "step.ids": "[x,y]"},
+            ["step=some_step", "step.filter={a: 1}", "step.ids=[x,y]"],
+            False,
+            id="JSON-like string values are not shell-quoted",
+        ),
     ],
 )
 def test_convert_params_to_hydra_positional_arg(input: dict, output: list[str], is_dataproc_job: bool) -> None:


### PR DESCRIPTION
# Context 

The fix reverts an incorrect application of `shlex.quote()` in `convert_params_to_hydra_positional_arg`. The initial change was included in heritability estimate batch job, is no longer required.

## Issue

The bug: String values starting with `{` or `[` (e.g. JSON-like objects/lists) were being wrapped in POSIX shell quotes, turning `step.filter={a: 1}` into `'step.filter={a: 1}'`. Hydra's override grammar is not a shell, so it received the literal single-quote characters as part of the argument, breaking the parse.


## Implementations
- [x] Removal of `shlex.quote`
- [x] Added regression test