### PR TITLE
feat(pts): wire up standalone transcript/safety_liability/tractability/chemical_probes steps

### DIFF
--- a/src/orchestration/dags/config/pts.yaml
+++ b/src/orchestration/dags/config/pts.yaml
@@ -381,7 +381,6 @@ steps:
           target: 3
           gene_essentiality: 4
       source:
-        diseases: output/disease
         ensembl: intermediate/target/ensembl/homo_sapiens.parquet
         gene_code: input/target/gencode/gencode.gff3.gz
         genetic_constraints: input/target/gnomad/gnomad_constraint_metrics.tsv
@@ -399,9 +398,7 @@ steps:
         ncbi: input/target/ncbi/Homo_sapiens.gene_info.gz
         reactome_etl: output/reactome
         reactome_pathways: input/target/reactome/Ensembl2Reactome.txt
-        safety_evidence: intermediate/target/safety.parquet
         tep: input/target/tep/tep.json.gz
-        tractability: input/target/tractability/tractability.tsv
         uniprot: intermediate/target/uniprot/uniprot.parquet
         uniprot_ssl: input/target/uniprot/uniprot-ssl.tsv.gz
         chembl: input/target/chembl/chembl_target.jsonl

--- a/src/orchestration/dags/config/pts.yaml
+++ b/src/orchestration/dags/config/pts.yaml
@@ -409,6 +409,18 @@ steps:
         gene_essentiality: output/target_essentiality
   ##################################################################################################
 
+  #: TRANSCRIPT STEP :#################################################################################
+  transcript:
+    - name: pyspark transcript
+      pyspark: transcript
+      settings:
+        partition_count: 2
+      source:
+        gene_code: input/target/gencode/gencode.gff3.gz
+        ensembl: intermediate/target/ensembl/homo_sapiens.parquet
+      destination: output/transcript
+  ##################################################################################################
+
   #: TARGET_SAFETY STEP :############### - part of target, pyspark tasks must run standalone for now
   target_safety:
     - name: pyspark safety

--- a/src/orchestration/dags/config/pts.yaml
+++ b/src/orchestration/dags/config/pts.yaml
@@ -273,11 +273,14 @@ steps:
   chemical_probes:
     - name: pyspark chemical probes
       pyspark: chemical_probes
+      settings:
+        partition_count: 2
       source:
         probes_excel: input/target/chemicalprobes/probes.xlsx
         drugs_csv: input/target/chemicalprobes/probes_links.csv
         chembl_molecule: intermediate/chembl_molecule
-      destination: intermediate/chemical_probes_evidence.parquet
+        target: output/target
+      destination: output/chemical_probes
   ##################################################################################################
 
   #: CODING VARIANT STEP :##########################################################################
@@ -402,7 +405,6 @@ steps:
         uniprot: intermediate/target/uniprot/uniprot.parquet
         uniprot_ssl: input/target/uniprot/uniprot-ssl.tsv.gz
         chembl: input/target/chembl/chembl_target.jsonl
-        chemical_probes: intermediate/chemical_probes_evidence.parquet
         gene_essentiality: intermediate/target/gene-essentiality/essentiality.parquet
       destination:
         target: output/target
@@ -728,7 +730,7 @@ steps:
         partition_count: 1
       source:
         molecule: intermediate/chembl_molecule
-        chemical_probes: intermediate/chemical_probes_evidence.parquet
+        chemical_probes: output/chemical_probes
         mechanism_of_action: output/drug_mechanism_of_action
         clinical_report: output/clinical_report
         disease: output/disease

--- a/src/orchestration/dags/config/pts.yaml
+++ b/src/orchestration/dags/config/pts.yaml
@@ -434,6 +434,18 @@ steps:
       destination: output/safety_liability
   ##################################################################################################
 
+  #: TARGET_TRACTABILITY STEP :#########################################################################
+  target_tractability:
+    - name: pyspark target_tractability
+      pyspark: target_tractability
+      settings:
+        partition_count: 2
+      source:
+        tractability: input/target/tractability/tractability.tsv
+        target: output/target
+      destination: output/target_tractability
+  ##################################################################################################
+
   #: TARGET_SAFETY STEP :############### - part of target, pyspark tasks must run standalone for now
   target_safety:
     - name: pyspark safety

--- a/src/orchestration/dags/config/pts.yaml
+++ b/src/orchestration/dags/config/pts.yaml
@@ -421,6 +421,19 @@ steps:
       destination: output/transcript
   ##################################################################################################
 
+  #: SAFETY_LIABILITY STEP :#############################################################################
+  safety_liability:
+    - name: pyspark safety_liability
+      pyspark: safety_liability
+      settings:
+        partition_count: 2
+      source:
+        safety_evidence: intermediate/target/safety.parquet
+        target: output/target
+        diseases: output/disease
+      destination: output/safety_liability
+  ##################################################################################################
+
   #: TARGET_SAFETY STEP :############### - part of target, pyspark tasks must run standalone for now
   target_safety:
     - name: pyspark safety

--- a/src/orchestration/dags/config/unified_pipeline.yaml
+++ b/src/orchestration/dags/config/unified_pipeline.yaml
@@ -150,6 +150,9 @@ steps:
       - pts_target_safety
       - pts_target
       - pts_disease
+  pts_target_tractability:
+    depends_on:
+      - pts_target
   pts_target_safety:
     depends_on:
       - pts_pharmacogenetics

--- a/src/orchestration/dags/config/unified_pipeline.yaml
+++ b/src/orchestration/dags/config/unified_pipeline.yaml
@@ -124,6 +124,7 @@ steps:
     depends_on:
       - pis_target
       - pts_chembl_molecule
+      - pts_target
   pts_coding_variant:
     depends_on:
       - gentropy_variant

--- a/src/orchestration/dags/config/unified_pipeline.yaml
+++ b/src/orchestration/dags/config/unified_pipeline.yaml
@@ -459,9 +459,7 @@ steps:
     depends_on:
       - pts_pre_target
       - pts_reactome
-      - pts_target_safety
       - pts_target_gene_essentiality
-      - pts_disease
 
   pts_search_facet:
     depends_on:

--- a/src/orchestration/dags/config/unified_pipeline.yaml
+++ b/src/orchestration/dags/config/unified_pipeline.yaml
@@ -142,6 +142,9 @@ steps:
   pts_pre_target:
     depends_on:
       - pis_target
+  pts_transcript:
+    depends_on:
+      - pts_pre_target
   pts_target_safety:
     depends_on:
       - pts_pharmacogenetics

--- a/src/orchestration/dags/config/unified_pipeline.yaml
+++ b/src/orchestration/dags/config/unified_pipeline.yaml
@@ -145,6 +145,11 @@ steps:
   pts_transcript:
     depends_on:
       - pts_pre_target
+  pts_safety_liability:
+    depends_on:
+      - pts_target_safety
+      - pts_target
+      - pts_disease
   pts_target_safety:
     depends_on:
       - pts_pharmacogenetics


### PR DESCRIPTION
## Summary

Companion orchestration changes for opentargets/pts#149 (opentargets/issues#4457): adds DAG entries and step configs for four datasets extracted out of `pts_target`:

- `pts_transcript` — depends on `pts_pre_target`
- `pts_safety_liability` — depends on `pts_target_safety`, `pts_target`, `pts_disease`
- `pts_target_tractability` — depends on `pts_target`
- `pts_chemical_probes` — now also depends on `pts_target` (needed for ENSG resolution). `pts_target` no longer depends on `pts_chemical_probes` (the `chemicalProbes` field was removed from the target index to avoid a circular dependency between the two steps). `pts_drug_molecule`'s `chemical_probes` source is updated from the old `intermediate/chemical_probes_evidence.parquet` to the new `output/chemical_probes`.

## Test plan

- [x] Validated `pts.yaml` and `unified_pipeline.yaml` parse correctly
- [x] Walked the full DAG programmatically to confirm no dependency cycles were introduced
- [x] Cross-checked against the matching `pts` repo changes (source/destination paths, step names)